### PR TITLE
[BPK-2270] Add theme definition to container controller API

### DIFF
--- a/Backpack/Theme/Classes/BPKThemeContainerController.h
+++ b/Backpack/Theme/Classes/BPKThemeContainerController.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import "BPKThemeDefinition.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -34,12 +36,12 @@ NS_SWIFT_NAME(ThemeContainerController) @interface BPKThemeContainerController :
 /**
  * Create an instance with a given container view and root view controller.
  *
- * @param container The container view to render the root view controller's view hierarchy inside.
+ * @param themeDefinition The theme that we want to wrap the view hierarchy in.
  * @param rootViewController The root view controller to be used as a child view controller.
  * @return A configured instance than can further be contained or set to be the `rootViewController` of a `window`.
  */
-- (instancetype)initWithThemeContainer:(UIView *)container
-                    rootViewController:(UIViewController *)rootViewController NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithThemeDefinition:(id<BPKThemeDefinition>)themeDefinition
+                     rootViewController:(UIViewController *)rootViewController NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
     __attribute__((unavailable("use initWithThemeContainer:rootViewController: instead")));
@@ -58,10 +60,17 @@ NS_SWIFT_NAME(ThemeContainerController) @interface BPKThemeContainerController :
 
 /**
  * The theme container that is currently being used if the theme is active.
+ * This value is `readonly`. In order to change the `themeContainer`, the
+ * `themeDefinition` property must be updated.
+ */
+@property(readonly, nonatomic, strong) UIView *themeContainer;
+
+/**
+ * The theme container that is currently being used if the theme is active.
  * Changing the value of this property will immediately cause the view hierarchy to update to reflect the
  * new state. As such it should only be called on the main thread.
  */
-@property(nonatomic, strong) UIView *themeContainer;
+@property(nonatomic, strong) id<BPKThemeDefinition> themeDefinition;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKThemeContainerController.m
+++ b/Backpack/Theme/Classes/BPKThemeContainerController.m
@@ -18,7 +18,6 @@
 
 #import "BPKThemeContainerController.h"
 #import "BPKTheme.h"
-#import "BPKThemeDefinition.h"
 
 #import <Backpack/Common.h>
 
@@ -33,13 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (instancetype)initWithThemeContainer:(UIView *)container
+- (instancetype)initWithThemeDefinition:(id<BPKThemeDefinition>)themeDefinition
                     rootViewController:(nonnull UIViewController *)rootViewController {
     self = [super initWithNibName:nil bundle:nil];
 
     if (self) {
         _themeActive = YES;
-        _themeContainer = container;
+        _themeDefinition = themeDefinition;
+        _themeContainer = [BPKTheme containerFor:_themeDefinition];
         self.rootViewController = rootViewController;
 
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         id<BPKThemeDefinition> definition = (id<BPKThemeDefinition>)notification.object;
-        [self setThemeContainer:[BPKTheme containerFor:definition]];
+        [self setThemeDefinition:definition];
     }
 }
 
@@ -104,13 +104,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)setThemeContainer:(UIView *)themeContainer {
+- (void)setThemeDefinition:(id<BPKThemeDefinition>)themeDefinition {
     BPKAssertMainThread();
 
-    if (_themeContainer != themeContainer) {
+    if (_themeDefinition != themeDefinition) {
+        _themeDefinition = themeDefinition;
         [self.rootViewController.view removeFromSuperview];
         [_themeContainer removeFromSuperview];
-        _themeContainer = themeContainer;
+        _themeContainer = [BPKTheme containerFor:themeDefinition];
         [self.view addSubview:_themeContainer];
         [_themeContainer addSubview:self.rootViewController.view];
 
@@ -120,9 +121,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BPKThemeContainerController *)createIdenticalThemeContainerForRootController:(UIViewController *)rootController {
-    UIView *themeContainer = [[_themeContainer class] new];
     BPKThemeContainerController *themeContainerController =
-        [[BPKThemeContainerController alloc] initWithThemeContainer:themeContainer rootViewController:rootController];
+    [[BPKThemeContainerController alloc] initWithThemeDefinition:_themeDefinition rootViewController:rootController];
     return themeContainerController;
 }
 

--- a/Example/Backpack/BPKAppDelegate.m
+++ b/Example/Backpack/BPKAppDelegate.m
@@ -35,10 +35,9 @@
     [ThemeHelpers applyAllThemes];
 
     id<BPKThemeDefinition> activeTheme = [ThemeHelpers themeDefinitionForTheme:Settings.sharedSettings.activeTheme];
-    UIView *themeContainer = [BPKTheme containerFor:activeTheme];
 
     BPKThemeContainerController *themeContainerController =
-    [[BPKThemeContainerController alloc] initWithThemeContainer:themeContainer
+    [[BPKThemeContainerController alloc] initWithThemeDefinition:activeTheme
                                              rootViewController:self.window.rootViewController];
     self.window.rootViewController = themeContainerController;
     [self.window makeKeyAndVisible];


### PR DESCRIPTION
So we realised that the ThemeContainer being agnostic to the ThemeDefinition was a bit of an oversight. This changes the API to take a themeDefinition. It then creates the appropriate container itself. (Previously consumers would create a themeContainer from the themeDefinition themselves, and pass the container in).

This simplifies the API, and also means we can expose the current themeDefinition.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
