### PR TITLE
[BPK-1844] Add enum creation method for BPKFont

### DIFF
--- a/Backpack/Classes/Font/Generated/BPKFont.h
+++ b/Backpack/Classes/Font/Generated/BPKFont.h
@@ -17,9 +17,24 @@
  */
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSUInteger, BPKFontStyle) {
+
+    BPKFontStyleTextBase,
+    BPKFontStyleTextBaseEmphasized,
+    BPKFontStyleTextLg,
+    BPKFontStyleTextLgEmphasized,
+    BPKFontStyleTextSm,
+    BPKFontStyleTextSmEmphasized,
+    BPKFontStyleTextXl,
+    BPKFontStyleTextXlEmphasized,
+    BPKFontStyleTextXs,
+    BPKFontStyleTextXsEmphasized,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 @class UIFont;
 @interface BPKFont: NSObject
++ (UIFont * _Nullable)fontWithStyle:(BPKFontStyle)style;
 
 + (UIFont *)textBase;
 

--- a/Backpack/Classes/Font/Generated/BPKFont.m
+++ b/Backpack/Classes/Font/Generated/BPKFont.m
@@ -19,6 +19,35 @@
 
 @implementation BPKFont
 
++ (UIFont * _Nullable)fontWithStyle:(BPKFontStyle)style {
+    switch (style) {
+    
+        case BPKFontStyleTextBase:
+            return [BPKFont textBase];
+        case BPKFontStyleTextBaseEmphasized:
+            return [BPKFont textBaseEmphasized];
+        case BPKFontStyleTextLg:
+            return [BPKFont textLg];
+        case BPKFontStyleTextLgEmphasized:
+            return [BPKFont textLgEmphasized];
+        case BPKFontStyleTextSm:
+            return [BPKFont textSm];
+        case BPKFontStyleTextSmEmphasized:
+            return [BPKFont textSmEmphasized];
+        case BPKFontStyleTextXl:
+            return [BPKFont textXl];
+        case BPKFontStyleTextXlEmphasized:
+            return [BPKFont textXlEmphasized];
+        case BPKFontStyleTextXs:
+            return [BPKFont textXs];
+        case BPKFontStyleTextXsEmphasized:
+            return [BPKFont textXsEmphasized];
+    }
+
+    return nil;
+}
+
+
 + (UIFont *)textBase {
     return [UIFont systemFontOfSize:15 weight:UIFontWeightRegular];
 }

--- a/Example/Tests/BPKFontTest.m
+++ b/Example/Tests/BPKFontTest.m
@@ -46,7 +46,29 @@
     for (NSString *selector in self.expectedSelectors) {
         XCTAssertNotNil([BPKFont performSelector:NSSelectorFromString(selector)], @"Expected BPKFont to have a textStyle called `%@` that returns a valid value", selector);
     }
+}
 
+- (void)testFontWithStyle {
+    // These tests rely on internal pointer caching by UIFont which is why pointer
+    // equality can be used to compare the results. If this starts to break
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextXs], [BPKFont textXs]);
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextXsEmphasized], [BPKFont textXsEmphasized]);
+
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextSm], [BPKFont textSm]);
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextSmEmphasized], [BPKFont textSmEmphasized]);
+
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextBase], [BPKFont textBase]);
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextBaseEmphasized], [BPKFont textBaseEmphasized]);
+
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextLg], [BPKFont textLg]);
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextLgEmphasized], [BPKFont textLgEmphasized]);
+
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextXl], [BPKFont textXl]);
+    XCTAssertEqual([BPKFont fontWithStyle:BPKFontStyleTextXlEmphasized], [BPKFont textXlEmphasized]);
+
+    // Small sanity checks
+    XCTAssertNotEqual([BPKFont fontWithStyle:BPKFontStyleTextXl], [BPKFont fontWithStyle:BPKFontStyleTextLg]);
+    XCTAssertNotEqual([BPKFont fontWithStyle:BPKFontStyleTextSm], [BPKFont fontWithStyle:BPKFontStyleTextBase]);
 }
 
 @end

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,6 +135,7 @@ const parseTokens = tokensData => {
 
       return {
         name: key,
+        enumName: `BPKFontStyle${_.upperFirst(key)}`,
         size: Number.parseInt(sizeProp[0].value, 10),
         weight: convertFontWeight(weightProp[0].value),
         type: 'font',
@@ -146,6 +147,7 @@ const parseTokens = tokensData => {
         ...properties,
         weight: emphazisedWeight,
         name: `${properties.name}Emphasized`,
+        enumName: `${properties.enumName}Emphasized`,
       },
     ])
     .value();

--- a/templates/BPKFont.h.njk
+++ b/templates/BPKFont.h.njk
@@ -17,9 +17,15 @@
  */
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSUInteger, BPKFontStyle) {
+{% for f in font %}
+    {{f.enumName}},{% endfor %}
+};
+
 NS_ASSUME_NONNULL_BEGIN
 @class UIFont;
 @interface BPKFont: NSObject
++ (UIFont * _Nullable)fontWithStyle:(BPKFontStyle)style;
 {% for f in font %}
 + (UIFont *){{f.name}};
 {% endfor %}

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -18,6 +18,17 @@
 #import "BPKFont.h"
 
 @implementation BPKFont
+
++ (UIFont * _Nullable)fontWithStyle:(BPKFontStyle)style {
+    switch (style) {
+    {% for f in font %}
+        case {{f.enumName}}:
+            return [BPKFont {{f.name}}];{% endfor %}
+    }
+
+    return nil;
+}
+
 {% for f in font %}
 + (UIFont *){{f.name}} {
     return [UIFont systemFontOfSize:{{f.size}} weight:{{f.weight}}];


### PR DESCRIPTION
This will make it easier to support `BPKLabel` with a costructor like
`BPKLabel initWithFontStyle:BPKFontStyleTextSm` etc.