### PR TITLE
Show primary color in stories

### DIFF
--- a/Example/Backpack/View Controllers/ColorsViewController.swift
+++ b/Example/Backpack/View Controllers/ColorsViewController.swift
@@ -21,7 +21,7 @@ import Backpack
 
 class ColorsViewController: UICollectionViewController {
     fileprivate static var primaryColors = [
-        ("blue500", Backpack.Color.blue500), ("blue700", Backpack.Color.blue700), ("white", Backpack.Color.white)
+        ("primary color", Backpack.Color.blue500), ("blue700", Backpack.Color.blue700), ("white", Backpack.Color.white)
     ]
     fileprivate static var secondaryColors = [
         ("green500", Backpack.Color.green500),
@@ -40,6 +40,10 @@ class ColorsViewController: UICollectionViewController {
 
     fileprivate static let cellIdentifier = "ColorPreviewCollectionViewCell"
     fileprivate static let headerIdentifier = "PreviewCollectionViewHeader"
+
+    override func viewDidAppear(_ animated: Bool) {
+        collectionView?.reloadData()
+    }
 
     override func viewDidLoad() {
         collectionView?.register(
@@ -97,7 +101,11 @@ extension ColorsViewController {
         let (_, sectionColors) = ColorsViewController.allColors[indexPath.section]
         let (name, color) = sectionColors[indexPath.row]
         cell.name = name
-        cell.color = color
+        if name == "primary color" {
+            cell.color = Theme.primaryColor(for: collectionView)
+        } else {
+            cell.color = color
+        }
 
         return cell
     }


### PR DESCRIPTION
Thought it would be good to show off the primary colour on the colours screen, especially now that we're going to support partner theming of all the grays as well - gives us a single place to see them all together...

![Screenshot 2019-05-16 at 13 14 49](https://user-images.githubusercontent.com/30267516/57853047-a5d1a080-77dc-11e9-83d1-44cb0b5b0866.png)
