### PR TITLE
BPKLabel size tests

### DIFF
--- a/Example/Tests/BPKLabelTest.m
+++ b/Example/Tests/BPKLabelTest.m
@@ -18,6 +18,7 @@
 #import <Backpack/Color.h>
 #import <Backpack/Label.h>
 #import <XCTest/XCTest.h>
+#import <Backpack/Theme.h>
 
 @interface BPKLabelTest : XCTestCase
 
@@ -124,6 +125,45 @@ NS_ASSUME_NONNULL_BEGIN
                                                                 fontMapping:fontMapping]);
     XCTAssertEqualObjects(range3Attributes, [BPKFont attributesForFontStyle:BPKFontStyleTextXxlHeavy
                                                                 fontMapping:fontMapping]);
+}
+
+- (void)testCompareBackpackLabelSizeWithNativeLabel {
+    UILabel *nativeLabel = [[UILabel alloc] init];
+    nativeLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    nativeLabel.numberOfLines = 0;
+    nativeLabel.textAlignment = NSTextAlignmentCenter;
+    BPKLondonTheme *londonTheme = [[BPKLondonTheme alloc] init];
+    nativeLabel.attributedText = [BPKFont attributedStringWithFontStyle:BPKFontStyleTextCapsEmphasized content:@"SDIJSOIFSJFO" fontMapping:londonTheme.fontMapping];
+    CGSize nativeLabelSize = [nativeLabel systemLayoutSizeFittingSize:CGSizeMake(12, 120) withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
+
+    BPKLabel *bpkLabel = [[BPKLabel alloc] init];
+    bpkLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    bpkLabel.numberOfLines = 0;
+    bpkLabel.textAlignment = NSTextAlignmentCenter;
+    bpkLabel.attributedText = [BPKFont attributedStringWithFontStyle:BPKFontStyleTextCapsEmphasized content:@"SDIJSOIFSJFO" fontMapping:londonTheme.fontMapping];
+    CGSize bpkLabelSize = [nativeLabel systemLayoutSizeFittingSize:CGSizeMake(12, 120) withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
+
+    XCTAssertEqual(nativeLabelSize.width, bpkLabelSize.width);
+    XCTAssertEqual(nativeLabelSize.height, bpkLabelSize.height);
+}
+
+- (void)testCompareBackpackLabelSizeWithNativeLabelAndFontMappingNil {
+    UILabel *nativeLabel = [[UILabel alloc] init];
+    nativeLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    nativeLabel.numberOfLines = 0;
+    nativeLabel.textAlignment = NSTextAlignmentCenter;
+    nativeLabel.attributedText = [BPKFont attributedStringWithFontStyle:BPKFontStyleTextCapsEmphasized content:@"SDIJSOIFSJFO" fontMapping:nil];
+    CGSize nativeLabelSize = [nativeLabel systemLayoutSizeFittingSize:CGSizeMake(120, 120) withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
+
+    BPKLabel *bpkLabel = [[BPKLabel alloc] init];
+    bpkLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    bpkLabel.numberOfLines = 0;
+    bpkLabel.textAlignment = NSTextAlignmentCenter;
+    bpkLabel.attributedText = [BPKFont attributedStringWithFontStyle:BPKFontStyleTextCapsEmphasized content:@"SDIJSOIFSJFO" fontMapping:nil];
+    CGSize bpkLabelSize = [nativeLabel systemLayoutSizeFittingSize:CGSizeMake(120, 120) withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
+
+    XCTAssertEqual(nativeLabelSize.width, bpkLabelSize.width);
+    XCTAssertEqual(nativeLabelSize.height, bpkLabelSize.height);
 }
 
 @end


### PR DESCRIPTION
+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
