### PR TITLE
[BPK-2320] Forward selectors in Theme Container

### DIFF
--- a/Backpack/Theme/Classes/BPKThemeContainerController.m
+++ b/Backpack/Theme/Classes/BPKThemeContainerController.m
@@ -127,13 +127,20 @@ NS_ASSUME_NONNULL_BEGIN
     return themeContainerController;
 }
 
-#pragma mark - Overriden methods
+#pragma mark - UIViewController methods
 
 - (nullable UIViewController *)childViewControllerForStatusBarStyle {
     return self.rootViewController;
 }
 
 - (nullable UIViewController *)childViewControllerForStatusBarHidden {
+    return self.rootViewController;
+}
+
+#pragma mark - NSObject methods
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+    NSAssert(NO, @"Forwarding unrecognized selector, %@, to `rootViewController` in `BPKThemeContainerController`. It is not recommended to rely on this behaviour", NSStringFromSelector(aSelector));
     return self.rootViewController;
 }
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,8 @@
 # Unreleased
 
+**Added:**
+
+- Backpack/Theme:
+  - `BPKThemeContainerController` now returns `self.rootViewController` for `forwardingTargetForSelector:` this improves code that makes assumptions about the specific methods available on `keyWindow.rootViewController` when the previous `rootViewController` is wrapped in a `BPKThemeContainerController`. In debug builds this will cause an assertion error as it is not a behaviour we encourage relying on.
+
+


### PR DESCRIPTION
Some apps make assumptions about the selectors available on
`keyWindow.rootViewController`. `BPKThemeContainerController` now
handles this better in release builds by not crashing and forwarding the
selector. In debug builds this causes an assertion failure.


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)