### PR TITLE
[BPK-2924] Align navigation bar autoscroll behaviour to system

### DIFF
--- a/Backpack/NavigationBar/Classes/BPKNavigationBar.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBar.m
@@ -121,7 +121,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)makeTitleVisibleWithScrollView:(UIScrollView *)scrollView {
     CGFloat adjustedYOffset = [self calculateYOffset:scrollView];
-    CGFloat thresholdPoint = self.baseYOffset + (BPKNavigationBarLargeTitleViewHeight / 2.0);
 
     if (adjustedYOffset <= self.baseYOffset) {
         // There is no need to adjust as the large title is fully in view
@@ -131,15 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    CGFloat adjustmentRequired = 0.0;
-    if (adjustedYOffset < thresholdPoint) {
-        // A small adjustment is needed to bring the large title fully into view
-        adjustmentRequired = adjustedYOffset - self.baseYOffset;
-    } else {
-        // A small adjustment is needed to bring the small title fully into view
-        adjustmentRequired = adjustedYOffset - (self.baseYOffset + BPKNavigationBarLargeTitleViewHeight);
-    }
-
+    CGFloat adjustmentRequired = adjustedYOffset - self.baseYOffset;
     [scrollView
         setContentOffset:CGPointMake(scrollView.contentOffset.x, scrollView.contentOffset.y - adjustmentRequired)
                 animated:YES];

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,10 @@
 # Unreleased
 > Place your changes below this line.
+**Fixed:**
+
+- Backpack/NavigationBar:
+  - Fixed issue that caused a partially obscured title to sometimes bounce to the collapsed state. It now always bounces to the expanded state, as per system behaviour.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
Before:
![2019-09-07 19 44 55](https://user-images.githubusercontent.com/30267516/64478974-4131bb80-d1a8-11e9-993d-64c29d0b4327.gif)

After:
![2019-09-07 19 45 59](https://user-images.githubusercontent.com/30267516/64478976-44c54280-d1a8-11e9-9b73-d29b0e894e94.gif)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
