### PR TITLE
Fix tappable link label font style with no theme applied

### DIFF
--- a/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.m
+++ b/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.m
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
     ]];
 
     // This initial call to set up colours is needed in case there is no theme initially applied
-    [self updateTextDisplay];
+    [self updateTextColors];
 }
 
 - (BPKFontStyle)getEmphasizedFontStyleFor:(BPKFontStyle)fontStyle {
@@ -156,6 +156,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.contentView.activeLinkAttributes = [BPKFont attributesForFontStyle:self.linkFontStyle
                                                        withCustomAttributes:activeLinkCustomAttributes
                                                                 fontMapping:self.fontMapping];
+
+    [self updateTextDisplay];
 }
 
 - (void)updateTextDisplay {
@@ -163,8 +165,6 @@ NS_ASSUME_NONNULL_BEGIN
         self.contentView.text = nil;
         return;
     }
-
-    [self updateTextColors];
 
     NSDictionary<NSAttributedStringKey, id> *newStringAttributes =
         [BPKFont attributesForFontStyle:self.fontStyle
@@ -219,7 +219,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (_fontStyle != fontStyle) {
         _fontStyle = fontStyle;
 
-        [self updateTextDisplay];
+        [self updateTextColors];
     }
 }
 
@@ -235,7 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (_linkColor != linkColor) {
         _linkColor = linkColor;
 
-        [self updateTextDisplay];
+        [self updateTextColors];
     }
 }
 
@@ -243,7 +243,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (_style != style) {
         _style = style;
 
-        [self updateTextDisplay];
+        [self updateTextColors];
     }
 }
 

--- a/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.m
+++ b/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.m
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
     ]];
 
     // This initial call to set up colours is needed in case there is no theme initially applied
-    [self updateTextColors];
+    [self updateTextDisplay];
 }
 
 - (BPKFontStyle)getEmphasizedFontStyleFor:(BPKFontStyle)fontStyle {
@@ -156,8 +156,6 @@ NS_ASSUME_NONNULL_BEGIN
     self.contentView.activeLinkAttributes = [BPKFont attributesForFontStyle:self.linkFontStyle
                                                        withCustomAttributes:activeLinkCustomAttributes
                                                                 fontMapping:self.fontMapping];
-
-    [self updateTextDisplay];
 }
 
 - (void)updateTextDisplay {
@@ -165,6 +163,8 @@ NS_ASSUME_NONNULL_BEGIN
         self.contentView.text = nil;
         return;
     }
+
+    [self updateTextColors];
 
     NSDictionary<NSAttributedStringKey, id> *newStringAttributes =
         [BPKFont attributesForFontStyle:self.fontStyle
@@ -235,7 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (_linkColor != linkColor) {
         _linkColor = linkColor;
 
-        [self updateTextColors];
+        [self updateTextDisplay];
     }
 }
 
@@ -243,7 +243,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (_style != style) {
         _style = style;
 
-        [self updateTextColors];
+        [self updateTextDisplay];
     }
 }
 


### PR DESCRIPTION
Based on https://github.com/Skyscanner/backpack-ios/pull/400

![image](https://user-images.githubusercontent.com/30267516/64049852-2048e500-cb6e-11e9-8049-4bcfc64e7115.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
