### PR TITLE
[No JIRA] Fix button layout bug

### DIFF
--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -105,15 +105,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isIconOnly {
-    return self.imageView && self.imageView.image && self.titleLabel.text.length == 0;
+    return self.currentImage && self.titleLabel.text.length == 0;
 }
 
 - (BOOL)isTextOnly {
-    return (self.imageView == nil || self.imageView.image == nil) && self.titleLabel.text.length > 0;
+    return (self.currentImage == nil) && self.titleLabel.text.length > 0;
 }
 
 - (BOOL)isTextAndIcon {
-    return self.imageView && self.imageView.image && self.titleLabel.text.length > 0;
+    return self.currentImage && self.titleLabel.text.length > 0;
 }
 
 #pragma mark - Style setters

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+**Fixed:**
+
++ Backpack/Button
+  + Fixed a bug where Backpack buttons would incorrectly lay out as if there was an image if the image was set and then removed.


### PR DESCRIPTION
When a button was laid out after having and image set and then the image
being set back to `nil` it would not lay out correctly. This was because
we were relying on `self.imageView.image` when determining if the button
had an image. When the image is set to `nil` via `setImage:forState` the
underlying `image` property on `UIImageView` still contains the image
and is thus not `nil`. With this change we use `currentImage` which
correctly determines if and image is set.


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)