### PR TITLE
[NO-JIRA] Nilify default theme

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -57,8 +57,8 @@ NS_SWIFT_NAME(CalendarDelegate) @protocol BPKCalendarDelegate<NSObject>
 NS_SWIFT_NAME(Calendar) @interface BPKCalendar : UIView
 
 @property(nullable, nonatomic, strong) BPKFontMapping *fontMapping UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *dateSelectedContentColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *dateSelectedBackgroundColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *dateSelectedContentColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *dateSelectedBackgroundColor UI_APPEARANCE_SELECTOR;
 
 /**
  * Create a calendar with given minimum date and maximum date.

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -76,8 +76,6 @@ NSString *const HeaderDateFormat = @"MMMM";
         // `minDate` and `maxDate` is `nonnull` so we need to ensure **it is not** `nil`.
         self.minDate = [[BPKSimpleDate alloc] initWithYear:1970 month:1 day:1];
         self.maxDate = [[BPKSimpleDate alloc] initWithYear:2099 month:12 day:31];
-        _dateSelectedBackgroundColor = BPKColor.skyBlue;
-        _dateSelectedContentColor = BPKColor.white;
         [self setup];
     }
 
@@ -92,8 +90,6 @@ NSString *const HeaderDateFormat = @"MMMM";
         // `minDate` and `maxDate` is `nonnull` so we need to ensure **it is not** `nil`.
         self.minDate = [[BPKSimpleDate alloc] initWithYear:1970 month:1 day:1];
         self.maxDate = [[BPKSimpleDate alloc] initWithYear:2099 month:12 day:31];
-        _dateSelectedBackgroundColor = BPKColor.skyBlue;
-        _dateSelectedContentColor = BPKColor.white;
         [self setup];
     }
 
@@ -107,8 +103,6 @@ NSString *const HeaderDateFormat = @"MMMM";
     if (self) {
         self.minDate = minDate;
         self.maxDate = maxDate;
-        _dateSelectedBackgroundColor = BPKColor.skyBlue;
-        _dateSelectedContentColor = BPKColor.white;
         [self setup];
     }
 
@@ -140,8 +134,8 @@ NSString *const HeaderDateFormat = @"MMMM";
     appearance.todayColor = BPKColor.textTertiaryDarkColor;
     appearance.titleTodayColor = BPKColor.textPrimaryColor;
     appearance.titleDefaultColor = BPKColor.textPrimaryColor;
-    appearance.selectionColor = self.dateSelectedBackgroundColor;
-    appearance.titleSelectionColor = self.dateSelectedContentColor;
+    appearance.selectionColor = self.currentDateSelectedBackgroundColor;
+    appearance.titleSelectionColor = self.currentDateSelectedContentColor;
     appearance.headerTitleFontStyle = BPKFontStyleTextLgEmphasized;
 
     _appearance = appearance;
@@ -292,18 +286,18 @@ NSString *const HeaderDateFormat = @"MMMM";
     return [self.maxDate dateWithLocale:self.locale];
 }
 
-- (void)setDateSelectedBackgroundColor:(UIColor *)dateSelectedBackgroundColor {
+- (void)setDateSelectedBackgroundColor:(UIColor *_Nullable)dateSelectedBackgroundColor {
     if (dateSelectedBackgroundColor != _dateSelectedBackgroundColor) {
         _dateSelectedBackgroundColor = dateSelectedBackgroundColor;
-        self.appearance.selectionColor = self.dateSelectedBackgroundColor;
+        self.appearance.selectionColor = self.currentDateSelectedBackgroundColor;
         [self.calendarView.collectionView reloadData];
     }
 }
 
-- (void)setDateSelectedContentColor:(UIColor *)dateSelectedContentColor {
+- (void)setDateSelectedContentColor:(UIColor *_Nullable)dateSelectedContentColor {
     if (dateSelectedContentColor != _dateSelectedContentColor) {
         _dateSelectedContentColor = dateSelectedContentColor;
-        self.appearance.titleSelectionColor = self.dateSelectedContentColor;
+        self.appearance.titleSelectionColor = self.currentDateSelectedContentColor;
         [self.calendarView.collectionView reloadData];
     }
 }
@@ -569,6 +563,16 @@ NSString *const HeaderDateFormat = @"MMMM";
         return self.calendarView;
     }
     return [super forwardingTargetForSelector:selector];
+}
+
+#pragma mark - Getters
+
+-(UIColor *)currentDateSelectedBackgroundColor {
+    return self.dateSelectedBackgroundColor != nil ? self.dateSelectedBackgroundColor : BPKColor.skyBlue;
+}
+
+-(UIColor *)currentDateSelectedContentColor {
+    return self.dateSelectedContentColor != nil ? self.dateSelectedContentColor : BPKColor.white;
 }
 
 @end

--- a/Backpack/Chip/Classes/BPKChip.h
+++ b/Backpack/Chip/Classes/BPKChip.h
@@ -60,7 +60,7 @@ NS_SWIFT_NAME(Chip) IB_DESIGNABLE @interface BPKChip : UIControl
  *
  * @warning This is not intended to be used directly, it exists to support theming only.
  */
-@property(nonatomic, strong) UIColor *primaryColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *primaryColor UI_APPEARANCE_SELECTOR;
 
 /**
  * Whether the shadow should be shown or not. By default, chips have a shadow.

--- a/Backpack/Chip/Classes/BPKChip.m
+++ b/Backpack/Chip/Classes/BPKChip.m
@@ -40,8 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super initWithFrame:frame];
 
     if (self) {
-        _primaryColor = BPKColor.skyBlue;
-
         [self setUp];
     }
 
@@ -53,8 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super initWithCoder:aDecoder];
 
     if (self) {
-        _primaryColor = BPKColor.skyBlue;
-
         [self setUp];
     }
 
@@ -66,8 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super initWithFrame:CGRectZero];
 
     if (self) {
-        _primaryColor = BPKColor.skyBlue;
-
         [self setUp];
     }
 
@@ -128,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - State setters
 
-- (void)setPrimaryColor:(UIColor *)primaryColor {
+- (void)setPrimaryColor:(UIColor *_Nullable)primaryColor {
     if (_primaryColor != primaryColor) {
         _primaryColor = primaryColor;
         [self updateStyle];
@@ -198,12 +192,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Updates
 
+- (UIColor *)currentPrimaryColor {
+    return self.primaryColor != nil ? self.primaryColor : BPKColor.skyBlue;
+}
+
 - (UIColor *)selectedBackgroundColor {
     if (self.backgroundTint != nil) {
         return self.backgroundTint;
     }
 
-    return self.primaryColor;
+    return self.currentPrimaryColor;
 }
 
 - (UIColor *)unselectedBackgroundColor {

--- a/Backpack/ProgressBar/Classes/BPKProgressBar.h
+++ b/Backpack/ProgressBar/Classes/BPKProgressBar.h
@@ -31,7 +31,7 @@ NS_SWIFT_NAME(ProgressBar) IB_DESIGNABLE @interface BPKProgressBar : UIProgressV
 /**
  * The colour to use in the progress track.
  */
-@property(nonatomic, strong) UIColor *fillColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *fillColor UI_APPEARANCE_SELECTOR;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/ProgressBar/Classes/BPKProgressBar.m
+++ b/Backpack/ProgressBar/Classes/BPKProgressBar.m
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setFillColor:(UIColor *)fillColor {
+- (void)setFillColor:(UIColor *_Nullable)fillColor {
     if (_fillColor != fillColor) {
         _fillColor = fillColor;
 

--- a/Backpack/Rating/Classes/BPKRating.h
+++ b/Backpack/Rating/Classes/BPKRating.h
@@ -87,9 +87,9 @@ NS_SWIFT_NAME(Rating) IB_DESIGNABLE @interface BPKRating : UIView
                               title:(BPKRatingTextDefinition *)title
                            subtitle:(BPKRatingTextDefinition *_Nullable)subtitle NS_DESIGNATED_INITIALIZER;
 
-@property(nonatomic, strong) UIColor *lowRatingColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *mediumRatingColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *highRatingColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *lowRatingColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *mediumRatingColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *highRatingColor UI_APPEARANCE_SELECTOR;
 
 @end
 

--- a/Backpack/Rating/Classes/BPKRating.m
+++ b/Backpack/Rating/Classes/BPKRating.m
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - State setters
 
-- (void)setLowRatingColor:(UIColor *)lowRatingColor {
+- (void)setLowRatingColor:(UIColor *_Nullable)lowRatingColor {
     BPKAssertMainThread();
     if (_lowRatingColor != lowRatingColor) {
         _lowRatingColor = lowRatingColor;
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)setMediumRatingColor:(UIColor *)mediumRatingColor {
+- (void)setMediumRatingColor:(UIColor *_Nullable)mediumRatingColor {
     BPKAssertMainThread();
     if (_mediumRatingColor != mediumRatingColor) {
         _mediumRatingColor = mediumRatingColor;
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)setHighRatingColor:(UIColor *)highRatingColor {
+- (void)setHighRatingColor:(UIColor *_Nullable)highRatingColor {
     BPKAssertMainThread();
     if (_highRatingColor != highRatingColor) {
         _highRatingColor = highRatingColor;

--- a/Backpack/StarRating/Classes/BPKStar.m
+++ b/Backpack/StarRating/Classes/BPKStar.m
@@ -98,8 +98,6 @@ NS_ASSUME_NONNULL_BEGIN
         [self.bottomAnchor constraintEqualToAnchor:self.halfStarView.bottomAnchor]
     ]];
 
-    self.starColor = [BPKColor skyGrayTint06];
-    self.starFilledColor = [BPKColor erfoud];
     _size = size;
     _state = BPKStarStateDefault;
 
@@ -148,6 +146,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Helpers
 
+- (UIColor *)currentStarFilledColor {
+    return self.starFilledColor != nil ? self.starFilledColor : [BPKColor erfoud];
+}
+
+- (UIColor *)currentStarColor {
+    return self.starColor != nil ? self.starColor : [BPKColor skyGrayTint06];
+}
+
 - (BPKIconSize)iconSizeForStarSize:(BPKStarSize)size {
     switch (size) {
     case BPKStarSizeXLarge:
@@ -172,8 +178,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)updateStarAppearance {
-    self.starView.tintColor = self.state == BPKStarStateFull ? self.starFilledColor : self.starColor;
-    self.halfStarView.tintColor = self.starFilledColor;
+    self.starView.tintColor = self.state == BPKStarStateFull ? self.currentStarFilledColor : self.currentStarColor;
+    self.halfStarView.tintColor = self.currentStarFilledColor;
     self.halfStarView.hidden = self.state != BPKStarStateHalf;
 }
 

--- a/Backpack/Switch/Classes/BPKSwitch.h
+++ b/Backpack/Switch/Classes/BPKSwitch.h
@@ -48,7 +48,7 @@ NS_SWIFT_NAME(Switch) IB_DESIGNABLE @interface BPKSwitch : UISwitch
  *
  * @warning This is not intended to be used directly, it exists to support theming only.
  */
-@property(nonatomic, strong) UIColor *primaryColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *primaryColor UI_APPEARANCE_SELECTOR;
 
 @end
 

--- a/Backpack/Switch/Classes/BPKSwitch.m
+++ b/Backpack/Switch/Classes/BPKSwitch.m
@@ -51,16 +51,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)setPrimaryColor:(UIColor *)primaryColor {
+- (void)setPrimaryColor:(UIColor *_Nullable)primaryColor {
     if (_primaryColor != primaryColor) {
         _primaryColor = primaryColor;
-        self.onTintColor = primaryColor;
+
+        [self updateSwitchOnColor];
     }
+}
+
+-(void)updateSwitchOnColor {
+    self.onTintColor = _primaryColor != nil ? _primaryColor : BPKColor.skyBlue;
 }
 
 - (void)setup {
     self.tintColor = BPKColor.skyGrayTint06;
-    self.onTintColor = _primaryColor;
+    [self updateSwitchOnColor];
     [self setNeedsDisplay];
 }
 

--- a/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.h
+++ b/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.h
@@ -47,7 +47,7 @@ typedef NS_SWIFT_NAME(TappableLinkLabelStyle) NS_ENUM(NSUInteger, BPKTappableLin
  */
 NS_SWIFT_NAME(TappableLinkLabel) IB_DESIGNABLE @interface BPKTappableLinkLabel : UIView
 
-@property(nonatomic, strong) UIColor *linkColor UI_APPEARANCE_SELECTOR;
+@property(nullable, nonatomic, strong) UIColor *linkColor UI_APPEARANCE_SELECTOR;
 @property(nullable, nonatomic, strong) BPKFontMapping *fontMapping UI_APPEARANCE_SELECTOR;
 
 /**

--- a/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.m
+++ b/Backpack/TappableLinkLabel/Classes/BPKTappableLinkLabel.m
@@ -231,7 +231,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)setLinkColor:(UIColor *)linkColor {
+- (void)setLinkColor:(UIColor *_Nullable)linkColor {
     if (_linkColor != linkColor) {
         _linkColor = linkColor;
 

--- a/Backpack/Theme/Classes/BPKDefaultTheme.m
+++ b/Backpack/Theme/Classes/BPKDefaultTheme.m
@@ -248,67 +248,67 @@ NSString *const DefaultThemeName = @"Default";
 }
 
 - (UIColor *)chipPrimaryColor {
-    return self.primaryColor;
+    return nil;
 }
 
 - (UIColor *)switchPrimaryColor {
-    return self.primaryColor;
+    return nil;
 }
 
 - (UIColor *)spinnerPrimaryColor {
-    return self.primaryColor;
+    return nil;
 }
 
 - (UIColor *)buttonLinkContentColor {
-    return self.primaryColor;
+    return nil;
 }
 
 - (UIColor *)buttonPrimaryContentColor {
-    return self.white;
+    return nil;
 }
 
 - (UIColor *)buttonPrimaryGradientStartColor {
-    return self.montverde500;
+    return nil;
 }
 
 - (UIColor *)buttonPrimaryGradientEndColor {
-    return self.montverde500;
+    return nil;
 }
 
 - (UIColor *)buttonFeaturedContentColor {
-    return self.white;
+    return nil;
 }
 
 - (UIColor *)buttonFeaturedGradientStartColor {
-    return self.skyBlue500;
+    return nil;
 }
 
 - (UIColor *)buttonFeaturedGradientEndColor {
-    return self.skyBlue500;
+    return nil;
 }
 
 - (UIColor *)buttonSecondaryContentColor {
-    return self.skyBlue500;
+    return nil;
 }
 
 - (UIColor *)buttonSecondaryBackgroundColor {
-    return self.white;
+    return nil;
 }
 
 - (UIColor *)buttonSecondaryBorderColor {
-    return self.gray100;
+    return nil;
 }
 
 - (UIColor *)buttonDestructiveContentColor {
-    return self.red500;
+    return nil;
 }
 
 - (UIColor *)buttonDestructiveBackgroundColor {
-    return self.white;
+    return nil;
 }
 
 - (UIColor *)buttonDestructiveBorderColor {
-    return self.gray300;
+    return nil;
 }
 
 - (NSNumber *)buttonCornerRadius {
@@ -316,19 +316,19 @@ NSString *const DefaultThemeName = @"Default";
 }
 
 - (UIColor *)starFilledColor {
-    return self.kolkata500;
+    return nil;
 }
 
 - (UIColor *)horiontalNavigationSelectedColor {
-    return self.primaryColor;
+    return nil;
 }
 
 - (UIColor *)calendarDateSelectedContentColor {
-    return self.white;
+    return nil;
 }
 
 - (UIColor *)calendarDateSelectedBackgroundColor {
-    return self.primaryColor;
+    return nil;
 }
 
 - (Class)themeContainerClass {
@@ -336,15 +336,15 @@ NSString *const DefaultThemeName = @"Default";
 }
 
 - (UIColor *)ratingLowColor {
-    return BPKColor.panjin;
+    return nil;
 }
 
 - (UIColor *)ratingMediumColor {
-    return BPKColor.kolkata;
+    return nil;
 }
 
 - (UIColor *)ratingHighColor {
-    return BPKColor.monteverde;
+    return nil;
 }
 
 @end

--- a/Backpack/Theme/Classes/BPKThemeDefinition.h
+++ b/Backpack/Theme/Classes/BPKThemeDefinition.h
@@ -28,24 +28,24 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) Class themeContainerClass;
 @property(nonatomic, readonly, strong) NSString *themeName;
 
-@property(nonatomic, readonly, strong) UIColor *switchPrimaryColor;
-@property(nonatomic, readonly, strong) UIColor *chipPrimaryColor;
-@property(nonatomic, readonly, strong) UIColor *spinnerPrimaryColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *switchPrimaryColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *chipPrimaryColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *spinnerPrimaryColor;
 @property(nullable, nonatomic, readonly, strong) BPKFontMapping *fontMapping;
 
-@property(nonatomic, readonly, strong) UIColor *buttonLinkContentColor;
-@property(nonatomic, readonly, strong) UIColor *buttonSecondaryContentColor;
-@property(nonatomic, readonly, strong) UIColor *buttonSecondaryBackgroundColor;
-@property(nonatomic, readonly, strong) UIColor *buttonSecondaryBorderColor;
-@property(nonatomic, readonly, strong) UIColor *buttonDestructiveContentColor;
-@property(nonatomic, readonly, strong) UIColor *buttonDestructiveBackgroundColor;
-@property(nonatomic, readonly, strong) UIColor *buttonDestructiveBorderColor;
-@property(nonatomic, readonly, strong) UIColor *buttonPrimaryContentColor;
-@property(nonatomic, readonly, strong) UIColor *buttonPrimaryGradientStartColor;
-@property(nonatomic, readonly, strong) UIColor *buttonPrimaryGradientEndColor;
-@property(nonatomic, readonly, strong) UIColor *buttonFeaturedContentColor;
-@property(nonatomic, readonly, strong) UIColor *buttonFeaturedGradientStartColor;
-@property(nonatomic, readonly, strong) UIColor *buttonFeaturedGradientEndColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonLinkContentColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonSecondaryContentColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonSecondaryBackgroundColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonSecondaryBorderColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonDestructiveContentColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonDestructiveBackgroundColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonDestructiveBorderColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonPrimaryContentColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonPrimaryGradientStartColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonPrimaryGradientEndColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonFeaturedContentColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonFeaturedGradientStartColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *buttonFeaturedGradientEndColor;
 
 @property(nonatomic, readonly, strong) UIColor *gray50;
 @property(nonatomic, readonly, strong) UIColor *gray100;
@@ -63,18 +63,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nullable, nonatomic, readonly, strong) NSNumber *buttonCornerRadius;
 
 @property(nonatomic, readonly, strong) UIColor *primaryColor;
-@property(nonatomic, readonly, strong) BPKGradient *primaryGradient;
+@property(nullable, nonatomic, readonly, strong) BPKGradient *primaryGradient;
 
-@property(nonatomic, readonly, strong) UIColor *calendarDateSelectedContentColor;
-@property(nonatomic, readonly, strong) UIColor *calendarDateSelectedBackgroundColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *calendarDateSelectedContentColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *calendarDateSelectedBackgroundColor;
 
 @property(nullable, nonatomic, readonly, strong) UIColor *starFilledColor;
 
-@property(nonatomic, readonly, strong) UIColor *horiontalNavigationSelectedColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *horiontalNavigationSelectedColor;
 
-@property(nonatomic, readonly, strong) UIColor *ratingLowColor;
-@property(nonatomic, readonly, strong) UIColor *ratingMediumColor;
-@property(nonatomic, readonly, strong) UIColor *ratingHighColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *ratingLowColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *ratingMediumColor;
+@property(nullable, nonatomic, readonly, strong) UIColor *ratingHighColor;
 
 @end
 


### PR DESCRIPTION
The default theme currently works by applying the default brand colours to every component themeable property. To make theming and dark mode play nicely together, the default theme should be able to simply revert the colour values to `nil` such that the component falls back to the default value itself.

Follow up PR for Calendar...

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
