### PR TITLE
[NO-JIRA] Reinstate exluded tests

### DIFF
--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		D24B548B22EA38D900ECD829 /* BPKProgressBarTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D24B548A22EA38D900ECD829 /* BPKProgressBarTest.m */; };
 		D24B548F22EA3E1E00ECD829 /* ProgressBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24B548E22EA3E1D00ECD829 /* ProgressBarViewController.swift */; };
 		D24D602B22F84CEC002847D1 /* TextField.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D24D602A22F84CEC002847D1 /* TextField.storyboard */; };
+		D257C769236AE3FB006683F5 /* TextViewUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D257C767236AE3FB006683F5 /* TextViewUITest.swift */; };
+		D257C76A236AE3FB006683F5 /* TextFieldUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D257C768236AE3FB006683F5 /* TextFieldUITest.swift */; };
 		D261F26822C0E52300A4A476 /* TappableLinkLabels.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D261F26722C0E52300A4A476 /* TappableLinkLabels.storyboard */; };
 		D261F26C22C0E6B600A4A476 /* TappableLinkLabelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D261F26B22C0E6B600A4A476 /* TappableLinkLabelsViewController.swift */; };
 		D263EA8C22B7B5D400569757 /* ThemeRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D263EA8B22B7B5D400569757 /* ThemeRegistry.swift */; };
@@ -107,6 +109,8 @@
 		D2CD11E7215E4D83000CEA5C /* CardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CD11E6215E4D83000CEA5C /* CardsViewController.swift */; };
 		D2D624AB231586F600D8ED38 /* PanelSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D624A9231586F500D8ED38 /* PanelSelectorViewController.swift */; };
 		D2D624AC231586F600D8ED38 /* PanelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D624AA231586F600D8ED38 /* PanelViewController.swift */; };
+		D2FBC4AC236AE68D00331506 /* BPKTextFieldTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D257C76C236AE402006683F5 /* BPKTextFieldTest.m */; };
+		D2FBC4AD236AE69000331506 /* BPKTappableLinkLabelTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D257C76B236AE402006683F5 /* BPKTappableLinkLabelTest.m */; };
 		D2FF309021903B2500E06F96 /* Badges.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2FF308F21903B2500E06F96 /* Badges.storyboard */; };
 		D613CE552006795400D60CC4 /* BPKColorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D613CE542006795400D60CC4 /* BPKColorTest.m */; };
 		D61ACE032306E1E7001C976E /* NavigationBar.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D61ACE022306E1E7001C976E /* NavigationBar.storyboard */; };
@@ -270,6 +274,10 @@
 		D24B548A22EA38D900ECD829 /* BPKProgressBarTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKProgressBarTest.m; sourceTree = "<group>"; };
 		D24B548E22EA3E1D00ECD829 /* ProgressBarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressBarViewController.swift; sourceTree = "<group>"; };
 		D24D602A22F84CEC002847D1 /* TextField.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TextField.storyboard; sourceTree = "<group>"; };
+		D257C767236AE3FB006683F5 /* TextViewUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewUITest.swift; sourceTree = "<group>"; };
+		D257C768236AE3FB006683F5 /* TextFieldUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldUITest.swift; sourceTree = "<group>"; };
+		D257C76B236AE402006683F5 /* BPKTappableLinkLabelTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKTappableLinkLabelTest.m; sourceTree = "<group>"; };
+		D257C76C236AE402006683F5 /* BPKTextFieldTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKTextFieldTest.m; sourceTree = "<group>"; };
 		D261F26722C0E52300A4A476 /* TappableLinkLabels.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TappableLinkLabels.storyboard; sourceTree = "<group>"; };
 		D261F26B22C0E6B600A4A476 /* TappableLinkLabelsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TappableLinkLabelsViewController.swift; sourceTree = "<group>"; };
 		D263EA8B22B7B5D400569757 /* ThemeRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeRegistry.swift; sourceTree = "<group>"; };
@@ -499,6 +507,8 @@
 		6003F5B5195388D20070C39A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D257C76B236AE402006683F5 /* BPKTappableLinkLabelTest.m */,
+				D257C76C236AE402006683F5 /* BPKTextFieldTest.m */,
 				D24B548A22EA38D900ECD829 /* BPKProgressBarTest.m */,
 				D216C20F22E974A300045A9E /* BPKHorizontalNavigationTest.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
@@ -617,6 +627,8 @@
 		D6517B40216DF5F800D85FF9 /* Backpack NativeUITests */ = {
 			isa = PBXGroup;
 			children = (
+				D257C768236AE3FB006683F5 /* TextFieldUITest.swift */,
+				D257C767236AE3FB006683F5 /* TextViewUITest.swift */,
 				D216C21222E974B100045A9E /* HorizontalNavigationUITest.swift */,
 				D6517B43216DF5F800D85FF9 /* Info.plist */,
 				D6517B4A216DF63700D85FF9 /* DialogUITest.swift */,
@@ -1131,6 +1143,8 @@
 				D655C51A200FA18100CB39AF /* BPKFontTest.m in Sources */,
 				D696CA23215CC1DB00682666 /* IconSwiftTest.swift in Sources */,
 				D6391602202CAF07006E8329 /* BPKShadowTest.m in Sources */,
+				D2FBC4AD236AE69000331506 /* BPKTappableLinkLabelTest.m in Sources */,
+				D2FBC4AC236AE68D00331506 /* BPKTextFieldTest.m in Sources */,
 				D6CE74F22124230000154D92 /* BPKPanelTest.m in Sources */,
 				D613CE552006795400D60CC4 /* BPKColorTest.m in Sources */,
 				589FD45522DE092800F252E9 /* BPKStarRatingTest.m in Sources */,
@@ -1145,6 +1159,8 @@
 				D6517B4B216DF63700D85FF9 /* DialogUITest.swift in Sources */,
 				760E41E5232BD50700A0CE8D /* ToastUITest.swift in Sources */,
 				D216C21322E974B100045A9E /* HorizontalNavigationUITest.swift in Sources */,
+				D257C76A236AE3FB006683F5 /* TextFieldUITest.swift in Sources */,
+				D257C769236AE3FB006683F5 /* TextViewUITest.swift in Sources */,
 				D28B3611219C209000E82A79 /* ChipUITest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Backpack/TextField.storyboard
+++ b/Example/Backpack/TextField.storyboard
@@ -18,6 +18,7 @@
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Loren ipse dolor sit" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="XWZ-pz-jIr" customClass="BPKTextField">
                                 <rect key="frame" x="20" y="351" width="374" height="34"/>
+                                <accessibility key="accessibilityConfiguration" identifier="textField"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>

--- a/Example/Backpack/View Controllers/TextViewsViewController.swift
+++ b/Example/Backpack/View Controllers/TextViewsViewController.swift
@@ -25,5 +25,6 @@ class TextViewsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        textView.accessibilityIdentifier = "textView"
     }
 }

--- a/Example/Tests/BPKTappableLinkLabelTest.m
+++ b/Example/Tests/BPKTappableLinkLabelTest.m
@@ -15,8 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #import <Backpack/Color.h>
 #import <Backpack/TappableLinkLabel.h>
+
 #import <XCTest/XCTest.h>
 
 @interface BPKTappableLinkLabelTest : XCTestCase

--- a/Example/Tests/BPKTextFieldTest.m
+++ b/Example/Tests/BPKTextFieldTest.m
@@ -15,8 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #import <Backpack/Color.h>
 #import <Backpack/TextField.h>
+
 #import <XCTest/XCTest.h>
 
 @interface BPKTextFieldTest : XCTestCase
@@ -33,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
     };
 
     NSUInteger length = sizeof(styles) / sizeof(styles[0]);
-    UIColor *expectedColor = [BPKColor gray900];
+    UIColor *expectedColor = BPKColor.textPrimaryColor;
 
     for (NSUInteger i = 0; i < length; i++) {
         BPKTextField *textField = [[BPKTextField alloc] initWithFontStyle:styles[i]];
@@ -65,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
     };
 
     NSUInteger length = sizeof(styles) / sizeof(styles[0]);
-    UIColor *expectedColor = [BPKColor gray900];
+    UIColor *expectedColor = BPKColor.textPrimaryColor;
 
     for (NSUInteger i = 0; i < length; i++) {
         BPKTextField *textField = [[BPKTextField alloc] initWithFontStyle:styles[i]];


### PR DESCRIPTION
Some tests were accidentally excluded from the project somehow - probably during a bad rebase?
This PR reinstates them!

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)