### PR TITLE
[BPK-2126] Prepare BPKCalendar for RN use

### DIFF
--- a/Backpack/Calendar/Classes/BPKSimpleDate.h
+++ b/Backpack/Calendar/Classes/BPKSimpleDate.h
@@ -1,0 +1,32 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BPKSimpleDate: NSObject
+@property(nonatomic, readonly) NSUInteger day;
+@property(nonatomic, readonly) NSUInteger month;
+@property(nonatomic, readonly) NSUInteger year;
+@property(nonatomic, strong, readonly) NSDate *fullDate;
+
+- (instancetype)initWithDateComponent:(NSDateComponents *)components fullDate:(NSDate *)fullDate;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKSimpleDate.m
+++ b/Backpack/Calendar/Classes/BPKSimpleDate.m
@@ -1,0 +1,72 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BPKSimpleDate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BPKSimpleDate()
+@property(nonatomic) NSUInteger day;
+@property(nonatomic) NSUInteger month;
+@property(nonatomic) NSUInteger year;
+@property(nonatomic, strong) NSDate *fullDate;
+
+@end
+
+@implementation BPKSimpleDate
+
+- (instancetype)initWithDateComponent:(NSDateComponents *)components fullDate:(NSDate *)fullDate {
+    self = [super init];
+
+    if (self) {
+        self.year = components.year;
+        self.month = components.month;
+        self.day = components.day;
+        self.fullDate = fullDate;
+    }
+
+    return self;
+}
+
+- (BOOL)isEqualToSimpleDate:(BPKSimpleDate *)other {
+    return other.year == self.year && other.month == self.month && other.day == self.day;
+}
+
+- (BOOL)isEqual:(id)object {
+    if (object == self) {
+        return true;
+    }
+
+    if (!object) {
+        return false;
+    }
+
+    if (![object isKindOfClass:[BPKSimpleDate class]]) {
+        return false;
+    }
+
+    return [self isEqualToSimpleDate:object];
+}
+
+- (NSUInteger)hash {
+    return self.year ^ self.month ^ self.day;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/SnapshotTests/BPKCalendarSnapshotTest.m
+++ b/Example/SnapshotTests/BPKCalendarSnapshotTest.m
@@ -46,8 +46,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)configureParentView:(UIView *)parentView forCalendar:(BPKCalendar *)calendar {
     parentView.translatesAutoresizingMaskIntoConstraints = NO;
+    calendar.translatesAutoresizingMaskIntoConstraints = NO;
     parentView.backgroundColor = [BPKColor white];
     [parentView addSubview:calendar];
+
     [parentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-16-[calendar]-16-|" options:0 metrics:nil views:@{@"calendar": calendar}]];
     [parentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-16-[calendar]-16-|" options:0 metrics:nil views:@{@"calendar": calendar}]];
     [parentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"[parentView(320)]" options:0 metrics:nil views:@{@"parentView": parentView}]];
@@ -72,12 +74,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testCalendarWithSingleSelection {
     UIView *parentView = [[UIView alloc] initWithFrame:CGRectZero];
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
-    
+
     [self configureParentView:parentView forCalendar:bpkCalendar];
     bpkCalendar.selectionType = BPKCalendarSelectionSingle;
     bpkCalendar.selectedDates = @[ self.date1 ];
     [bpkCalendar reloadData];
-    
+
     FBSnapshotVerifyView(parentView, nil);
 }
 


### PR DESCRIPTION
This PR changes the calendar to use manual layout rather than Auto Layout as Auto Layout and Yoga don't play well together.

Fix a bug were `setSelectedDates:` would reselect all dates which causes the following visual issue when controlled from React Native
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1333960/51461957-b9558900-1d5f-11e9-8135-ac86e84094ba.gif)
