### PR TITLE
[NO-JIRA] Add accessibility labels to calendar dates

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -475,10 +475,18 @@ NSString *const HeaderDateFormat = @"MMMM";
 
         calendarCell.selectionType = selectionType;
         calendarCell.rowType = rowType;
+        calendarCell.accessibilityLabel = [self formattedDate:date];
     }
 }
 
 #pragma mark - helpers
+
+- (NSString *)formattedDate:(NSDate *)date {
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    dateFormatter.locale = self.locale;
+    dateFormatter.dateStyle = NSDateFormatterLongStyle;
+    return [dateFormatter stringFromDate:date];
+}
 
 - (BOOL)isDateInToday:(NSDate *)date {
     return [self.calendarView.gregorian isDateInToday:date];

--- a/Backpack/Calendar/Classes/BPKCalendarCell.m
+++ b/Backpack/Calendar/Classes/BPKCalendarCell.m
@@ -173,6 +173,10 @@
     }
 }
 
+- (void)setAccessibilityLabel:(NSString *)accessibilityLabel {
+    self.titleLabel.accessibilityLabel = accessibilityLabel;
+}
+
 - (void)setSelectionType:(SelectionType)selectionType {
     if (_selectionType != selectionType) {
         _selectionType = selectionType;

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,7 +2,9 @@
 
 **Added:**
 
+- Backpack/Calendar:
+  - Added accessibility labels to `BPKCalendar` cells to provide month and year context to screen-readers.
+
 - Backpack/Theme:
   - `BPKThemeContainerController` now returns `self.rootViewController` for `forwardingTargetForSelector:` this improves code that makes assumptions about the specific methods available on `keyWindow.rootViewController` when the previous `rootViewController` is wrapped in a `BPKThemeContainerController`. In debug builds this will cause an assertion error as it is not a behaviour we encourage relying on.
-
 


### PR DESCRIPTION
Previously the BPKCalendarCell labels simply read out the number displayed. Now they also provide voiceover with the date and year.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_


### Before:
<img width="811" alt="image" src="https://user-images.githubusercontent.com/30267516/56112143-0fe2f580-5f52-11e9-9689-33a5e340a632.png">

### Now:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/30267516/56112176-27ba7980-5f52-11e9-9dc5-b811fb0ddafd.png">

### With a custom locale that doesn't match the system:
<img width="810" alt="image" src="https://user-images.githubusercontent.com/30267516/56112217-4587de80-5f52-11e9-8e31-492ff6e51bb0.png">
