### PR TITLE
 BPKNavigationBar Animations

### DIFF
--- a/Backpack/NavigationBar/Classes/BPKNavigationBar.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBar.m
@@ -48,6 +48,8 @@ NS_ASSUME_NONNULL_BEGIN
  * The default values is `NO`.
  */
 @property(nonatomic, assign, getter=isCollapsed) BOOL collapsed;
+@property(nonatomic) CGFloat lastScrollOffset;
+@property(nonatomic) CGFloat largeTitleFontSize;
 @end
 
 @implementation BPKNavigationBar
@@ -81,6 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         self.largeTitleView.titleLabel.text = _title;
         self.titleView.titleLabel.text = _title;
+        self.largeTitleFontSize = self.largeTitleView.titleLabel.font.pointSize;
     }
 }
 
@@ -111,8 +114,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateWithScrollView:(UIScrollView *)scrollView {
-    CGFloat adjustedYOffset =
-        (scrollView.adjustedContentInset.top - scrollView.contentInset.top) + scrollView.contentOffset.y;
+    CGFloat adjustedYOffset = (scrollView.adjustedContentInset.top - scrollView.contentInset.top) + scrollView.contentOffset.y;
+    CGFloat scrollOffsetY = fabs(scrollView.contentOffset.y);
+    CGFloat currentFontSize = self.largeTitleView.titleLabel.font.pointSize;
 
     if (adjustedYOffset >= -BPKNavigationBarTitleHeight) {
         // Collapsed state
@@ -143,6 +147,17 @@ NS_ASSUME_NONNULL_BEGIN
 
             self.collapsed = NO;
         }
+
+        if (self.lastScrollOffset < scrollOffsetY
+            && currentFontSize < self.largeTitleFontSize + 4) {
+            self.largeTitleView.titleLabel.font = [self.largeTitleView.titleLabel.font
+                                                   fontWithSize: currentFontSize + .1];
+        } else if (currentFontSize > self.largeTitleFontSize ) {
+            self.largeTitleView.titleLabel.font = [self.largeTitleView.titleLabel.font
+                                                   fontWithSize: currentFontSize - .2];
+        }
+
+        self.lastScrollOffset = scrollOffsetY;
     }
 }
 

--- a/Backpack/NavigationBar/Classes/BPKNavigationBarLargeTitleView.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBarLargeTitleView.m
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!_titleLabel) {
         _titleLabel = [[BPKLabel alloc] initWithFontStyle:BPKFontStyleTextXxxlHeavy];
         _titleLabel.translatesAutoresizingMaskIntoConstraints = false;
+        self.titleLabel.accessibilityTraits = UIAccessibilityTraitHeader;
     }
 
     return _titleLabel;

--- a/Backpack/NavigationBar/Classes/BPKNavigationBarTitleView.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBarTitleView.m
@@ -45,13 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
     if (_showsContent != showsContent) {
         _showsContent = showsContent;
 
-        if (_showsContent) {
-            self.titleLabel.alpha = 1.0;
-            self.backgroundColor = BPKColor.clear;
-        } else {
-            self.titleLabel.alpha = 0.0;
-            self.backgroundColor = BPKColor.white;
-        }
+        [UIView animateWithDuration:.2 animations:^{
+            self.titleLabel.alpha = self.showsContent ? 1.0 : 0.0;
+            self.backgroundColor = self.showsContent ? UIColor.clearColor : UIColor.whiteColor;
+        }];
     }
 }
 
@@ -62,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
         _titleLabel = [[BPKLabel alloc] initWithFontStyle:BPKFontStyleTextBaseEmphasized];
         _titleLabel.textAlignment = NSTextAlignmentCenter;
         _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        self.titleLabel.accessibilityTraits = UIAccessibilityTraitHeader;
     }
 
     return _titleLabel;

--- a/Backpack/NavigationBar/Classes/BPKNavigationBarTitleView.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBarTitleView.m
@@ -19,6 +19,7 @@
 
 #import <Backpack/Color.h>
 #import <Backpack/Common.h>
+#import <Backpack/Color.h>
 #import <Backpack/Label.h>
 
 const CGFloat BPKNavigationBarTitleHeight = 44;
@@ -45,9 +46,9 @@ NS_ASSUME_NONNULL_BEGIN
     if (_showsContent != showsContent) {
         _showsContent = showsContent;
 
-        [UIView animateWithDuration:.2 animations:^{
+        [UIView animateWithDuration:.15 animations:^{
             self.titleLabel.alpha = self.showsContent ? 1.0 : 0.0;
-            self.backgroundColor = self.showsContent ? UIColor.clearColor : UIColor.whiteColor;
+            self.backgroundColor = self.showsContent ? BPKColor.clear : BPKColor.white;
         }];
     }
 }

--- a/Example/Backpack/NavigationBar.storyboard
+++ b/Example/Backpack/NavigationBar.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Mys-Bm-MM1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Mys-Bm-MM1">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="311" width="375" height="44"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2W5-YS-q6h">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2W5-YS-q6h">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>

--- a/Example/Backpack/View Controllers/NavigationBarViewController.swift
+++ b/Example/Backpack/View Controllers/NavigationBarViewController.swift
@@ -29,13 +29,13 @@ class NavigationBarViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.navigationBar.isHidden = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        navigationController?.setNavigationBarHidden(false, animated: false)
+        navigationController?.navigationBar.isHidden = true
     }
 
     override func viewDidLoad() {

--- a/Example/Backpack/View Controllers/NavigationBarViewController.swift
+++ b/Example/Backpack/View Controllers/NavigationBarViewController.swift
@@ -35,7 +35,7 @@ class NavigationBarViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        navigationController?.navigationBar.isHidden = true
+        navigationController?.navigationBar.isHidden = false
     }
 
     override func viewDidLoad() {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -3,8 +3,12 @@
 
 **Fixed:**
 
-- Backpack/TappableLinkLabel:
-  - Fixed issue that caused links to appear at base size when no theme is applied.
+ - Backpack/TappableLinkLabel:
+   - Fixed issue that caused links to appear at base size when no theme is applied.
+
+**Added:**
+ - Backpack/NavigationBar
+   - Some improvements in the `BPKNavigationBar` animations imitating the native behaviour
 
 ## How to write a good changelog entry
 


### PR DESCRIPTION
Some improvements related to the `BPKNavigationBar` component.
Now the `largeTitle` increase/decrease the `fontSize` following the scroll behaviour.

The collapsed title now appears using a fade-in/out animation.
These animations mimic the native navigation behavior.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/10763919/64133306-153fc000-cdcd-11e9-8b00-1b6af22052f4.gif)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_