### PR TITLE
[BPK-2126] Expose the `NSCalendar` in `BPKCalendar`

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -54,6 +54,11 @@ NS_SWIFT_NAME(CalendarDelegate) @protocol BPKCalendarDelegate <NSObject>
 NS_SWIFT_NAME(Calendar) @interface BPKCalendar: UIView
 
 /**
+ * The active calendar being used by the reciever.
+ */
+@property(nonatomic, strong, nonnull, readonly) NSCalendar *gregorian;
+
+/**
  * Locale used for displaying name of days and months
  */
 @property (copy, nonatomic) NSLocale *locale;

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,7 @@
 # Unreleased
 
-_Nothing yet..._
+**Fixed:**
+
+- Backpack/Calendar
+  - Expose the `NSCalendar` instance used as a readonly property.
+


### PR DESCRIPTION
Expose the `NSCalendar` instance used internall by `BPKCalendar` and
thus `FSCalendar`. This is required for the RN calendar.