### PR TITLE
[NO-JIRA] Add themeName to theme definition protocol

### DIFF
--- a/Backpack/Theme/Classes/BPKDefaultTheme.m
+++ b/Backpack/Theme/Classes/BPKDefaultTheme.m
@@ -27,6 +27,10 @@
 
 @implementation BPKDefaultTheme
 
+- (NSString *)themeName {
+    return @"Default";
+}
+
 - (UIColor *)switchPrimaryColor {
     return BPKColor.blue500;
 }

--- a/Backpack/Theme/Classes/BPKDohaTheme.m
+++ b/Backpack/Theme/Classes/BPKDohaTheme.m
@@ -26,6 +26,10 @@
 
 @implementation BPKDohaTheme
 
+- (NSString *)themeName {
+    return @"Doha";
+}
+
 - (UIColor *)switchPrimaryColor {
     return [UIColor colorWithRed:255.0f/255.0f green:184.0f/255.0f blue:2.0f/255.0f alpha:1.0f];
 }

--- a/Backpack/Theme/Classes/BPKHongKongTheme.m
+++ b/Backpack/Theme/Classes/BPKHongKongTheme.m
@@ -26,6 +26,10 @@
 
 @implementation BPKHongKongTheme
 
+- (NSString *)themeName {
+    return @"Hong Kong";
+}
+
 - (UIColor *)switchPrimaryColor {
     return [UIColor colorWithRed:76.0f/255.0f green:76.0f/255.0f blue:76.0f/255.0f alpha:1.0f];
 }

--- a/Backpack/Theme/Classes/BPKLondonTheme.m
+++ b/Backpack/Theme/Classes/BPKLondonTheme.m
@@ -26,6 +26,10 @@
 
 @implementation BPKLondonTheme
 
+- (NSString *)themeName {
+    return @"London";
+}
+
 - (UIColor *)switchPrimaryColor {
     return [UIColor colorWithRed:237.0f/255.0f green:27.0f/255.0f blue:40.0f/255.0f alpha:1.0f];
 }

--- a/Backpack/Theme/Classes/BPKThemeDefinition.h
+++ b/Backpack/Theme/Classes/BPKThemeDefinition.h
@@ -24,8 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @required
 
-@property (nonatomic, readonly, strong) UIColor* switchPrimaryColor;
-@property (nonatomic, readonly) Class themeContainerClass;
+@property(nonatomic, readonly, strong) NSString *themeName;
+@property(nonatomic, readonly, strong) UIColor *switchPrimaryColor;
+@property(nonatomic, readonly) Class themeContainerClass;
 
 @end
 


### PR DESCRIPTION
Decided that adding a `themeName` to the theme definition protocol would help for identifying it in settings etc.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)