### PR TITLE
[NO-JIRA] Enforce swiftlint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,11 @@ def repeat_on_fail(command, run_count = 1)
   end
 end
 
+
+def swiftlint()
+  `swiftlint autocorrect`
+end
+
 def install_pods_in_example_project()
   `(cd Example && bundle exec pod install)`
   $?.exitstatus == 0
@@ -93,6 +98,9 @@ task :test do
 end
 
 task :lint do
+  abort red 'git status should be clean before linting.' unless check_pristine
+  swiftlint
+  abort red 'Swiftlint changed files.' unless check_pristine
   sh "bundle exec pod lib lint"
 end
 


### PR DESCRIPTION
Runs swiftlint in CI and ensures that files already comply.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
