### PR TITLE
[AMT-3954] Fix animation glitch when updating `HorizontalNavigation`

### DIFF
--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.m
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.m
@@ -108,7 +108,8 @@ NS_ASSUME_NONNULL_BEGIN
         if (UIAccessibilityIsReduceMotionEnabled()) {
             animationDuration = 0.0;
         }
-
+        
+        [self layoutIfNeeded];
         [UIView animateWithDuration:animationDuration
                          animations:^{
                            [self adjustBarConstraintsForView:selectedButton];
@@ -257,6 +258,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Remove all current arranged views:
     for (UIView *subView in self.stackView.arrangedSubviews) {
         [self.stackView removeArrangedSubview:subView];
+        [subView removeFromSuperview];
     }
 
     for (BPKHorizontalNavigationOption *option in self.options) {
@@ -274,7 +276,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setOptions:(NSArray<BPKHorizontalNavigationOption *> *)options {
-    if (_options != options) {
+    if (![_options isEqualToArray:options]) {
         _options = [options copy];
 
         [self repopulateStackview];

--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOption.m
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOption.m
@@ -79,6 +79,12 @@ NS_ASSUME_NONNULL_BEGIN
     return self.iconName != nil;
 }
 
+- (BOOL)isEqual:(BPKHorizontalNavigationOption *)other {
+    return self.tag == other.tag &&
+        [self.name isEqualToString:other.name] &&
+        [(self.iconName ?: @"") isEqualToString:(other.iconName ?: @"")];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,9 +2,11 @@
 > Place your changes below this line.
 
 **Fixed:**
+- Backpack/Font:
+  - Removed old brand methods, leaving the API unchanged.
 
- - Backpack/Font:
-   - Removed old brand methods, leaving the API unchanged.
+- Backpack/HorizontalNavigation:
+  - Fixed issue where `HorizontalNavigation` would have an animation glitch when updating its options.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
This PR fixes an animation glitch that happens when updating the options in the `HorizontalNavigation`.

![48e7d780-0aea-11ea-894b-300787413134](https://user-images.githubusercontent.com/3900360/69821915-331e9480-1205-11ea-8638-fbfd5f2214ff.gif)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [ ] Tests
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
