### PR TITLE
Added main thread assertions

### DIFF
--- a/Backpack.podspec
+++ b/Backpack.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     git: 'https://github.com/Skyscanner/backpack-ios.git', tag: s.version.to_s
   }
   s.ios.deployment_target = '10.0'
-  s.source_files = 'Backpack/Backpack.h', 'Backpack/*/Classes/**/*.{h,m}'
+  s.source_files = 'Backpack/Backpack.h', 'Backpack/Common.h', 'Backpack/*/Classes/**/*.{h,m}'
   s.public_header_files = 'Backpack/Backpack.h', 'Backpack/*/Classes/**/*.h'
   s.ios.resource_bundle = {
     'Icon' => 'Backpack/Icon/Assets/*'

--- a/Backpack/Badge/Classes/BPKBadge.m
+++ b/Backpack/Badge/Classes/BPKBadge.m
@@ -22,6 +22,7 @@
 #import <Backpack/Radii.h>
 #import <Backpack/Font.h>
 #import <Backpack/Label.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKBadge()
@@ -34,12 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKBadge
 
 - (instancetype)initWithMessage:(NSString *)message {
+    BPKAssertMainThread();
       self = [self initWithType:BPKBadgeTypeSuccess message:message];
 
     return self;
 }
 
 - (instancetype)initWithType:(BPKBadgeType)type message:(NSString *)message {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];
 
     if (self) {
@@ -52,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
 
     if (self) {
@@ -62,6 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
 
     if (self) {
@@ -72,6 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setType:(BPKBadgeType)type {
+    BPKAssertMainThread();
     _type = type;
 
     self.layer.borderWidth = 0.0;
@@ -108,6 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setMessage:(NSString *)message {
+    BPKAssertMainThread();
     self.label.text = message;
 }
 

--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -23,6 +23,7 @@
 #import <Backpack/Gradient.h>
 #import <Backpack/Spacing.h>
 #import <Backpack/UIView+BPKRTL.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKButton()
@@ -46,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKButton
 
 - (instancetype)initWithSize:(BPKButtonSize)size style:(BPKButtonStyle)style {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];
     
     if (self) {
@@ -57,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
     
     if (self) {
@@ -67,6 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
     
     if (self) {
@@ -115,6 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Style setters
 
 - (void)setSize:(BPKButtonSize)size {
+    BPKAssertMainThread();
     if (_size != size || self.isInitializing) {
         _size = size;
         
@@ -124,6 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setStyle:(BPKButtonStyle)style {
+    BPKAssertMainThread();
     if (_style != style || self.isInitializing) {
         _style = style;
         
@@ -142,6 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTitle:(NSString *_Nullable)title {
+    BPKAssertMainThread();
     _title = [title copy];
     
     if (title) {
@@ -156,6 +163,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setImage:(UIImage *_Nullable)image {
+    BPKAssertMainThread();
     [super setImage:image forState:UIControlStateNormal];
     
     [self updateContentColor];
@@ -166,6 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - State setters
 
 - (void)setEnabled:(BOOL)enabled {
+    BPKAssertMainThread();
     BOOL changed = self.isEnabled != enabled;
     
     [super setEnabled:enabled];
@@ -178,11 +187,13 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSelected:(BOOL)selected {
+    BPKAssertMainThread();
     NSAssert(NO, @"The Backpack button does not support selected");
     [super setSelected:selected];
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
+    BPKAssertMainThread();
     BOOL changed = self.isHighlighted != highlighted;
     
     [super setHighlighted:highlighted];

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -27,6 +27,7 @@
 #import <Backpack/Color.h>
 #import <Backpack/Font.h>
 #import <Backpack/Spacing.h>
+#import <Backpack/Common.h>
 
 #import <FSCalendar/FSCalendar.h>
 #import <FSCalendar/FSCalendarCollectionView.h>
@@ -65,7 +66,7 @@ NSString * const HeaderReuseId = @"header";
 NSString * const HeaderDateFormat = @"MMMM";
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
-
+    BPKAssertMainThread();
     self = [super initWithCoder:coder];
     if (self) {
         [self setup];
@@ -75,8 +76,8 @@ NSString * const HeaderDateFormat = @"MMMM";
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
-
     if (self) {
         [self setup];
     }
@@ -162,6 +163,7 @@ NSString * const HeaderDateFormat = @"MMMM";
 }
 
 - (void)setLocale:(NSLocale *)locale {
+    BPKAssertMainThread();
     self.gregorian.locale = locale;
     self.calendarView.locale = locale;
     self.calendarView.firstWeekday = [[locale objectForKey:NSLocaleCalendar] firstWeekday];
@@ -169,6 +171,7 @@ NSString * const HeaderDateFormat = @"MMMM";
 }
 
 - (void)setSelectionType:(BPKCalendarSelection)selectionType {
+    BPKAssertMainThread();
     _selectionType = selectionType;
     self.calendarView.allowsMultipleSelection = _selectionType != BPKCalendarSelectionSingle;
     for (NSDate *date in self.calendarView.selectedDates) {
@@ -198,6 +201,7 @@ NSString * const HeaderDateFormat = @"MMMM";
 }
 
 - (void)setSelectedDates:(NSArray<NSDate *> *)selectedDates {
+    BPKAssertMainThread();
     NSSet<BPKSimpleDate *> *previouslySelectedDates = [self createDateSet:self.calendarView.selectedDates];
     NSSet<BPKSimpleDate *> *newSelectedDates = [self createDateSet:selectedDates];
 

--- a/Backpack/Card/Classes/BPKCard.m
+++ b/Backpack/Card/Classes/BPKCard.m
@@ -21,6 +21,7 @@
 #import <Backpack/Color.h>
 #import <Backpack/Radii.h>
 #import <Backpack/Shadow.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 const BOOL BPKCardDefaultPaddedValue = YES;
@@ -35,6 +36,7 @@ const BOOL BPKCardDefaultPaddedValue = YES;
 @implementation BPKCard
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
     
     if (self) {
@@ -45,6 +47,7 @@ const BOOL BPKCardDefaultPaddedValue = YES;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
     
     if (self) {
@@ -55,10 +58,12 @@ const BOOL BPKCardDefaultPaddedValue = YES;
 }
 
 - (instancetype)initWithPadded:(BOOL)padded {
+    BPKAssertMainThread();
     return [self initWithPadded:padded cornerStyle:BPKCardDefaultCornerStyle];
 }
 
 - (instancetype)initWithPadded:(BOOL)padded cornerStyle:(BPKCardCornerStyle)cornerStyle {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];
 
     if (self) {
@@ -69,6 +74,7 @@ const BOOL BPKCardDefaultPaddedValue = YES;
 }
 
 - (void)setPadded:(BOOL)padded {
+    BPKAssertMainThread();
     if (padded) {
         self.layoutMargins = UIEdgeInsetsMake(BPKSpacingBase, BPKSpacingBase, BPKSpacingBase, BPKSpacingBase);
     } else {
@@ -80,11 +86,13 @@ const BOOL BPKCardDefaultPaddedValue = YES;
 }
 
 - (void)setCornerStyle:(BPKCardCornerStyle)cornerStyle {
+    BPKAssertMainThread();
     _cornerStyle = cornerStyle;
     [self updateCorners];
 }
 
 - (void)setSelected:(BOOL)selected {
+    BPKAssertMainThread();
     [super setSelected:selected];
     BPKShadow *shadow = selected ? [BPKShadow shadowLg] : [BPKShadow shadowSm];
     [shadow applyToLayer:self.layer];
@@ -98,12 +106,14 @@ const BOOL BPKCardDefaultPaddedValue = YES;
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
+    BPKAssertMainThread();
     [super setHighlighted:highlighted];
     
     self.backgroundColor = highlighted ? BPKColor.gray100 : BPKColor.white;
 }
 
 - (void)setSubview:(UIView *_Nullable)view {
+    BPKAssertMainThread();
     if (self.subview != nil) {
         [self.subview removeFromSuperview];
     }

--- a/Backpack/Chip/Classes/BPKChip.m
+++ b/Backpack/Chip/Classes/BPKChip.m
@@ -23,6 +23,7 @@
 #import <Backpack/Color.h>
 #import <Backpack/Shadow.h>
 #import <Backpack/Spacing.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKChip()
@@ -35,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKChip
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
 
     if (self) {
@@ -45,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
 
     if (self) {
@@ -55,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithTitle:(NSString *)title {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];
 
     if (self) {
@@ -103,17 +107,20 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - State setters
 
 - (void)setTitle:(NSString *_Nullable)title {
+    BPKAssertMainThread();
     _title = [title copy];
 
     [self updateTitle];
 }
 
 - (void)setSelected:(BOOL)selected {
+    BPKAssertMainThread();
     [super setSelected:selected];
     [self updateStyle];
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
+    BPKAssertMainThread();
     [super setHighlighted:highlighted];
 
     [CATransaction begin];
@@ -123,6 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setEnabled:(BOOL)enabled {
+    BPKAssertMainThread();
     [super setEnabled:enabled];
     [self updateStyle];
 }

--- a/Backpack/Common.h
+++ b/Backpack/Common.h
@@ -20,13 +20,6 @@
 
 #import <pthread.h>
 
-#if !defined(NS_BLOCK_ASSERTIONS)
-#define BPK_ASSERTIONS_ENABLED 1
-#else
-#define BPK_ASSERTIONS_ENABLED 0
-#endif
-
-#define BPKAssert(condition, desc, ...) NSAssert(condition, desc, ##__VA_ARGS__)
-#define BPKAssertMainThread() BPKAssert(!BPK_ASSERTIONS_ENABLED || 0 != pthread_main_np(), @"This method must be called on the main thread")
+#define BPKAssertMainThread() NSAssert(0 != pthread_main_np(), @"This method must be called on the main thread")
 
 #endif

--- a/Backpack/Common.h
+++ b/Backpack/Common.h
@@ -15,39 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef BPK_Common_h
+#define BPK_Common_h
 
-#import "BPKLondonThemeContainer.h"
-#import <Backpack/Common.h>
+#import <pthread.h>
 
-NS_ASSUME_NONNULL_BEGIN
+#if !defined(NS_BLOCK_ASSERTIONS)
+#define BPK_ASSERTIONS_ENABLED 1
+#else
+#define BPK_ASSERTIONS_ENABLED 0
+#endif
 
-@interface BPKLondonThemeContainer()
+#define BPKAssert(condition, desc, ...) NSAssert(condition, desc, ##__VA_ARGS__)
+#define BPKAssertMainThread() BPKAssert(!BPK_ASSERTIONS_ENABLED || 0 != pthread_main_np(), @"This method must be called on the main thread")
 
-@end
-
-@implementation BPKLondonThemeContainer
-
-- (instancetype)initWithFrame:(CGRect)frame {
-    self = [super initWithFrame:frame];
-    if (self) {
-        BPKAssertMainThread();
-    }
-    return self;
-}
-
-- (nullable instancetype)initWithCoder:(NSCoder *)coder {
-    self = [super initWithCoder:coder];
-    if (self) {
-        BPKAssertMainThread();
-    }
-    return self;
-}
-
-- (void)addSubview:(UIView *)view {
-    [super addSubview:view];
-    BPKAssertMainThread();
-}
-
-@end
-
-NS_ASSUME_NONNULL_END
+#endif

--- a/Backpack/Dialog/Classes/BPKDialogView.m
+++ b/Backpack/Dialog/Classes/BPKDialogView.m
@@ -26,6 +26,7 @@
 #import <Backpack/Button.h>
 #import <Backpack/Color.h>
 #import <Backpack/Radii.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKActionButtonPair : NSObject
@@ -55,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
                       message:(NSString *)message
           iconBackgroundColor:(UIColor *)iconBackgroundColor
                     iconImage:(UIImage *)iconImage {
+    BPKAssertMainThread();
     self = [self initWithFrame:CGRectZero];
 
     if (self) {
@@ -68,6 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
 
     if (self) {
@@ -82,6 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
 
     if (self) {
@@ -203,6 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Property overrides
 
 - (void)setIconBackgroundColor:(UIColor *_Nullable)iconBackgroundColor {
+    BPKAssertMainThread();
     self.iconView.iconBackgroundColor = iconBackgroundColor;
 }
 
@@ -211,6 +216,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setIconImage:(UIImage *_Nullable)iconImage {
+    BPKAssertMainThread();
     self.iconView.iconImage = iconImage;
 }
 
@@ -219,6 +225,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setTitle:(NSString *_Nullable)title {
+    BPKAssertMainThread();
     self.titleLabel.text = title;
 }
 
@@ -228,6 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 - (void)setMessage:(NSString *_Nullable)description {
+    BPKAssertMainThread();
     self.descriptionLabel.text = description;
 }
 
@@ -238,6 +246,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Other public methods
 
 - (void)addButtonAction:(BPKDialogButtonAction *)action {
+    BPKAssertMainThread();
     BPKButton *button = [[BPKButton alloc] initWithSize:BPKButtonSizeLarge style:action.style];
     [button setTitle:action.title];
     [button addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];

--- a/Backpack/Gradient/Classes/BPKGradientView.m
+++ b/Backpack/Gradient/Classes/BPKGradientView.m
@@ -18,6 +18,7 @@
 #import "BPKGradientView.h"
 
 #import "BPKGradientLayer.h"
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKGradientView()
@@ -29,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @dynamic gradientLayer;
 
 - (instancetype)initWithGradient:(BPKGradient *)gradient {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];
 
     if (self) {
@@ -47,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setGradient:(BPKGradient *_Nullable)gradient {
+    BPKAssertMainThread();
     self.gradientLayer.gradient = gradient;
 }
 

--- a/Backpack/Icon/Classes/BPKIconView.m
+++ b/Backpack/Icon/Classes/BPKIconView.m
@@ -18,6 +18,7 @@
 #import "BPKIconView.h"
 
 #import "BPKColor.h"
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKIconView
 
 - (instancetype)initWithIconName:(nullable BPKIconName)iconName size:(BPKIconSize)size {
+    BPKAssertMainThread();
     CGSize displaySize = [BPKIcon concreteSizeForIconSize:size];
 
     self = [super initWithFrame:CGRectMake(0, 0, displaySize.width, displaySize.height)];
@@ -52,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setIconName:(nullable BPKIconName)iconName {
+    BPKAssertMainThread();
     if (![iconName isEqualToString:_iconName]) {
         _iconName = [iconName copy];
 

--- a/Backpack/Label/Classes/BPKLabel.m
+++ b/Backpack/Label/Classes/BPKLabel.m
@@ -17,6 +17,7 @@
  */
 #import "BPKLabel.h"
 #import <Backpack/Color.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKLabel()
@@ -26,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKLabel
 
 - (instancetype)initWithFontStyle:(BPKFontStyle)style {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];
 
     if (self) {
@@ -36,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
 
     if (self) {
@@ -46,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
 
     if (self) {
@@ -56,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setText:(NSString *_Nullable)text {
+    BPKAssertMainThread();
     if (text == nil) {
         self.attributedText = nil;
         return;
@@ -71,6 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setFontStyle:(BPKFontStyle)fontStyle {
+    BPKAssertMainThread();
     _fontStyle = fontStyle;
     self.text = self.attributedText.string;
 }

--- a/Backpack/Panel/Classes/BPKPanel.m
+++ b/Backpack/Panel/Classes/BPKPanel.m
@@ -20,6 +20,7 @@
 #import <Backpack/Spacing.h>
 #import <Backpack/Color.h>
 #import <Backpack/Radii.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 const BOOL BPKPanelDefaultPaddedValue = YES;
@@ -34,6 +35,7 @@ const BOOL BPKPanelDefaultPaddedValue = YES;
 @implementation BPKPanel
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
 
     if (self) {
@@ -44,6 +46,7 @@ const BOOL BPKPanelDefaultPaddedValue = YES;
 }
 
 - (instancetype)initWithPadded:(BOOL)padded {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];
 
     if (self) {
@@ -54,6 +57,7 @@ const BOOL BPKPanelDefaultPaddedValue = YES;
 }
 
 - (void)setPadded:(BOOL)padded {
+    BPKAssertMainThread();
     if (padded) {
         self.layoutMargins = self.originalLayoutMargins;
     } else {
@@ -64,6 +68,7 @@ const BOOL BPKPanelDefaultPaddedValue = YES;
 }
 
 - (void)addSubview:(UIView *)view {
+    BPKAssertMainThread();
     NSAssert(self.subviews.count == 0, @"BPKPanel can only have a single subview");
     if (self.subviews.count > 0) {
         return;

--- a/Backpack/RTLSupport/Classes/UIView+BPKRTL.m
+++ b/Backpack/RTLSupport/Classes/UIView+BPKRTL.m
@@ -17,6 +17,7 @@
  */
 #import "UIView+BPKRTL.h"
 #import "BPKRTLSupport.h"
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @implementation UIView(BPKRTL)
@@ -24,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
                                           leading:(CGFloat)leading
                                            bottom:(CGFloat)bottom
                                          trailing:(CGFloat)trailing {
+    BPKAssertMainThread();
     return [BPKRTLSupport makeRTLAwareEdgeInsetsForView:self top:top leading:leading bottom:bottom trailing:trailing];
 }
 @end

--- a/Backpack/Spinner/Classes/BPKSpinner.m
+++ b/Backpack/Spinner/Classes/BPKSpinner.m
@@ -18,6 +18,7 @@
 
 #import "BPKSpinner.h"
 #import <Backpack/Color.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKSpinner
 
 - (instancetype)initWithStyle:(BPKSpinnerStyle)style size:(BPKSpinnerSize)size {
+    BPKAssertMainThread();
     self = [super initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
     if (self) {
         [self setupWithStyle:style size:size];
@@ -36,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
+    BPKAssertMainThread();
     self = [super initWithCoder:coder];
     if (self) {
         [self setupWithDefaultValues];
@@ -44,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
     if (self) {
         [self setupWithDefaultValues];
@@ -62,12 +66,14 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setSize:(BPKSpinnerSize)size {
+    BPKAssertMainThread();
     _size = size;
     [self didChangeProperty];
     [self setNeedsLayout];
 }
 
 - (void)setStyle:(BPKSpinnerStyle)style {
+    BPKAssertMainThread();
     _style = style;
     [self didChangeProperty];
 }

--- a/Backpack/Switch/Classes/BPKSwitch.m
+++ b/Backpack/Switch/Classes/BPKSwitch.m
@@ -18,6 +18,7 @@
 
 #import "BPKSwitch.h"
 #import <Backpack/Color.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKSwitch
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
+    BPKAssertMainThread();
     self = [super initWithCoder:coder];
     if (self) {
         [self setup];
@@ -36,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame];
     if (self) {
         [self setup];

--- a/Backpack/TextView/Classes/BPKTextView.m
+++ b/Backpack/TextView/Classes/BPKTextView.m
@@ -17,6 +17,7 @@
  */
 #import "BPKTextView.h"
 #import <Backpack/Color.h>
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKTextView()
@@ -26,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation BPKTextView
 
 - (instancetype)initWithFontStyle:(BPKFontStyle)style {
+    BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero textContainer:nil];
 
     if (self) {
@@ -36,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    BPKAssertMainThread();
     self = [super initWithCoder:aDecoder];
 
     if (self) {
@@ -46,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithFrame:(CGRect)frame textContainer:(nullable NSTextContainer *)textContainer {
+    BPKAssertMainThread();
     self = [super initWithFrame:frame textContainer:textContainer];
 
     if (self) {
@@ -56,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setText:(NSString *_Nullable)text {
+    BPKAssertMainThread();
     if (text == nil) {
         self.attributedText = nil;
         return;
@@ -71,6 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setFontStyle:(BPKFontStyle)fontStyle {
+    BPKAssertMainThread();
     _fontStyle = fontStyle;
     [self setText:self.attributedText.string];
 }

--- a/Backpack/Theme/Classes/BPKHongKongThemeContainer.m
+++ b/Backpack/Theme/Classes/BPKHongKongThemeContainer.m
@@ -17,6 +17,7 @@
  */
 
 #import "BPKHongKongThemeContainer.h"
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,6 +26,27 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation BPKHongKongThemeContainer
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        BPKAssertMainThread();
+    }
+    return self;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        BPKAssertMainThread();
+    }
+    return self;
+}
+
+- (void)addSubview:(UIView *)view {
+    [super addSubview:view];
+    BPKAssertMainThread();
+}
 
 @end
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Backpack: dd23c7a5b887d106a3d83f144dc48ea84937704f
+  Backpack: 24abe150bda7b63a55a9c004de9027664a051d8c
   FSCalendar: 3a5ed3636e2ba1b83ebebfcf0c2603105a6f5efe
   iOSSnapshotTestCase: 711379b19f69a22c131527df862352c877c2773c
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073


### PR DESCRIPTION
Ensuring at runtime that all Backpack UI components are being called from the main thread.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](./CODE_REVIEW_GUIDELINES.md)_
