### PR TITLE
[NO-JIRA] repoduce apps release see all button issue

### DIFF
--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -517,6 +517,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setLinkStyleWithColor:(UIColor *)color {
     self.gradientLayer.gradient = nil;
+    [self setBackgroundColor:UIColor.purpleColor];
     
     [self.layer setBorderColor:BPKColor.clear.CGColor];
     [self.layer setBorderWidth:0];
@@ -536,7 +537,7 @@ NS_ASSUME_NONNULL_BEGIN
             backgroundColor = BPKColor.white;
             break;
         case BPKButtonStyleLink:
-            backgroundColor = UIColor.clearColor;
+            backgroundColor = UIColor.purpleColor;
             break;
         default:
             backgroundColor = nil;

--- a/Example/Backpack/View Controllers/BPKButtonsViewController.m
+++ b/Example/Backpack/View Controllers/BPKButtonsViewController.m
@@ -91,8 +91,14 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setupButton:(BPKButton *)button image:(UIImage *_Nullable)image title:(NSString *_Nullable)title {
-    [button setImage:image];
+    UIImage *smallLongArrowIcon = self.isRTL ? [BPKIcon templateIconNamed:@"long-arrow-left" size:BPKIconSizeLarge] : [BPKIcon templateIconNamed:@"long-arrow-right" size:BPKIconSizeSmall];
+
+    [button setImage:smallLongArrowIcon];
+    [button setNeedsLayout];
+    [button setNeedsLayout];
+    [button layoutIfNeeded];
     [button setTitle:title];
+    [button setImage:nil];
 }
 
 - (BOOL)isRTL {


### PR DESCRIPTION
This code exposes a bug seen and reported in the app codebase which causes the layout to be incorrect when an image has been rendered inside the button, and then is removed.

This code should be used to test, but not merged 

What this does when an image is set, and then removed:
<img width="545" alt="screenshot 2019-03-07 at 13 00 25" src="https://user-images.githubusercontent.com/30267516/53958474-0ce62100-40d9-11e9-8ccc-1d10a330806e.png">

What it should do:
<img width="545" alt="screenshot 2019-03-07 at 12 50 31" src="https://user-images.githubusercontent.com/30267516/53958475-0ce62100-40d9-11e9-8d23-e8180b556f29.png">
