### PR TITLE
[NO-JIRA] linkContentColor setter on BPKButton should update content color

### DIFF
--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -714,7 +714,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setLinkContentColor:(UIColor *_Nullable)linkContentColor {
     if (linkContentColor != _linkContentColor) {
         _linkContentColor = linkContentColor;
-        [self updateBackgroundAndStyle];
+        [self updateContentColor];
     }
 }
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+
+- Backpack/Button:
+  - Fixed issue where content color of `BPKButton` didn't change after changing its linkContentColor
 
 ## How to write a good changelog entry
 


### PR DESCRIPTION
The linkContentColor property on BPKButton is determining tint color for link style buttons, however the setter of this property was calling an update on background and style which are not affected by this property. As a result, the button's content color didn't change until an interaction happened on it. This fix is replacing that call with an update on content color, so when linkContentColor is changed then the visible content color is changing as well. 

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
