### PR TITLE
[BPK-2270] Primary color utility spike 2

### DIFF
--- a/Backpack/Theme/Classes/BPKDefaultThemeContainer.m
+++ b/Backpack/Theme/Classes/BPKDefaultThemeContainer.m
@@ -15,11 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #import "BPKDefaultThemeContainer.h"
+#import "BPKDefaultTheme.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation BPKDefaultThemeContainer
+
+- (id<BPKThemeDefinition>)themeDefinition {
+    return [BPKDefaultTheme new];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKDohaThemeContainer.h
+++ b/Backpack/Theme/Classes/BPKDohaThemeContainer.h
@@ -16,15 +16,17 @@
  * limitations under the License.
  */
 
+#import "BPKThemeContainer.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * `BPKDohaThemeContainer` is a subclass of `UIView` which allows the BPKDoha theme to be applied to all its children.
+ * `BPKDohaThemeContainer` is a subclass of `BPKThemeContainer` which allows the BPKDoha theme to be applied to all its
+ * children.
  */
-NS_SWIFT_NAME(DohaThemeContainer) @interface BPKDohaThemeContainer : UIView
+NS_SWIFT_NAME(DohaThemeContainer) @interface BPKDohaThemeContainer : BPKThemeContainer
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKDohaThemeContainer.m
+++ b/Backpack/Theme/Classes/BPKDohaThemeContainer.m
@@ -17,15 +17,15 @@
  */
 
 #import "BPKDohaThemeContainer.h"
-#import <Backpack/Common.h>
+#import "BPKDohaTheme.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BPKDohaThemeContainer ()
-
-@end
-
 @implementation BPKDohaThemeContainer
+
+- (id<BPKThemeDefinition>)themeDefinition {
+    return [BPKDohaTheme new];
+}
 
 @end
 

--- a/Backpack/Theme/Classes/BPKHongKongThemeContainer.h
+++ b/Backpack/Theme/Classes/BPKHongKongThemeContainer.h
@@ -16,16 +16,17 @@
  * limitations under the License.
  */
 
+#import "BPKThemeContainer.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * `BPKHongKongThemeContainer` is a subclass of `UIView` which allows the BPKHongKong theme to be applied to all its
- * children.
+ * `BPKHongKongThemeContainer` is a subclass of `BPKThemeContainer` which allows the BPKHongKong theme to be applied to
+ * all its children.
  */
-NS_SWIFT_NAME(HongKongThemeContainer) @interface BPKHongKongThemeContainer : UIView
+NS_SWIFT_NAME(HongKongThemeContainer) @interface BPKHongKongThemeContainer : BPKThemeContainer
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKHongKongThemeContainer.m
+++ b/Backpack/Theme/Classes/BPKHongKongThemeContainer.m
@@ -17,15 +17,15 @@
  */
 
 #import "BPKHongKongThemeContainer.h"
-#import <Backpack/Common.h>
+#import "BPKHongKongTheme.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BPKHongKongThemeContainer ()
-
-@end
-
 @implementation BPKHongKongThemeContainer
+
+- (id<BPKThemeDefinition>)themeDefinition {
+    return [BPKHongKongTheme new];
+}
 
 @end
 

--- a/Backpack/Theme/Classes/BPKLondonThemeContainer.h
+++ b/Backpack/Theme/Classes/BPKLondonThemeContainer.h
@@ -16,16 +16,17 @@
  * limitations under the License.
  */
 
+#import "BPKThemeContainer.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * `BPKLondonThemeContainer` is a subclass of `UIView` which allows the BPKLondon theme to be applied to all its
- * children.
+ * `BPKLondonThemeContainer` is a subclass of `BPKThemeContainer` which allows the BPKLondon theme to be applied to all
+ * its children.
  */
-NS_SWIFT_NAME(LondonThemeContainer) @interface BPKLondonThemeContainer : UIView
+NS_SWIFT_NAME(LondonThemeContainer) @interface BPKLondonThemeContainer : BPKThemeContainer
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKLondonThemeContainer.m
+++ b/Backpack/Theme/Classes/BPKLondonThemeContainer.m
@@ -17,15 +17,15 @@
  */
 
 #import "BPKLondonThemeContainer.h"
-#import <Backpack/Common.h>
+#import "BPKLondonTheme.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BPKLondonThemeContainer ()
-
-@end
-
 @implementation BPKLondonThemeContainer
+
+- (id<BPKThemeDefinition>)themeDefinition {
+    return [BPKLondonTheme new];
+}
 
 @end
 

--- a/Backpack/Theme/Classes/BPKTheme.h
+++ b/Backpack/Theme/Classes/BPKTheme.h
@@ -31,6 +31,13 @@ NS_SWIFT_NAME(Theme) @interface BPKTheme : NSObject
 @property(class, nonatomic, assign, readonly) NSString *didChangeNotification;
 
 /**
+ * Returns the themed primary color for a given `UIView`.
+ *
+ * @return the themed `UIColor` value.
+ */
++ (UIColor *)primaryColorFor:(UIView *)view;
+
+/**
  * Creates and returns an instance of the container view for the receiver's theme.
  *
  * @return An instance of the container to use with this theme.

--- a/Backpack/Theme/Classes/BPKTheme.m
+++ b/Backpack/Theme/Classes/BPKTheme.m
@@ -18,8 +18,11 @@
 
 #import "BPKTheme.h"
 #import "BPKDohaThemeContainer.h"
-#import "BPKThemeDefinition.h"
+#import "BPKThemeContainer.h"
+#import "BPKThemeContainerController.h"
+#import "UIView+BPKThemeContainer.h"
 
+#import <Backpack/Color.h>
 #import <Backpack/Spinner.h>
 #import <Backpack/Switch.h>
 
@@ -28,6 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *BPKThemeDidChangeNotification = @"BPKThemeDidChangeNotification";
 
 @implementation BPKTheme
+
++ (UIColor *)primaryColorFor:(UIView *)view {
+    BPKThemeContainer *themeContainer = view.themeContainer;
+    if (themeContainer != nil) {
+        return themeContainer.themeDefinition.primaryColor;
+    }
+
+    return BPKColor.blue500;
+}
 
 + (NSString *)didChangeNotification {
     return BPKThemeDidChangeNotification;

--- a/Backpack/Theme/Classes/BPKThemeContainer.h
+++ b/Backpack/Theme/Classes/BPKThemeContainer.h
@@ -16,17 +16,23 @@
  * limitations under the License.
  */
 
-#import "BPKThemeContainer.h"
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * `BPKDefaultThemeContainer` is a subclass of `BPKThemeContainer` which allows the BPKDefault theme to be applied to
- * all its children.
+ * An abstract base class to define a theme that can be applied to a
+ * view hierarchy containing Backpack components. This should be subclassed
+ * to create concrete themes.
  */
-NS_SWIFT_NAME(DefaultThemeContainer) @interface BPKDefaultThemeContainer : BPKThemeContainer
+@protocol BPKThemeDefinition;
+NS_SWIFT_NAME(ThemeContainer) @interface BPKThemeContainer : UIView {
+  @protected
+    id<BPKThemeDefinition> _themeDefinition;
+}
+
+@property(strong, readonly) id<BPKThemeDefinition> themeDefinition;
 
 @end
+
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKThemeContainer.m
+++ b/Backpack/Theme/Classes/BPKThemeContainer.m
@@ -17,16 +17,10 @@
  */
 
 #import "BPKThemeContainer.h"
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * `BPKDefaultThemeContainer` is a subclass of `BPKThemeContainer` which allows the BPKDefault theme to be applied to
- * all its children.
- */
-NS_SWIFT_NAME(DefaultThemeContainer) @interface BPKDefaultThemeContainer : BPKThemeContainer
-
+@implementation BPKThemeContainer
 @end
+
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/UIView+BPKThemeContainer.h
+++ b/Backpack/Theme/Classes/UIView+BPKThemeContainer.h
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2019 Skyscanner Ltd
+ * Copyright 2019 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,18 @@
  * limitations under the License.
  */
 
-#import "BPKThemeContainer.h"
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class BPKThemeContainer;
+@interface UIView (BPKThemeContainer)
+
 /**
- * `BPKDefaultThemeContainer` is a subclass of `BPKThemeContainer` which allows the BPKDefault theme to be applied to
- * all its children.
+ * The nearest ancestor in the view hierachy that is a `BPKThemeContainer`. If
+ * no ancestor is a `BPKThemeController`, this will return `nil`.
  */
-NS_SWIFT_NAME(DefaultThemeContainer) @interface BPKDefaultThemeContainer : BPKThemeContainer
+@property(nonatomic, nullable, readonly) BPKThemeContainer *themeContainer;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/UIView+BPKThemeContainer.m
+++ b/Backpack/Theme/Classes/UIView+BPKThemeContainer.m
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2019 Skyscanner Ltd
+ * Copyright 2019 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,27 @@
  * limitations under the License.
  */
 
+#import "UIView+BPKThemeContainer.h"
+
 #import "BPKThemeContainer.h"
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
+@implementation UIView (BPKThemeContainer)
 
-/**
- * `BPKDefaultThemeContainer` is a subclass of `BPKThemeContainer` which allows the BPKDefault theme to be applied to
- * all its children.
- */
-NS_SWIFT_NAME(DefaultThemeContainer) @interface BPKDefaultThemeContainer : BPKThemeContainer
+- (nullable BPKThemeContainer *)themeContainer {
+    UIView *parent = self;
+
+    while (parent != nil) {
+        if ([parent isKindOfClass:[BPKThemeContainer class]]) {
+            return (BPKThemeContainer *)parent;
+        }
+
+        parent = parent.superview;
+    }
+
+    return nil;
+}
 
 @end
+
 NS_ASSUME_NONNULL_END

--- a/Example/Backpack/Views/BPKTableViewSelectableCell.swift
+++ b/Example/Backpack/Views/BPKTableViewSelectableCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import Backpack.Spacing
 import Backpack.Icon
+import Backpack.Theme
 
 class BPKTableViewSelectableCell: UITableViewCell {
     let tickIcon: IconView = IconView(iconName: IconName.tick, size: BPKIconSize.small)
@@ -30,7 +31,6 @@ class BPKTableViewSelectableCell: UITableViewCell {
     }
 
     func setup() {
-        tickIcon.tintColor = Color.blue500
         contentView.addSubview(tickIcon)
         tickIcon.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -38,6 +38,10 @@ class BPKTableViewSelectableCell: UITableViewCell {
             tickIcon.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -BPKSpacingBase)
         ])
         tickIcon.isHidden = true
+    }
+
+    override func didMoveToWindow() {
+        tickIcon.tintColor = Theme.primaryColor(for: self)
     }
 
     func setApplied(applied: Bool) {


### PR DESCRIPTION
Food for thought:
 - We can traverse the view hierarchy of a given view to find out what theme is the most appropriate.
 - What should consumers do to ensure that changes to the view hierarchy result in the correct change to the primary color? Relying on `didChangeTheme` to trigger re-pulling the `primaryColor` will not be 100% reliable. Instead can they just respond to all view hierarchy changes?

 - Logic would probably be simpler if we attached themeDefinition to each ThemeContainerView. Then we could simply traverse the hierarchy to find an instance of BPKThemeContainer instead of needing to work out which ViewController is active.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
