### PR TITLE
Introducing SimpleDate in BPKCalendar

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -17,6 +17,7 @@
  */
 
 @class BPKCalendar;
+@class BPKSimpleDate;
 
 /**
  * Enum values for specifying calendar selection type
@@ -35,7 +36,7 @@ NS_SWIFT_NAME(CalendarDelegate) @protocol BPKCalendarDelegate <NSObject>
  * @param calendar The backpack calendar.
  * @param dateList List of selected dates.
  */
-- (void)calendar:(BPKCalendar *)calendar didChangeDateSelection:(NSArray<NSDate *> *)dateList;
+- (void)calendar:(BPKCalendar *)calendar didChangeDateSelection:(NSArray<BPKSimpleDate *> *)dateList;
 
 @optional
 
@@ -71,17 +72,17 @@ NS_SWIFT_NAME(Calendar) @interface BPKCalendar: UIView
 /**
  * List of selected dates
  */
-@property (nonatomic) NSArray<NSDate *> *selectedDates;
+@property (nonatomic) NSArray<BPKSimpleDate *> *selectedDates;
 
 /**
  * The earliest date that the user is allowed to select
  */
-@property (nonatomic) NSDate *minDate;
+@property (nonatomic) BPKSimpleDate *minDate;
 
 /**
  * The latest date that the user is allowed to select
  */
-@property (nonatomic) NSDate *maxDate;
+@property (nonatomic) BPKSimpleDate *maxDate;
 
 /**
  * The underlying scrollView's content offset
@@ -119,5 +120,19 @@ NS_SWIFT_NAME(Calendar) @interface BPKCalendar: UIView
 @property (nonatomic) id<BPKCalendarDelegate> delegate;
 
 - (void)reloadData;
+
+/**
+ * Converts a Date to a SimpleDate based on the device's locale timezone
+ * @param date Date object in the device's local timezone
+ * @return SimpleDate representing a timezone independent date
+ */
+- (BPKSimpleDate *)simpleDateFromDate:(NSDate *)date;
+
+/**
+ * Converts a SimpleDate to a Date based on the device's locale timezone
+ * @param simpleDate A SimpleDate representing a timezone independent date
+ * @return Date object in the device's local timezone
+ */
+-(NSDate *)dateFromSimpleDate:(BPKSimpleDate *)simpleDate;
 
 @end

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -179,20 +179,20 @@ NSString * const HeaderDateFormat = @"MMMM";
     }
 }
 
-- (NSArray<NSDate *> *)selectedDates {
+- (NSArray<BPKSimpleDate *> *)selectedDates {
     if (self.sameDayRange) {
-        return [self.calendarView.selectedDates arrayByAddingObject:self.calendarView.selectedDates.firstObject];
+        NSArray<NSDate *> *dates = [self.calendarView.selectedDates arrayByAddingObject:self.calendarView.selectedDates.firstObject];
+        return [self simpleDatesFromDates:dates];
     }
     
-    return self.calendarView.selectedDates;
+    return [self simpleDatesFromDates:self.calendarView.selectedDates];
 }
 
 - (NSSet<BPKSimpleDate *> *)createDateSet:(NSArray<NSDate *> *)dates {
     NSMutableSet<BPKSimpleDate *> *set = [[NSMutableSet alloc] initWithCapacity:dates.count];
 
     for (NSDate *date in dates) {
-        NSDateComponents *components = [self.gregorian components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
-        BPKSimpleDate *simpleDate = [[BPKSimpleDate alloc] initWithDateComponent:components fullDate:date];
+        BPKSimpleDate *simpleDate = [self simpleDateFromDate:date];
 
         [set addObject:simpleDate];
     }
@@ -200,14 +200,14 @@ NSString * const HeaderDateFormat = @"MMMM";
     return [set copy];
 }
 
-- (void)setSelectedDates:(NSArray<NSDate *> *)selectedDates {
+- (void)setSelectedDates:(NSArray<BPKSimpleDate *> *)selectedDates {
     BPKAssertMainThread();
     NSSet<BPKSimpleDate *> *previouslySelectedDates = [self createDateSet:self.calendarView.selectedDates];
-    NSSet<BPKSimpleDate *> *newSelectedDates = [self createDateSet:selectedDates];
+    NSSet<BPKSimpleDate *> *newSelectedDates = [NSSet setWithArray:selectedDates];
 
     for (BPKSimpleDate *date in newSelectedDates) {
         if (![previouslySelectedDates containsObject:date]) {
-            [self.calendarView selectDate:date.fullDate];
+            [self.calendarView selectDate:[self dateFromSimpleDate:date]];
         }
     }
 
@@ -215,11 +215,11 @@ NSString * const HeaderDateFormat = @"MMMM";
     [toDeselect minusSet:newSelectedDates];
 
     for (BPKSimpleDate *date in toDeselect) {
-        [self.calendarView deselectDate:date.fullDate];
+        [self.calendarView deselectDate:[self dateFromSimpleDate: date]];
     }
 
     if (selectedDates.count == 2
-        && [selectedDates.firstObject isEqualToDate:selectedDates.lastObject]) {
+        && [selectedDates.firstObject isEqualToSimpleDate:selectedDates.lastObject]) {
         self.sameDayRange = YES;
     }
 }
@@ -238,11 +238,11 @@ NSString * const HeaderDateFormat = @"MMMM";
 }
 
 - (NSDate *)minimumDateForCalendar:(FSCalendar *)calendar {
-    return self.minDate;
+    return [self dateFromSimpleDate:self.minDate];
 }
 
 - (NSDate *)maximumDateForCalendar:(FSCalendar *)calendar {
-    return self.maxDate;
+    return [self dateFromSimpleDate:self.maxDate];
 }
 
 #pragma mark - <FSCalendarDelegate>
@@ -443,6 +443,41 @@ NSString * const HeaderDateFormat = @"MMMM";
         return NO;
     
     return YES;
+}
+
+- (BPKSimpleDate *_Nullable)simpleDateFromDate:(NSDate *_Nullable)date {
+    if(date == nil) {
+        return nil;
+    }
+    
+    NSDateComponents *components = [self.calendarView.gregorian components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay
+                                                                  fromDate:date];
+    
+    return [[BPKSimpleDate alloc] initWithYear:components.year month:components.month day:components.day];
+}
+
+- (NSArray<BPKSimpleDate *> *)simpleDatesFromDates:(NSArray<NSDate *> *)dates {
+    NSMutableArray *simpleDates = [[NSMutableArray alloc] initWithCapacity:dates.count];
+    
+    for (NSDate *date in dates) {
+        [simpleDates addObject:[self simpleDateFromDate:date]];
+    }
+    
+    return [simpleDates copy];
+}
+
+-(NSDate *_Nullable)dateFromSimpleDate:(BPKSimpleDate *_Nullable)simpleDate {
+    if(simpleDate == nil) {
+        return nil;
+    }
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.timeZone = self.gregorian.timeZone;
+    [components setDay:simpleDate.day];
+    [components setMonth:simpleDate.month];
+    [components setYear:simpleDate.year];
+    
+    return [self.calendarView.gregorian dateFromComponents:components];
 }
 
 #pragma mark -

--- a/Backpack/Calendar/Classes/BPKSimpleDate.h
+++ b/Backpack/Calendar/Classes/BPKSimpleDate.h
@@ -20,13 +20,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BPKSimpleDate: NSObject
+NS_SWIFT_NAME(SimpleDate) @interface BPKSimpleDate: NSObject
 @property(nonatomic, readonly) NSUInteger day;
 @property(nonatomic, readonly) NSUInteger month;
 @property(nonatomic, readonly) NSUInteger year;
-@property(nonatomic, strong, readonly) NSDate *fullDate;
 
-- (instancetype)initWithDateComponent:(NSDateComponents *)components fullDate:(NSDate *)fullDate;
+- (instancetype)initWithYear:(NSUInteger)year month:(NSUInteger)month day:(NSUInteger)day;
+
+- (BOOL)isEqualToSimpleDate:(BPKSimpleDate *)other;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKSimpleDate.m
+++ b/Backpack/Calendar/Classes/BPKSimpleDate.m
@@ -30,16 +30,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation BPKSimpleDate
 
-- (instancetype)initWithDateComponent:(NSDateComponents *)components fullDate:(NSDate *)fullDate {
+- (instancetype)initWithYear:(NSUInteger)year month:(NSUInteger)month day:(NSUInteger)day {
     self = [super init];
-
+    
     if (self) {
-        self.year = components.year;
-        self.month = components.month;
-        self.day = components.day;
-        self.fullDate = fullDate;
+        self.year = year;
+        self.month = month;
+        self.day = day;
     }
-
+    
     return self;
 }
 
@@ -65,6 +64,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)hash {
     return self.year ^ self.month ^ self.day;
+}
+
+-(NSString *)description {
+    return [NSString stringWithFormat:@"<BPKSimpleDate %lu-%lu-%lu>", (unsigned long)self.year, (unsigned long)self.month, (unsigned long)self.day];
 }
 
 @end

--- a/Backpack/Calendar/Classes/Calendar.h
+++ b/Backpack/Calendar/Classes/Calendar.h
@@ -20,5 +20,6 @@
 #define __BACKPACK_CALENDAR__
 #import "BPKCalendar.h"
 #import "BPKCalendarYearPill.h"
+#import "BPKSimpleDate.h"
 #endif
 

--- a/Example/Backpack/View Controllers/CalendarViewController.swift
+++ b/Example/Backpack/View Controllers/CalendarViewController.swift
@@ -25,7 +25,7 @@ class CalendarViewController: UIViewController, CalendarDelegate {
     @IBOutlet weak var segmentedControl: UISegmentedControl!
 
     override func viewDidLoad() {
-        myView.minDate = Date()
+        myView.minDate = myView.simpleDate(from: Date())
         myView.locale = Locale.current
         myView.delegate = self
     }
@@ -35,7 +35,7 @@ class CalendarViewController: UIViewController, CalendarDelegate {
         myView.reloadData()
     }
 
-    func calendar(_ calendar: Backpack.Calendar!, didChangeDateSelection dateList: [Date]!) {
+    func calendar(_ calendar: Backpack.Calendar!, didChangeDateSelection dateList: [SimpleDate]!) {
         print("calendar:", calendar, "didChangeDateSelection:", dateList)
     }
 

--- a/Example/SnapshotTests/BPKCalendarSnapshotTest.m
+++ b/Example/SnapshotTests/BPKCalendarSnapshotTest.m
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
     bpkCalendar.selectionType = BPKCalendarSelectionSingle;
-    bpkCalendar.selectedDates = @[ self.date1 ];
+    bpkCalendar.selectedDates = @[ [bpkCalendar simpleDateFromDate:self.date1] ];
     [bpkCalendar reloadData];
 
     FBSnapshotVerifyView(parentView, nil);
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     [self configureParentView:parentView forCalendar:bpkCalendar];
     bpkCalendar.selectionType = BPKCalendarSelectionRange;
-    bpkCalendar.selectedDates = @[ self.date1, self.date2 ];
+    bpkCalendar.selectedDates = @[ [bpkCalendar simpleDateFromDate:self.date1], [bpkCalendar simpleDateFromDate:self.date2] ];
     [bpkCalendar reloadData];
     
     FBSnapshotVerifyView(parentView, nil);
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     [self configureParentView:parentView forCalendar:bpkCalendar];
     bpkCalendar.selectionType = BPKCalendarSelectionMultiple;
-    bpkCalendar.selectedDates = @[ self.date1, self.date2 ];
+    bpkCalendar.selectedDates = @[ [bpkCalendar simpleDateFromDate:self.date1], [bpkCalendar simpleDateFromDate:self.date2] ];
     [bpkCalendar reloadData];
     
     FBSnapshotVerifyView(parentView, nil);


### PR DESCRIPTION
The update changes the public interface of the BPKCalendar to surface the selected dates as SimpleDate, instead of NSDate to make it explicit that the values should be timezone independent and less error prone to accidental timezone conversions.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
