### PR TITLE
[BPK-2829] Fix button pressed state

### DIFF
--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -574,7 +574,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setFilledStyleWithNormalBackgroundColorGradientOnTop:(UIColor *)normalColorOnTop
                                             gradientOnBottom:(UIColor *)normalColorOnBottom {
     if (self.isHighlighted) {
-        self.gradientLayer.gradient = [self gradientWithSingleColor:normalColorOnBottom];
+        self.gradientLayer.gradient = [self gradientWithSingleColor:[BPKColor blend:normalColorOnTop
+                                                                               with:BPKColor.gray900
+                                                                             weight:0.85f]];
     } else {
         self.gradientLayer.gradient = [self gradientWithTopColor:normalColorOnTop bottomColor:normalColorOnBottom];
     }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,10 @@
 # Unreleased
 > Place your changes below this line.
+**Fixed:**
+
+- Backpack/Button:
+  - Fixed issue with Button pressed state being too subtle.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
Instead of using the end-gradient colour as the pressed state colour, I am instead taking the start gradient colour and combining it with gray900 to be the pressed-state colour. This means that even with a theme applied where start gradient color == end gradient color, there will be a visual difference when pressed.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

<img width="534" alt="BPK-2829" src="https://user-images.githubusercontent.com/30267516/63284392-5e5f2280-c2ab-11e9-9726-892c33d3f62e.png">
