### PR TITLE
[NO-JIRA] Disable dark mode in example app

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -141,6 +141,7 @@ APLv2
 AVDs
 Autosuggest
 BEM
+DarkMode
 DOM
 Horcrux
 IntersectionObserver

--- a/Backpack/DarkMode/Classes/DarkMode.h
+++ b/Backpack/DarkMode/Classes/DarkMode.h
@@ -16,38 +16,9 @@
  * limitations under the License.
  */
 
-#ifndef __BACKPACK__
-#define __BACKPACK__
+#ifndef __BACKPACK_DARKMODE__
+#define __BACKPACK_DARKMODE__
 
-#import "Color.h"
-#import "Font.h"
-#import "Gradient.h"
-#import "Radii.h"
-#import "Shadow.h"
-#import "Spacing.h"
-
-#import "Badge.h"
-#import "Button.h"
-#import "Calendar.h"
-#import "Card.h"
-#import "Chip.h"
-#import "DarkMode.h"
-#import "Dialog.h"
-#import "FlareView.h"
-#import "HorizontalNavigation.h"
-#import "Icon.h"
-#import "Label.h"
-#import "NavigationBar.h"
-#import "Panel.h"
-#import "ProgressBar.h"
-#import "Rating.h"
-#import "Spinner.h"
-#import "StarRating.h"
-#import "Switch.h"
-#import "TappableLinkLabel.h"
-#import "TextField.h"
-#import "TextView.h"
-#import "Theme.h"
-#import "Toast.h"
+#define __BPK_DARK_MODE_SUPPORTED __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 
 #endif

--- a/Backpack/DarkMode/README.md
+++ b/Backpack/DarkMode/README.md
@@ -1,0 +1,32 @@
+# Backpack/DarkMode
+
+## Usage
+
+`Backpack/DarkMode`/`Backpack.DarkMode` contains utilities that help when developing applications which support dark mode.
+
+`__DARK_MODE_SUPPORTED` is a macro which determines if dark-mode specific compiler features are available. For example, `UIViewController` `overrideUserInterfaceStyle` property, which is only available in XCode 11.
+
+### Objective-C
+
+**`__DARK_MODE_SUPPORTED`**
+
+```objective-c
+#import <Backpack/DarkMode.h>
+
+#if __BPK_DARK_MODE_SUPPORTED
+  self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+#endif
+```
+
+### Swift
+
+**`__DARK_MODE_SUPPORTED`**
+
+```swift
+import Backpack.DarkMode
+
+#if __BPK_DARK_MODE_SUPPORTED
+  overrideUserInterfaceStyle = .light
+#endif
+```
+

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		D216C21122E974A700045A9E /* BPKHorizontalNavigationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D216C20F22E974A300045A9E /* BPKHorizontalNavigationTest.m */; };
 		D216C21322E974B100045A9E /* HorizontalNavigationUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D216C21222E974B100045A9E /* HorizontalNavigationUITest.swift */; };
 		D219C1E02163918B00C9968D /* DividedCardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D219C1DF2163918B00C9968D /* DividedCardsViewController.swift */; };
+		D21D645D2333A90A00BCA3EC /* BPKDarkModeTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D21D645C2333A90A00BCA3EC /* BPKDarkModeTableViewController.m */; };
 		D21FA97A22EA370500FD866D /* BPKProgressBarSnapshotTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D21FA97822EA370100FD866D /* BPKProgressBarSnapshotTest.m */; };
 		D225BBE2216218FF00FC8B17 /* CardsSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D225BBE1216218FF00FC8B17 /* CardsSelectorViewController.swift */; };
 		D2297C2A232A7F3F006E00E0 /* RatingSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2297C28232A7F3F006E00E0 /* RatingSelectorViewController.swift */; };
@@ -246,6 +247,8 @@
 		D216C20F22E974A300045A9E /* BPKHorizontalNavigationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKHorizontalNavigationTest.m; sourceTree = "<group>"; };
 		D216C21222E974B100045A9E /* HorizontalNavigationUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalNavigationUITest.swift; sourceTree = "<group>"; };
 		D219C1DF2163918B00C9968D /* DividedCardsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividedCardsViewController.swift; sourceTree = "<group>"; };
+		D21D645B2333A90A00BCA3EC /* BPKDarkModeTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPKDarkModeTableViewController.h; sourceTree = "<group>"; };
+		D21D645C2333A90A00BCA3EC /* BPKDarkModeTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKDarkModeTableViewController.m; sourceTree = "<group>"; };
 		D21FA97822EA370100FD866D /* BPKProgressBarSnapshotTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKProgressBarSnapshotTest.m; sourceTree = "<group>"; };
 		D225BBE1216218FF00FC8B17 /* CardsSelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsSelectorViewController.swift; sourceTree = "<group>"; };
 		D2297C28232A7F3F006E00E0 /* RatingSelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RatingSelectorViewController.swift; sourceTree = "<group>"; };
@@ -615,6 +618,8 @@
 		D655C515200F9B9200CB39AF /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				D21D645B2333A90A00BCA3EC /* BPKDarkModeTableViewController.h */,
+				D21D645C2333A90A00BCA3EC /* BPKDarkModeTableViewController.m */,
 				D2297C28232A7F3F006E00E0 /* RatingSelectorViewController.swift */,
 				D2297C29232A7F3F006E00E0 /* RatingsViewController.swift */,
 				D279B4BB23295116000F5898 /* ChipSelectorViewController.swift */,
@@ -1032,6 +1037,7 @@
 				E397BEA422F5FCE500C8EC04 /* BottomSheetBottomSectionVIewController.swift in Sources */,
 				D2297C2A232A7F3F006E00E0 /* RatingSelectorViewController.swift in Sources */,
 				E38947D422F5F0E900A357DB /* BottomSheetViewController.swift in Sources */,
+				D21D645D2333A90A00BCA3EC /* BPKDarkModeTableViewController.m in Sources */,
 				D2B8A01B2147FF6A002290DE /* PreviewCollectionViewHeader.swift in Sources */,
 				D27E88402199A5D000C962BF /* ChipPreviewCollectionViewCell.swift in Sources */,
 				D28443EB22FC42A30066F88B /* FlareViewViewController.swift in Sources */,

--- a/Example/Backpack.xcodeproj/xcshareddata/xcschemes/Backpack Native w dark mode.xcscheme
+++ b/Example/Backpack.xcodeproj/xcshareddata/xcschemes/Backpack Native w dark mode.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6003F589195388D20070C39A"
+               BuildableName = "Backpack Native.app"
+               BlueprintName = "Backpack Native"
+               ReferencedContainer = "container:Backpack.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6003F589195388D20070C39A"
+            BuildableName = "Backpack Native.app"
+            BlueprintName = "Backpack Native"
+            ReferencedContainer = "container:Backpack.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DARK_MODE_ENABLED"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6003F589195388D20070C39A"
+            BuildableName = "Backpack Native.app"
+            BlueprintName = "Backpack Native"
+            ReferencedContainer = "container:Backpack.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Backpack/Backpack Native-Bridging-Header.h
+++ b/Example/Backpack/Backpack Native-Bridging-Header.h
@@ -2,3 +2,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 #import "BPKThemeContainerController.h"
+#import "BPKDarkModeTableViewController.h"

--- a/Example/Backpack/StarRatings.storyboard
+++ b/Example/Backpack/StarRatings.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SnM-BG-eES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SnM-BG-eES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -107,7 +105,7 @@
         <!--Star Ratings-->
         <scene sceneID="LWM-vm-v7y">
             <objects>
-                <tableViewController title="Star Ratings" id="SnM-BG-eES" sceneMemberID="viewController">
+                <tableViewController title="Star Ratings" id="SnM-BG-eES" customClass="BPKDarkModeTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="yRa-Zx-M8f">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Example/Backpack/View Controllers/BPKButtonSelectorViewController.h
+++ b/Example/Backpack/View Controllers/BPKButtonSelectorViewController.h
@@ -18,9 +18,11 @@
 
 #import <UIKit/UIKit.h>
 
+#import "BPKDarkModeTableViewController.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BPKButtonSelectorViewController : UITableViewController
+@interface BPKButtonSelectorViewController : BPKDarkModeTableViewController
 
 @end
 

--- a/Example/Backpack/View Controllers/BPKDarkModeTableViewController.h
+++ b/Example/Backpack/View Controllers/BPKDarkModeTableViewController.h
@@ -16,38 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef __BACKPACK__
-#define __BACKPACK__
+#import <UIKit/UIKit.h>
 
-#import "Color.h"
-#import "Font.h"
-#import "Gradient.h"
-#import "Radii.h"
-#import "Shadow.h"
-#import "Spacing.h"
+NS_SWIFT_NAME(DarkModeTableViewController) @interface BPKDarkModeTableViewController : UITableViewController
 
-#import "Badge.h"
-#import "Button.h"
-#import "Calendar.h"
-#import "Card.h"
-#import "Chip.h"
-#import "DarkMode.h"
-#import "Dialog.h"
-#import "FlareView.h"
-#import "HorizontalNavigation.h"
-#import "Icon.h"
-#import "Label.h"
-#import "NavigationBar.h"
-#import "Panel.h"
-#import "ProgressBar.h"
-#import "Rating.h"
-#import "Spinner.h"
-#import "StarRating.h"
-#import "Switch.h"
-#import "TappableLinkLabel.h"
-#import "TextField.h"
-#import "TextView.h"
-#import "Theme.h"
-#import "Toast.h"
-
-#endif
+@end

--- a/Example/Backpack/View Controllers/BPKDarkModeTableViewController.m
+++ b/Example/Backpack/View Controllers/BPKDarkModeTableViewController.m
@@ -16,38 +16,24 @@
  * limitations under the License.
  */
 
-#ifndef __BACKPACK__
-#define __BACKPACK__
+#import "BPKRootListTableViewController.h"
 
-#import "Color.h"
-#import "Font.h"
-#import "Gradient.h"
-#import "Radii.h"
-#import "Shadow.h"
-#import "Spacing.h"
+#import <Backpack/DarkMode.h>
 
-#import "Badge.h"
-#import "Button.h"
-#import "Calendar.h"
-#import "Card.h"
-#import "Chip.h"
-#import "DarkMode.h"
-#import "Dialog.h"
-#import "FlareView.h"
-#import "HorizontalNavigation.h"
-#import "Icon.h"
-#import "Label.h"
-#import "NavigationBar.h"
-#import "Panel.h"
-#import "ProgressBar.h"
-#import "Rating.h"
-#import "Spinner.h"
-#import "StarRating.h"
-#import "Switch.h"
-#import "TappableLinkLabel.h"
-#import "TextField.h"
-#import "TextView.h"
-#import "Theme.h"
-#import "Toast.h"
+#import "Backpack_Native-Swift.h"
 
+@implementation BPKDarkModeTableViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+#if __BPK_DARK_MODE_SUPPORTED
+    if (!ThemeHelpers.isDarkModeSupported) {
+        if (@available(iOS 13.0, *)) {
+            self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+        }
+    }
 #endif
+}
+
+@end

--- a/Example/Backpack/View Controllers/BPKRootListTableViewController.h
+++ b/Example/Backpack/View Controllers/BPKRootListTableViewController.h
@@ -18,6 +18,8 @@
 
 #import <UIKit/UIKit.h>
 
-@interface BPKRootListTableViewController : UITableViewController
+#import "BPKDarkModeTableViewController.h"
+
+@interface BPKRootListTableViewController : BPKDarkModeTableViewController
 
 @end

--- a/Example/Backpack/View Controllers/BPKRootListTableViewController.m
+++ b/Example/Backpack/View Controllers/BPKRootListTableViewController.m
@@ -17,6 +17,7 @@
  */
 
 #import "BPKRootListTableViewController.h"
+
 #import "Backpack_Native-Swift.h"
 #import <Backpack/Color.h>
 #import <Backpack/Icon.h>
@@ -30,7 +31,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    if(ThemeHelpers.isThemingSupported) {
+    if (ThemeHelpers.isThemingSupported) {
         UIImage *largeSettingsIcon = [BPKIcon templateIconNamed:@"settings" size:BPKIconSizeLarge];
         self.settingsButton.image = largeSettingsIcon;
         self.settingsButton.accessibilityLabel = @"Settings";

--- a/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetContentViewController.swift
+++ b/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetContentViewController.swift
@@ -19,7 +19,7 @@
 
 import Backpack
 
-final class BottomSheetContentViewController: UITableViewController {
+final class BottomSheetContentViewController: DarkModeTableViewController {
 
 }
 

--- a/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetViewController.swift
+++ b/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetViewController.swift
@@ -19,7 +19,7 @@
 
 import Backpack
 
-final class BottomSheetViewController: UITableViewController {
+final class BottomSheetViewController: DarkModeTableViewController {
 
     @IBOutlet weak var scrollViewBottomSheet: UITableViewCell!
     @IBOutlet weak var bottomSectionBottomSheet: UITableViewCell!

--- a/Example/Backpack/View Controllers/CardsSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/CardsSelectorViewController.swift
@@ -19,7 +19,7 @@
 import Backpack.Card
 import Backpack.Color
 
-class CardsSelectorViewController: UITableViewController {
+class CardsSelectorViewController: DarkModeTableViewController {
     func prepareDevided(for segue: UIStoryboardSegue, sender: Any?) {
         guard let target = segue.destination as? DividedCardsViewController else {
             fatalError("Expected destination to be of type DividedCardsViewController.")

--- a/Example/Backpack/View Controllers/ChipSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/ChipSelectorViewController.swift
@@ -27,7 +27,7 @@ enum ChipSegueIdentifier: String {
     case backgroundColorUnselectedNoShadow = "BackgroundColorUnselectedNoShadow"
 }
 
-class ChipSelectorViewController: UITableViewController {
+class ChipSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let target = segue.destination as? ChipsViewController else {
             fatalError("Expected destination to be of type ChipViewController.")

--- a/Example/Backpack/View Controllers/DialogSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/DialogSelectorViewController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-class DialogSelectorViewController: UITableViewController {
+class DialogSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let destinationController = segue.destination as? DialogViewController  else {
             fatalError("""

--- a/Example/Backpack/View Controllers/FlareViewSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/FlareViewSelectorViewController.swift
@@ -25,7 +25,7 @@ enum FlareViewSegueIdentifier: String {
     case backgroundImage = "BackgroundImage"
 }
 
-class FlareViewSelectorViewController: UITableViewController {
+class FlareViewSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let target = segue.destination as? FlareViewViewController else {
             fatalError("Expected destination to be of type FlareViewViewController.")

--- a/Example/Backpack/View Controllers/GradientSelectorTableViewController.swift
+++ b/Example/Backpack/View Controllers/GradientSelectorTableViewController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-class GradientSelectorTableViewController: UITableViewController {
+class GradientSelectorTableViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let destination = segue.destination as? GradientViewController {
             switch segue.identifier {

--- a/Example/Backpack/View Controllers/HorizontalNavSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/HorizontalNavSelectorViewController.swift
@@ -28,7 +28,7 @@ enum HorizontalNavSegueIdentifier: String {
     case wide = "Wide"
 }
 
-class HorizontalNavSelectorViewController: UITableViewController {
+class HorizontalNavSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let maybeHorizontalNavController = segue.destination as? HorizontalNavViewController
 

--- a/Example/Backpack/View Controllers/LabelsSelectorTableViewController.swift
+++ b/Example/Backpack/View Controllers/LabelsSelectorTableViewController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-class LabelsSelectorTableViewController: UITableViewController {
+class LabelsSelectorTableViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let maybeLabelsController = segue.destination as? LabelsViewController
 

--- a/Example/Backpack/View Controllers/PanelSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/PanelSelectorViewController.swift
@@ -25,7 +25,7 @@ enum PanelSegueIdentifier: String {
     case elevated = "Elevated"
 }
 
-class PanelSelectorViewController: UITableViewController {
+class PanelSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let target = segue.destination as? PanelViewController else {
             fatalError("Expected destination to be of type PanelViewController.")

--- a/Example/Backpack/View Controllers/RatingSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/RatingSelectorViewController.swift
@@ -25,7 +25,7 @@ enum RatingSegueIdentifier: String {
     case sizes = "Sizes"
 }
 
-class RatingSelectorViewController: UITableViewController {
+class RatingSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let target = segue.destination as? RatingsViewController else {
             fatalError("Expected destination to be of type RatingViewController.")

--- a/Example/Backpack/View Controllers/SettingsViewController.swift
+++ b/Example/Backpack/View Controllers/SettingsViewController.swift
@@ -19,7 +19,7 @@
 import UIKit
 import Backpack
 
-class SettingsViewController: UITableViewController {
+class SettingsViewController: DarkModeTableViewController {
     @IBOutlet weak var closeButton: UIBarButtonItem!
     @IBOutlet weak var enableThemeSwitch: Switch!
     var showThemeList: Bool = false

--- a/Example/Backpack/View Controllers/TappableLinkLabelsSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/TappableLinkLabelsSelectorViewController.swift
@@ -26,7 +26,7 @@ enum TappableLinkLabelsSegueIdentifier: String {
     case nonURLLinks = "NonURLLinks"
 }
 
-class TappableLinkLabelsSelectorViewController: UITableViewController {
+class TappableLinkLabelsSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let maybeTappableLinkLabelsController = segue.destination as? TappableLinkLabelsViewController
 

--- a/Example/Backpack/View Controllers/ToastSelectorViewController.swift
+++ b/Example/Backpack/View Controllers/ToastSelectorViewController.swift
@@ -19,7 +19,7 @@
 
 import UIKit
 
-class ToastSelectorViewController: UITableViewController {
+class ToastSelectorViewController: DarkModeTableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let destinationController = segue.destination as? ToastViewController else {
             fatalError("""

--- a/Example/Utils/ThemeHelpers.swift
+++ b/Example/Utils/ThemeHelpers.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import Backpack.DarkMode
 import Backpack.Theme
 
 class ThemeHelpers: NSObject {
@@ -44,6 +45,14 @@ class ThemeHelpers: NSObject {
     @objc
     class func isThemingSupported() -> Bool {
         return ProcessInfo.processInfo.environment["THEMING_ENABLED"] != "NO"
+    }
+
+    @objc
+    class func isDarkModeSupported() -> Bool {
+#if __BPK_DARK_MODE_SUPPORTED
+        return ProcessInfo.processInfo.environment["DARK_MODE_ENABLED"] == "YES"
+#endif
+        return false
     }
 
     @objc


### PR DESCRIPTION
By default, I have disabled dark mode on all VC's, but it can be enabled with the new Schema `Backpack Native w dark mode`

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
