### PR TITLE
[BPK-2245] Add interchangeable theme wrapper to example app

### DIFF
--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		D220CACC221467AB0086A72E /* ShakeableWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = D220CACA221467AA0086A72E /* ShakeableWindow.m */; };
 		D225BBE2216218FF00FC8B17 /* CardsSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D225BBE1216218FF00FC8B17 /* CardsSelectorViewController.swift */; };
 		D233F00F2162159E00A07D9B /* Cards.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D233F00E2162159E00A07D9B /* Cards.storyboard */; };
+		D2387C22221C276100883F93 /* BPKThemeContainerController.m in Sources */ = {isa = PBXBuildFile; fileRef = D2387C20221C276000883F93 /* BPKThemeContainerController.m */; };
 		D23E2C13219204A900A15AAE /* BPKBadgeContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23E2C12219204A800A15AAE /* BPKBadgeContainer.swift */; };
 		D246C1F4216643B8001CB366 /* BPKCardTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D246C1F3216643B8001CB366 /* BPKCardTest.m */; };
 		D246C1F621665056001CB366 /* BPKCardSnapshotTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D246C1F521665056001CB366 /* BPKCardSnapshotTest.m */; };
@@ -182,6 +183,8 @@
 		D220CACB221467AB0086A72E /* ShakeableWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShakeableWindow.h; sourceTree = "<group>"; };
 		D225BBE1216218FF00FC8B17 /* CardsSelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsSelectorViewController.swift; sourceTree = "<group>"; };
 		D233F00E2162159E00A07D9B /* Cards.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Cards.storyboard; sourceTree = "<group>"; };
+		D2387C20221C276000883F93 /* BPKThemeContainerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKThemeContainerController.m; sourceTree = "<group>"; };
+		D2387C21221C276100883F93 /* BPKThemeContainerController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPKThemeContainerController.h; sourceTree = "<group>"; };
 		D23E2C12219204A800A15AAE /* BPKBadgeContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPKBadgeContainer.swift; sourceTree = "<group>"; };
 		D246C1F3216643B8001CB366 /* BPKCardTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKCardTest.m; sourceTree = "<group>"; };
 		D246C1F521665056001CB366 /* BPKCardSnapshotTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKCardSnapshotTest.m; sourceTree = "<group>"; };
@@ -334,6 +337,8 @@
 		6003F593195388D20070C39A /* Example for Backpack */ = {
 			isa = PBXGroup;
 			children = (
+				D2387C21221C276100883F93 /* BPKThemeContainerController.h */,
+				D2387C20221C276000883F93 /* BPKThemeContainerController.m */,
 				D220CACB221467AB0086A72E /* ShakeableWindow.h */,
 				D220CACA221467AA0086A72E /* ShakeableWindow.m */,
 				D2161D4F2146B8910097D0B1 /* Views */,
@@ -835,6 +840,7 @@
 				D2CD11E7215E4D83000CEA5C /* CardsViewController.swift in Sources */,
 				6003F59E195388D20070C39A /* BPKAppDelegate.m in Sources */,
 				D225BBE2216218FF00FC8B17 /* CardsSelectorViewController.swift in Sources */,
+				D2387C22221C276100883F93 /* BPKThemeContainerController.m in Sources */,
 				60D302CF201B77F4006DBC18 /* BPKSpacingsViewController.m in Sources */,
 				D6907040215A4F2C0088C97B /* LabelsPerformanceViewController.swift in Sources */,
 				3A7D2D47214AB9F400ECBD5B /* BPKButtonsViewController.m in Sources */,

--- a/Example/Backpack/BPKThemeContainerController.h
+++ b/Example/Backpack/BPKThemeContainerController.h
@@ -1,0 +1,32 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(ThemeContainerController) @interface BPKThemeContainerController : UINavigationController
+
++ (BPKThemeContainerController *) themeContainerController;
+
+- (void) swapThemeContainers;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Backpack/BPKThemeContainerController.m
+++ b/Example/Backpack/BPKThemeContainerController.m
@@ -1,0 +1,72 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BPKThemeContainerController.h"
+#import "Backpack_Native-Swift.h"
+#import <objc/runtime.h>
+
+@interface BPKThemeContainerController ()
+@end
+
+@implementation BPKThemeContainerController
+
+static BPKThemeContainerController *themeContainerController;
+
++ (BPKThemeContainerController *) themeContainerController {
+    return themeContainerController;
+}
+
+bool additionalSubviewAdded = NO;
+
+- (void) viewDidLoad {
+    [super viewDidLoad];
+
+    themeContainerController = self;
+}
+
+- (void) swapThemeContainers {
+    // TODO Get theme from settings once implemented!
+    NSString *themeName = nil;
+
+    NSArray *subviewsToPreserve = [[self view] subviews];
+    if(additionalSubviewAdded){
+        subviewsToPreserve = [[subviewsToPreserve objectAtIndex:0] subviews];
+    }
+
+    UIView *themedView = nil;
+    if ([themeName  isEqual: @"London"]){
+        themedView = [[BPKLondonThemeContainer alloc]initWithFrame:self.view.frame];
+    } else if ([themeName  isEqual: @"Hong Kong"]) {
+        themedView = [[BPKHongKongThemeContainer alloc]initWithFrame:self.view.frame];
+    } else if ([themeName  isEqual: @"Doha"]) {
+        themedView = [[BPKDohaThemeContainer alloc]initWithFrame:self.view.frame];
+    }else{
+        themedView = [[UIView alloc]initWithFrame:self.view.frame];
+    }
+
+    [[[self view] subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];
+
+    [self.view addSubview:themedView];
+    additionalSubviewAdded = YES;
+
+    for (UIView *sv in subviewsToPreserve){
+        [themedView addSubview:sv];
+    }
+}
+
+@end

--- a/Example/Backpack/Backpack Native-Bridging-Header.h
+++ b/Example/Backpack/Backpack Native-Bridging-Header.h
@@ -1,3 +1,4 @@
 //
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
+#import "BPKThemeContainerController.h"

--- a/Example/Backpack/Base.lproj/Main.storyboard
+++ b/Example/Backpack/Base.lproj/Main.storyboard
@@ -1019,10 +1019,10 @@
             </objects>
             <point key="canvasLocation" x="1696.8" y="1754.5727136431785"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Theme Container Controller-->
         <scene sceneID="8hg-xW-f3B">
             <objects>
-                <navigationController id="i7P-2f-H5J" sceneMemberID="viewController">
+                <navigationController id="i7P-2f-H5J" customClass="BPKThemeContainerController" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="lNQ-uI-aCM">
                         <rect key="frame" x="0.0" y="20" width="375" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
Wraps the entire example app in a class that allows us to set a theme container. This will be required when we wish to switch themes on the fly at runtime

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
