### PR TITLE
[BPK-1838] Add deploy step to backpack-ios travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,9 @@ script:
   - 'echo "$TRAVIS_TAG"'
   - '[ "$MAIN_STAGE" = true ] && ./scripts/check-pristine-state package-lock.json || true'
   - '[ "$MAIN_STAGE" = true ] && [ "$TRAVIS_TAG" ] && mkdir -p ./docs/versions/$TRAVIS_TAG'
-  - '[ "$MAIN_STAGE" = true ] && [ "$TRAVIS_TAG" ] && echo "SIMPLER" > ./docs/index.html'
-  - '[ "$MAIN_STAGE" = true ] && [ "$TRAVIS_TAG" ] && mkdir -p ./docs/versions/latest && echo "SIMPLER" > ./docs/versions/latest/index.html'
+  - '[ "$MAIN_STAGE" = true ] && [ "$TRAVIS_TAG" ] && rake "docs[\"./docs/versions/$TRAVIS_TAG\"]"'
+  - '[ "$MAIN_STAGE" = true ] && [ "$TRAVIS_TAG" ] && echo "<!DOCTYPE html> <html> <script type=\"text/javascript\"> window.location = \"/ios/versions/latest\"; </script> </html>" > ./docs/index.html'
+  - '[ "$MAIN_STAGE" = true ] && [ "$TRAVIS_TAG" ] && mkdir -p ./docs/versions/latest && echo "<!DOCTYPE html> <html> <script type=\"text/javascript\"> window.location = \"/ios/versions/$TRAVIS_TAG\"; </script> </html>" > ./docs/versions/latest/index.html'
   - (cd Example && bundle exec rake ci)
 after_script: '[ "$MAIN_STAGE" = true ] && greenkeeper-lockfile-upload || true'
 branches:


### PR DESCRIPTION
Difficult to test this properly until we merge and perform a release.

Things left to do after this is merged:
 - [x] Prevent deploying twice (there are two build configs, and each one runs the travis script)

It skips the docs deployment on non-master branches (and also if there's no tag)
https://travis-ci.org/Skyscanner/backpack-ios/jobs/429660677#L1105