### PR TITLE
[BPK-2339] Prevent duplicate settings ui showing

### DIFF
--- a/Example/Backpack/BPKExampleApp.swift
+++ b/Example/Backpack/BPKExampleApp.swift
@@ -20,13 +20,23 @@ import Backpack.Theme
 
 @objc class BPKExampleApp: UIApplication {
 
-    @objc override func sendEvent(_ event: UIEvent) {
-        if event.type == .motion && event.subtype == .motionShake {
+    #if swift(>=4.2)
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
             BPKExampleApp.showSettingsView()
         }
 
-        super.sendEvent(event)
+        super.motionEnded(motion, with: event)
     }
+    #else
+    override func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            BPKExampleApp.showSettingsView()
+        }
+
+        super.motionEnded(motion, with: event)
+    }
+    #endif
 
     @objc class func showSettingsView() {
         let storyboardName = "Main"


### PR DESCRIPTION
Why does this fail on SDK 11.4?
https://travis-ci.org/Skyscanner/backpack-ios/jobs/514199570#L856

It should be available since SDK 3!
https://developer.apple.com/documentation/uikit/uievent/eventsubtype

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
