### PR TITLE
Enable running the app with no theme enabled

### DIFF
--- a/Backpack/Theme/Classes/BPKContainerController.h
+++ b/Backpack/Theme/Classes/BPKContainerController.h
@@ -34,7 +34,7 @@ NS_SWIFT_NAME(ContainerController) @interface BPKContainerController : UIViewCon
  *
  * @param containerClass The class of the container to wrap the view hierarchy in.
  * @param rootViewController The root view controller to be used as a child view controller.
- * @return A configured instance than can further be contained or set to be the `rootViewController` of a `window`.
+ * @return A configured instance that can further be contained or set to be the `rootViewController` of a `window`.
  */
 - (instancetype)initWithContainerClass:(Class)containerClass
                     rootViewController:(UIViewController *)rootViewController NS_DESIGNATED_INITIALIZER;

--- a/Backpack/Theme/Classes/BPKDefaultTheme.h
+++ b/Backpack/Theme/Classes/BPKDefaultTheme.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(DefaultTheme) @interface BPKDefaultTheme : NSObject<BPKThemeDefinition>
 
+extern NSString *const BPKDefaultThemeName;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Theme/Classes/BPKDefaultTheme.m
+++ b/Backpack/Theme/Classes/BPKDefaultTheme.m
@@ -30,8 +30,10 @@
 
 @implementation BPKDefaultTheme
 
+NSString *const BPKDefaultThemeName = @"Default";
+
 - (NSString *)themeName {
-    return @"Default";
+    return BPKDefaultThemeName;
 }
 
 - (BPKFontMapping *)fontMapping {

--- a/Backpack/Theme/Classes/BPKThemeContainerController.h
+++ b/Backpack/Theme/Classes/BPKThemeContainerController.h
@@ -38,7 +38,7 @@ NS_SWIFT_NAME(ThemeContainerController) @interface BPKThemeContainerController :
  *
  * @param themeDefinition The theme that we want to wrap the view hierarchy in.
  * @param rootViewController The root view controller to be used as a child view controller.
- * @return A configured instance than can further be contained or set to be the `rootViewController` of a `window`.
+ * @return A configured instance that can further be contained or set to be the `rootViewController` of a `window`.
  */
 - (instancetype)initWithThemeDefinition:(id<BPKThemeDefinition>)themeDefinition
                      rootViewController:(UIViewController *)rootViewController;

--- a/Example/Backpack.xcodeproj/xcshareddata/xcschemes/Backpack Native no theme.xcscheme
+++ b/Example/Backpack.xcodeproj/xcshareddata/xcschemes/Backpack Native no theme.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6003F589195388D20070C39A"
+               BuildableName = "Backpack Native.app"
+               BlueprintName = "Backpack Native"
+               ReferencedContainer = "container:Backpack.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6003F589195388D20070C39A"
+            BuildableName = "Backpack Native.app"
+            BlueprintName = "Backpack Native"
+            ReferencedContainer = "container:Backpack.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6003F589195388D20070C39A"
+            BuildableName = "Backpack Native.app"
+            BlueprintName = "Backpack Native"
+            ReferencedContainer = "container:Backpack.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "THEMING_ENABLED"
+            value = "NO"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6003F589195388D20070C39A"
+            BuildableName = "Backpack Native.app"
+            BlueprintName = "Backpack Native"
+            ReferencedContainer = "container:Backpack.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Backpack/BPKAppDelegate.m
+++ b/Example/Backpack/BPKAppDelegate.m
@@ -32,16 +32,17 @@
         [UINavigationBar appearance].largeTitleTextAttributes = @{NSForegroundColorAttributeName: BPKColor.gray900};
     }
 
-    [ThemeHelpers applyAllThemes];
+    if ([ThemeHelpers isThemingSupported]) {
+        [ThemeHelpers applyAllThemes];
 
-    id<BPKThemeDefinition> activeTheme = [ThemeHelpers themeDefinitionForTheme:Settings.sharedSettings.activeTheme];
+        id<BPKThemeDefinition> activeTheme = [ThemeHelpers themeDefinitionForTheme:Settings.sharedSettings.activeTheme];
 
-    BPKThemeContainerController *themeContainerController =
-        [[BPKThemeContainerController alloc] initWithThemeDefinition:activeTheme
+        BPKThemeContainerController *themeContainerController =
+            [[BPKThemeContainerController alloc] initWithThemeDefinition:activeTheme
                                                   rootViewController:self.window.rootViewController];
-    self.window.rootViewController = themeContainerController;
-    [self.window makeKeyAndVisible];
-    
+        self.window.rootViewController = themeContainerController;
+        [self.window makeKeyAndVisible];
+    }
 
     return YES;
 }

--- a/Example/Backpack/View Controllers/BPKRootListTableViewController.m
+++ b/Example/Backpack/View Controllers/BPKRootListTableViewController.m
@@ -30,12 +30,14 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    UIImage *largeSettingsIcon = [BPKIcon templateIconNamed:@"settings" size:BPKIconSizeLarge];
-    self.settingsButton.image = largeSettingsIcon;
-    self.settingsButton.accessibilityLabel = @"Settings";
+    if(ThemeHelpers.isThemingSupported) {
+        UIImage *largeSettingsIcon = [BPKIcon templateIconNamed:@"settings" size:BPKIconSizeLarge];
+        self.settingsButton.image = largeSettingsIcon;
+        self.settingsButton.accessibilityLabel = @"Settings";
 
-    self.settingsButton.target = self;
-    self.settingsButton.action = @selector(didTapSettingsButton);
+        self.settingsButton.target = self;
+        self.settingsButton.action = @selector(didTapSettingsButton);
+    }
 }
 
 - (void)didTapSettingsButton {

--- a/Example/Utils/ThemeHelpers.swift
+++ b/Example/Utils/ThemeHelpers.swift
@@ -42,6 +42,11 @@ class ThemeHelpers: NSObject {
     }
 
     @objc
+    class func isThemingSupported() -> Bool {
+        return ProcessInfo.processInfo.environment["THEMING_ENABLED"] != "NO"
+    }
+
+    @objc
     class func themeDefinition(forTheme: ThemeName) -> BPKThemeDefinition {
         switch forTheme {
         case .none:

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,11 @@
 # Unreleased
 > Place your changes below this line.
 
+**Fixed:**
+
+- Backpack/TappableLinkLabel:
+  - Fixed issue that caused links to appear at base size when no theme is applied.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
When the example app starts, it immediately applies a theme (even if that theme is `Default`).
This means we have no way of testing our components when un-themed.

As a result - bugs like this cannot be found:
![Simulator Screen Shot - iPhone 8 - 2019-08-30 at 19 41 20](https://user-images.githubusercontent.com/30267516/64044332-6433ee00-cb5e-11e9-8340-797bcaf12bc5.png)

This change ensures that, if no theme is enabled on app start, no theme wrapper will be applied until theming is enabled.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
