### PR TITLE
same day range selection

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendarCell.h
+++ b/Backpack/Calendar/Classes/BPKCalendarCell.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSUInteger, SelectionType) {
     SelectionTypeLeftBorder,
     SelectionTypeMiddle,
     SelectionTypeRightBorder,
+    SelectionTypeSameDay
 };
 
 typedef NS_ENUM(NSUInteger, RowType) {


### PR DESCRIPTION
This PR implements the ability to select ranges that start and end on the same day. A typical use-case would be a flight where you come back to your home airport on the same day.