### PR TITLE
[NO-JIRA] Add docs build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
   - npm run build
   - 'if [[ "$MAIN_STAGE" = true ]]; then ./scripts/check-pristine-state package-lock.json; fi'
   - 'if [[ "$MAIN_STAGE" = true ]]; then Example/Pods/SwiftLint/swiftlint lint --strict --config Example/.swiftlint.yml; fi'
+  - 'if [[ "$MAIN_STAGE" = true && ! -n "$TRAVIS_TAG" ]]; then ./scripts/build-docs-ci && rm -rf docs; fi'
   - 'if [[ "$MAIN_STAGE" = true && -n "$TRAVIS_TAG" ]]; then ./scripts/build-docs-ci $TRAVIS_TAG; fi'
   - (cd Example && bundle exec rake ci)
 after_script: 'if [[ "$MAIN_STAGE" = true ]]; then greenkeeper-lockfile-upload; fi'
@@ -51,7 +52,7 @@ deploy:
   on:
     tags: true
     all_branches: true
-    condition: "$MAIN_STAGE = true"
+    condition: "$MAIN_STAGE = true" && -n "$TRAVIS_TAG"
   local_dir: docs/
   skip_cleanup: true
   detect_encoding: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ deploy:
   on:
     tags: true
     all_branches: true
-    condition: "$MAIN_STAGE = true" && -n "$TRAVIS_TAG"
+    condition: "$MAIN_STAGE = true"
   local_dir: docs/
   skip_cleanup: true
   detect_encoding: true


### PR DESCRIPTION
We realised that we weren't catching breaks to the docs building process in CI as it only gets built when a release is done. This PR adds docs building to the CI process (but not deploying) so that we catch errors earlier.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
