### PR TITLE
[BPK-2270] Update default theme container

### DIFF
--- a/Backpack/Theme/Classes/BPKDefaultThemeContainer.h
+++ b/Backpack/Theme/Classes/BPKDefaultThemeContainer.h
@@ -15,11 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
-@interface BPKDefaultThemeContainer : UIView
+
+/**
+ * `BPKDefaultThemeContainer` is a subclass of `UIView` which allows the BPKDoha theme to be applied to all its
+ * children.
+ */
+NS_SWIFT_NAME(DefaultThemeContainer) @interface BPKDefaultThemeContainer : UIView
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKDefaultThemeContainer.m
+++ b/Backpack/Theme/Classes/BPKDefaultThemeContainer.m
@@ -15,11 +15,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #import "BPKDefaultThemeContainer.h"
+#import <Backpack/Common.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface BPKDefaultThemeContainer ()
+
+@end
+
 @implementation BPKDefaultThemeContainer
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        BPKAssertMainThread();
+    }
+    return self;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (self) {
+        BPKAssertMainThread();
+    }
+    return self;
+}
+
+- (void)addSubview:(UIView *)view {
+    [super addSubview:view];
+    BPKAssertMainThread();
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
For some reason the default theme container was missing stuff that we've previously added to all the other theme containers (init overrides etc). This brings it in line with the existing ones.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
