### PR TITLE
[BPK-2270] Primary color utility spike

### DIFF
--- a/Backpack/Theme/Classes/BPKTheme.h
+++ b/Backpack/Theme/Classes/BPKTheme.h
@@ -28,7 +28,14 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol BPKThemeDefinition;
 NS_SWIFT_NAME(Theme) @interface BPKTheme : NSObject
 
-@property (class, nonatomic, assign, readonly) NSString *didChangeNotification;
+@property(class, nonatomic, assign, readonly) NSString *didChangeNotification;
+
+/**
+ * Returns the themed primary color for a given `UIViewController`.
+ *
+ * @return the themed `UIColor` value.
+ */
++ (UIColor *)primaryColorFor:(UIViewController *)viewController;
 
 /**
  * Creates and returns an instance of the container view for the receiver's theme.

--- a/Backpack/Theme/Classes/BPKTheme.m
+++ b/Backpack/Theme/Classes/BPKTheme.m
@@ -18,8 +18,11 @@
 
 #import "BPKTheme.h"
 #import "BPKDohaThemeContainer.h"
+#import "BPKThemeContainerController.h"
 #import "BPKThemeDefinition.h"
+#import "UIViewController+BPKThemeContainerController.h"
 
+#import <Backpack/Color.h>
 #import <Backpack/Switch.h>
 #import <Backpack/Spinner.h>
 
@@ -28,6 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *BPKThemeDidChangeNotification = @"BPKThemeDidChangeNotification";
 
 @implementation BPKTheme
+
++ (UIColor *)primaryColorFor:(UIViewController *)viewController {
+    BPKThemeContainerController *tcc = viewController.themeContainerController;
+    if(tcc != nil) {
+        return tcc.themeDefinition.primaryColor;
+    }
+
+    return BPKColor.blue500;
+}
 
 + (NSString *)didChangeNotification {
     return BPKThemeDidChangeNotification;

--- a/Backpack/Theme/Classes/UIViewController+BPKThemeContainerController.h
+++ b/Backpack/Theme/Classes/UIViewController+BPKThemeContainerController.h
@@ -28,5 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
  * there are no theme container controllers among the receivers ancestors.
  */
 @property(nonatomic, nullable, readonly) BPKThemeContainerController *themeContainerController;
+
+/**
+ * A convenience method that attempts to return the current `UIViewController`.
+ */
++(UIViewController*) currentViewController;
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/UIViewController+BPKThemeContainerController.m
+++ b/Backpack/Theme/Classes/UIViewController+BPKThemeContainerController.m
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #import "UIViewController+BPKThemeContainerController.h"
 
 #import "BPKThemeContainerController.h"
@@ -34,6 +35,49 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return nil;
+}
+
++(UIViewController*) findBestViewController:(UIViewController*)vc {
+
+    if (vc.presentedViewController) {
+        return [UIViewController findBestViewController:vc.presentedViewController];
+    } else if ([vc isKindOfClass:[UISplitViewController class]]) {
+        // Return right hand side
+        UISplitViewController* svc = (UISplitViewController*) vc;
+
+        if (svc.viewControllers.count > 0){
+            return [UIViewController findBestViewController:svc.viewControllers.lastObject];
+        }else{
+            return vc;
+        }
+    } else if ([vc isKindOfClass:[UINavigationController class]]) {
+        // Return top view
+        UINavigationController* svc = (UINavigationController*) vc;
+
+        if (svc.viewControllers.count > 0) {
+
+            return [UIViewController findBestViewController:svc.topViewController];
+        }        else {
+            return vc;
+        }
+    } else if ([vc isKindOfClass:[UITabBarController class]]) {
+        // Return visible view
+        UITabBarController* svc = (UITabBarController*) vc;
+
+        if (svc.viewControllers.count > 0){
+            return [UIViewController findBestViewController:svc.selectedViewController];
+        }else{
+            return vc;
+        }
+    }
+
+    // Default. Return the original `UIViewController`
+    return vc;
+}
+
++(UIViewController*) currentViewController {
+    UIViewController* rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    return [UIViewController findBestViewController:rootViewController];
 }
 
 @end

--- a/Example/Backpack/Views/BPKTableViewSelectableCell.swift
+++ b/Example/Backpack/Views/BPKTableViewSelectableCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import Backpack.Spacing
 import Backpack.Icon
+import Backpack.Theme
 
 class BPKTableViewSelectableCell: UITableViewCell {
     let tickIcon: IconView = IconView(iconName: IconName.tick, size: BPKIconSize.small)
@@ -30,7 +31,7 @@ class BPKTableViewSelectableCell: UITableViewCell {
     }
 
     func setup() {
-        tickIcon.tintColor = Color.blue500
+        tickIcon.tintColor = Theme.primaryColor(for: UIViewController.current())
         contentView.addSubview(tickIcon)
         tickIcon.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -38,9 +39,21 @@ class BPKTableViewSelectableCell: UITableViewCell {
             tickIcon.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -BPKSpacingBase)
         ])
         tickIcon.isHidden = true
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.receieveTheme),
+            name: NSNotification.Name(rawValue: NSNotification.Name.RawValue(Theme.didChangeNotification)),
+            object: nil
+        )
     }
 
     func setApplied(applied: Bool) {
         tickIcon.isHidden = !applied
+    }
+
+    @objc
+    func receieveTheme() {
+        tickIcon.tintColor = Theme.primaryColor(for: UIViewController.current())
     }
 }


### PR DESCRIPTION
Food for thought:
 - We can traverse the view hierarchy of a given view to find out what theme is the most appropriate.
 - What should consumers do to ensure that changes to the view hierarchy result in the correct change to the primary color? Relying on `didChangeTheme` to trigger re-pulling the `primaryColor` will not be 100% reliable. Instead can they just respond to all view hierarchy changes?

 - Logic would probably be simpler if we attached themeDefinition to each ThemeContainerView. Then we could simply traverse the hierarchy to find an instance of BPKThemeContainer instead of needing to work out which ViewController is active.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
