### PR TITLE
Exposing some of the underlying scrollview's properties as readonly props

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -42,9 +42,9 @@ NS_SWIFT_NAME(CalendarDelegate) @protocol BPKCalendarDelegate <NSObject>
 /**
  * Called when the calendar was scrolled
  * @param calendar The backpack calendar.
- * @param contentOffset The content offset
+ * @param scrollView The scrollView of the calendar
  */
-- (void)calendar:(BPKCalendar *)calendar didScroll:(CGPoint)contentOffset;
+- (void)calendar:(BPKCalendar *)calendar didScroll:(UIScrollView *)scrollView;
 
 @end
 

--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -42,9 +42,9 @@ NS_SWIFT_NAME(CalendarDelegate) @protocol BPKCalendarDelegate <NSObject>
 /**
  * Called when the calendar was scrolled
  * @param calendar The backpack calendar.
- * @param scrollView The scrollView of the calendar
+ * @param contentOffset The content offset
  */
-- (void)calendar:(BPKCalendar *)calendar didScroll:(UIScrollView *)scrollView;
+- (void)calendar:(BPKCalendar *)calendar didScroll:(CGPoint)contentOffset;
 
 @end
 
@@ -82,6 +82,36 @@ NS_SWIFT_NAME(Calendar) @interface BPKCalendar: UIView
  * The latest date that the user is allowed to select
  */
 @property (nonatomic) NSDate *maxDate;
+
+/**
+ * The underlying scrollView's content offset
+ */
+@property (readonly) CGPoint contentOffset;
+
+/**
+ * The underlying scrollView's content inset
+ */
+@property (readonly) UIEdgeInsets contentInset;
+
+/**
+ * The underlying scrollView's content size
+ */
+@property (readonly) CGSize contentSize;
+
+/**
+ * The underlying scrollView's isDecelerating
+ */
+@property (readonly) BOOL isDecelerating;
+
+/**
+ * The underlying scrollView's isTracking
+ */
+@property (readonly) BOOL isTracking;
+
+/**
+ * The underlying scrollView's isDragging
+ */
+@property (readonly) BOOL isDragging;
 
 /**
  * The calendar's delegate

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -337,7 +337,7 @@ NSString * const HeaderDateFormat = @"MMMM";
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     if ([self.delegate respondsToSelector:@selector(calendar:didScroll:)]) {
-        [self.delegate calendar:self didScroll:scrollView.contentOffset];
+        [self.delegate calendar:self didScroll:scrollView];
     }
     [self.calendarView scrollViewDidScroll:scrollView];
 }

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -337,12 +337,36 @@ NSString * const HeaderDateFormat = @"MMMM";
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     if ([self.delegate respondsToSelector:@selector(calendar:didScroll:)]) {
-        [self.delegate calendar:self didScroll:scrollView];
+        [self.delegate calendar:self didScroll:scrollView.contentOffset];
     }
     [self.calendarView scrollViewDidScroll:scrollView];
 }
 
 #pragma mark - private
+
+- (CGPoint)contentOffset {
+    return self.calendarView.collectionView.contentOffset;
+}
+
+- (UIEdgeInsets)contentInset {
+    return self.calendarView.collectionView.contentInset;
+}
+
+- (CGSize)contentSize {
+    return self.calendarView.collectionView.contentSize;
+}
+
+- (BOOL)isDecelerating {
+    return self.calendarView.collectionView.isDecelerating;
+}
+
+- (BOOL)isDragging {
+    return self.calendarView.collectionView.isDragging;
+}
+
+- (BOOL)isTracking {
+    return self.calendarView.collectionView.isTracking;
+}
 
 - (void)configureVisibleCells {
     [self.calendarView.visibleCells enumerateObjectsUsingBlock:^(__kindof FSCalendarCell * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {

--- a/Example/Backpack/View Controllers/CalendarViewController.swift
+++ b/Example/Backpack/View Controllers/CalendarViewController.swift
@@ -39,7 +39,7 @@ class CalendarViewController: UIViewController, CalendarDelegate {
         print("calendar:", calendar, "didChangeDateSelection:", dateList)
     }
 
-    func calendar(_ calendar: Backpack.Calendar!, didScroll scrollView: UIScrollView!) {
-        print("calendar:", calendar, "didScroll:", scrollView.contentOffset)
+    func calendar(_ calendar: Backpack.Calendar!, didScroll contentOffset: CGPoint) {
+        print("calendar:", calendar, "didScroll:", contentOffset, "isTracking:", calendar.isTracking)
     }
 }

--- a/Example/Backpack/View Controllers/CalendarViewController.swift
+++ b/Example/Backpack/View Controllers/CalendarViewController.swift
@@ -39,7 +39,7 @@ class CalendarViewController: UIViewController, CalendarDelegate {
         print("calendar:", calendar, "didChangeDateSelection:", dateList)
     }
 
-    func calendar(_ calendar: Backpack.Calendar!, didScroll contentOffset: CGPoint) {
-        print("calendar:", calendar, "didScroll:", contentOffset)
+    func calendar(_ calendar: Backpack.Calendar!, didScroll scrollView: UIScrollView!) {
+        print("calendar:", calendar, "didScroll:", scrollView.contentOffset)
     }
 }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,4 @@
 # Unreleased
 
-- CalendarDelegate exposes the whole scrollview instead of just the content offset
+- BPKCalendar:
+  - Exposed some properties of the calendar's underlying scrollView

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,3 @@
 # Unreleased
 
+- CalendarDelegate exposes the whole scrollview instead of just the content offset

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,6 @@
 # Unreleased
 
-- BPKCalendar:
+**Added:**
+- Backapck/Calendar
+  - Exposed some properties of the calendar's underlying scrollView.
   - Exposed some properties of the calendar's underlying scrollView


### PR DESCRIPTION
This will enable more complex interactions with the calendar. example: animated external header

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
