### PR TITLE
[NO-JIRA] Make dialog test less flaky

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ end
 
 task :test do
   only_testing = FULL_TESTS ? '' : '-only-testing:Backpack_Tests'
-  sh "set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace #{EXAMPLE_WORKSPACE} -scheme \"#{EXAMPLE_SCHEMA}\" -sdk #{BUILD_SDK} -destination \"#{DESTINATION}\" #{only_testing} ONLY_ACTIVE_ARCH=NO | xcpretty"
+  sh "set -o pipefail && xcrun simctl erase all && xcodebuild test -enableCodeCoverage YES -workspace #{EXAMPLE_WORKSPACE} -scheme \"#{EXAMPLE_SCHEMA}\" -sdk #{BUILD_SDK} -destination \"#{DESTINATION}\" #{only_testing} ONLY_ACTIVE_ARCH=NO | xcpretty"
 end
 
 task :lint do


### PR DESCRIPTION
Trying to make the XCUI tests less flaky, as ≅ 50% of runs on Travis fail at this point. [Por ejemplo](https://travis-ci.org/Skyscanner/backpack-ios/jobs/501186441#L1387)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


So in summary, this PR failed to achieve what I set out to.
However, I don’t think my change actually does any harm, so shall we merge it anyway?
https://github.com/Skyscanner/backpack-ios/pull/198

Change 2:

| Number | Result           |
| -------- | ------------ |
| Test 1     |  Pass            |
| Test 2     | Pass             |
| Test 3     | Pass             |
| Test 4     | Pass             |
| Test 5     | Fail               |
| Test 6     | Pass             |
| Test 7     | Fail               |