### PR TITLE
[NO-JIRA] Enable calendar gray theming

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -57,6 +57,9 @@ NS_SWIFT_NAME(Calendar) @interface BPKCalendar : UIView
 
 @property(nonatomic, strong) UIColor *dateSelectedContentColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *dateSelectedBackgroundColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *gray100Color UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *gray500Color UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong) UIColor *gray900Color UI_APPEARANCE_SELECTOR;
 
 /**
  * Create a calendar with given minimum date and maximum date.

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -131,13 +131,13 @@ NSString *const HeaderDateFormat = @"MMMM";
 
     BPKCalendarAppearance *appearance = [BPKCalendarAppearance fromFSCalendarAppearance:self.calendarView.appearance];
     appearance.headerDateFormat = HeaderDateFormat;
-    appearance.headerTitleColor = [BPKColor gray900];
+    appearance.headerTitleColor = self.gray900Color;
     appearance.separators = FSCalendarSeparatorNone;
     appearance.weekdayFont = weekdayTextAttributes[NSFontAttributeName];
-    appearance.weekdayTextColor = [BPKColor gray500];
-    appearance.todayColor = [BPKColor gray100];
-    appearance.titleTodayColor = [BPKColor gray900];
-    appearance.titleDefaultColor = [BPKColor gray900];
+    appearance.weekdayTextColor = self.gray500Color;
+    appearance.todayColor = self.gray100Color;
+    appearance.titleTodayColor = self.gray900Color;
+    appearance.titleDefaultColor = self.gray900Color;
     appearance.selectionColor = self.dateSelectedBackgroundColor;
     appearance.titleSelectionColor = self.dateSelectedContentColor;
     appearance.headerTitleFontStyle = BPKFontStyleTextLgEmphasized;
@@ -161,7 +161,7 @@ NSString *const HeaderDateFormat = @"MMMM";
     [self addSubview:self.calendarWeekdayView];
 
     self.bottomBorder = [[UIView alloc] initWithFrame:CGRectZero];
-    self.bottomBorder.backgroundColor = [BPKColor gray100];
+    self.bottomBorder.backgroundColor = self.gray100Color;
     [self addSubview:self.bottomBorder];
 
     self.yearPill = [[BPKCalendarYearPill alloc] initWithFrame:CGRectZero];
@@ -293,6 +293,33 @@ NSString *const HeaderDateFormat = @"MMMM";
     if (dateSelectedBackgroundColor != _dateSelectedBackgroundColor) {
         _dateSelectedBackgroundColor = dateSelectedBackgroundColor;
         self.appearance.selectionColor = self.dateSelectedBackgroundColor;
+        [self.calendarView.collectionView reloadData];
+    }
+}
+
+- (void)setGray100Color:(UIColor *)gray100Color {
+    if (gray100Color != _gray100Color) {
+        _gray100Color = gray100Color;
+        self.bottomBorder.backgroundColor = self.gray100Color;
+        self.appearance.todayColor = self.gray100Color;
+        [self.calendarView.collectionView reloadData];
+    }
+}
+
+- (void)setGray500Color:(UIColor *)gray500Color {
+    if (gray500Color != _gray500Color) {
+        _gray500Color = gray500Color;
+        self.appearance.weekdayTextColor = self.gray500Color;
+        [self.calendarView.collectionView reloadData];
+    }
+}
+
+- (void)setGray900Color:(UIColor *)gray900Color {
+    if (gray900Color != _gray900Color) {
+        _gray900Color = gray900Color;
+        self.appearance.headerTitleColor = self.gray900Color;
+        self.appearance.titleTodayColor = self.gray900Color;
+        self.appearance.titleDefaultColor = self.gray900Color;
         [self.calendarView.collectionView reloadData];
     }
 }

--- a/Backpack/Theme/Classes/BPKTheme.m
+++ b/Backpack/Theme/Classes/BPKTheme.m
@@ -159,6 +159,9 @@ typedef NS_ENUM(NSInteger, BPKGrayColor) {
     BPKCalendar *calendarAppearance = [BPKCalendar appearanceWhenContainedInInstancesOfClasses:@[class]];
     calendarAppearance.dateSelectedContentColor = theme.calendarDateSelectedContentColor;
     calendarAppearance.dateSelectedBackgroundColor = theme.calendarDateSelectedBackgroundColor;
+    calendarAppearance.gray100Color = theme.gray100;
+    calendarAppearance.gray500Color = theme.gray500;
+    calendarAppearance.gray900Color = theme.gray900;
 
     BPKPrimaryGradientView *primaryGradientViewAppearance =
         [BPKPrimaryGradientView appearanceWhenContainedInInstancesOfClasses:@[class]];


### PR DESCRIPTION
+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Screenshot with an outrageous set of grays applied:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/30267516/58228313-38ff5e80-7d26-11e9-839d-8b16dfc1d0f5.png">
