### PR TITLE
[No JIRA] Make sure root pod works

### DIFF
--- a/Backpack.podspec
+++ b/Backpack.podspec
@@ -32,6 +32,8 @@ Pod::Spec.new do |s|
     git: "https://github.com/Skyscanner/backpack-ios.git", tag: s.version.to_s
   }
   s.ios.deployment_target = "9.0"
+  s.source_files = 'Backpack/Classes/Backpack.h'
+  s.public_header_files = 'Backpack/Classes/Backpack.h'
 
   s.subspec 'Color' do |ss|
     ss.source_files = 'Backpack/Classes/Color/**/*.{h,m}'

--- a/Backpack/Classes/Backpack.h
+++ b/Backpack/Classes/Backpack.h
@@ -19,6 +19,10 @@
 #ifndef __BACKPACK__
     #define __BACKPACK__
 
-    #import "BPKColor.h"
+    #import "Color.h"
+    #import "Font.h"
+    #import "Radii.h"
+    #import "Shadow.h"
+    #import "Spacing.h"
 #endif
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,38 @@
 # Unreleased
 
-__Nothing yet...___
+**Fixed:**
+
+- Ensure that the root pod spec can be used and that the `Backpack/Backpack.h` import works as expected.
 
 # 0.5.0
 
 **Added:**
 
-* Backpack shadows via `BPKShadow` and the `Backpack/Shadow` subpsec.
+- Backpack shadows via `BPKShadow` and the `Backpack/Shadow` subpsec.
 
 ## 0.4.0
 
 **Added:**
 
-* Backpack radii constants via `BpkRadii` and the `Backpack/Radii` subspec.
+- Backpack radii constants via `BpkRadii` and the `Backpack/Radii` subspec.
 
 ## 0.3.0
 
 **Added:**
 
-* Backpack spacing constants via `BpkSpacing` and the `Backpack/Spacing` subspec.
+- Backpack spacing constants via `BpkSpacing` and the `Backpack/Spacing` subspec.
 
 ## 0.2.0
 
 **Added:**
 
-* Introduced Backpack Font stack via `BPKFont` and the `Backpack/Font` subspec.
+- Introduced Backpack Font stack via `BPKFont` and the `Backpack/Font` subspec.
 
 ## 0.1.0
 
 **Breaking:**
 
-* Moved colors to a subspec in `Backpack/Color`.
+- Moved colors to a subspec in `Backpack/Color`.
 
 Use as
 

--- a/Example/Backpack/BPKAppDelegate.m
+++ b/Example/Backpack/BPKAppDelegate.m
@@ -17,7 +17,6 @@
  */
 
 #import "BPKAppDelegate.h"
-#import <Backpack/Font.h>
 
 @implementation BPKAppDelegate
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Backpack (0.4.0):
-    - Backpack/Color (= 0.4.0)
-    - Backpack/Font (= 0.4.0)
-    - Backpack/Radii (= 0.4.0)
-    - Backpack/Shadow (= 0.4.0)
-    - Backpack/Spacing (= 0.4.0)
-  - Backpack/Color (0.4.0)
-  - Backpack/Font (0.4.0)
-  - Backpack/Radii (0.4.0)
-  - Backpack/Shadow (0.4.0)
-  - Backpack/Spacing (0.4.0)
+  - Backpack (0.5.0):
+    - Backpack/Color (= 0.5.0)
+    - Backpack/Font (= 0.5.0)
+    - Backpack/Radii (= 0.5.0)
+    - Backpack/Shadow (= 0.5.0)
+    - Backpack/Spacing (= 0.5.0)
+  - Backpack/Color (0.5.0)
+  - Backpack/Font (0.5.0)
+  - Backpack/Radii (0.5.0)
+  - Backpack/Shadow (0.5.0)
+  - Backpack/Spacing (0.5.0)
 
 DEPENDENCIES:
   - Backpack (from `../`)
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Backpack: 95cca47c2e119292b9617f24e1176395f4217eaa
+  Backpack: fa09e739dd14976db8e8a936accb1411a7b61ff7
 
 PODFILE CHECKSUM: 616a3d74af75a352aed7508397a150c90a592d17
 


### PR DESCRIPTION
This makes sure you can also use the root pod correctly with `pod 'Backpack'` and `#import <Backpack/Backpack.h>`.