### PR TITLE
[NO-JIRA] Fix travis system time issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - osx_image: xcode9.4
       env: BUILD_SDK=iphonesimulator11.4 DESTINATION="OS=10.3.1,platform=iOS Simulator,name=iPhone 7" FULL_TESTS="false" MAIN_STAGE="false"
 before_install:
+  - sudo sntp -sS time.apple.com
   - nvm install
   - nvm use
   - 'if [[ "$MAIN_STAGE" = true ]]; then npm install -g greenkeeper-lockfile@1; fi'


### PR DESCRIPTION
The random NPMJS SSL errors we've seen recently are happening due to the Travis machine having the incorrect time set.

<img width="355" alt="Screenshot 2019-04-03 at 17 53 44" src="https://user-images.githubusercontent.com/30267516/55497619-aac9fe80-5639-11e9-9e01-9f8e6d780871.png">

Anyway, this seems to fix it, so 🤷‍♂️

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
