### PR TITLE
Layout update issue fixed

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -154,6 +154,8 @@ NSString * const HeaderDateFormat = @"MMMM";
     CGFloat yearPillWidth = CGRectGetWidth(self.yearPill.bounds);
     CGFloat yearPillHeight = CGRectGetHeight(self.yearPill.bounds);
     self.yearPill.frame = CGRectMake(width / 2.0 - yearPillWidth / 2.0, CGRectGetHeight(self.calendarWeekdayView.frame) + BPKSpacingLg, yearPillWidth, yearPillHeight);
+    
+    [self.calendarView.collectionViewLayout invalidateLayout];
 }
 
 #pragma mark - property getters/setters

--- a/Example/Backpack/View Controllers/CalendarViewController.swift
+++ b/Example/Backpack/View Controllers/CalendarViewController.swift
@@ -45,6 +45,6 @@ class CalendarViewController: UIViewController, CalendarDelegate {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        myView.reloadData()
+        coordinator.animate(alongsideTransition: nil, completion: { _ in self.myView.reloadData() })
     }
 }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,6 @@
 # Unreleased
 
+**Fixed:**
+
++ Backpack/Calendar
+  + Fixes for split screen: Layout updated at the right time (after screen transition completed)


### PR DESCRIPTION
This change moves the update of the calendar's collectionview from the beginning of a size transition to the end which is the right time to reload the data. This fixes the split screen issues and some weird behaviour on screen rotation.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
