### PR TITLE
[BPK-3279] Remove BPKFont caching

### DIFF
--- a/Backpack/Font/Classes/Generated/BPKFont.m
+++ b/Backpack/Font/Classes/Generated/BPKFont.m
@@ -26,7 +26,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BPKFont()
-@property(nonatomic, strong, readonly) NSCache<NSString *, NSDictionary *> *attributesCache;
 @end
 
 @implementation BPKFont
@@ -197,16 +196,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Private
 
-+ (NSCache<NSString *, NSDictionary *> *)attributesCache {
-    static dispatch_once_t onceToken;
-    static NSCache *_attributesCache = nil;
-    dispatch_once(&onceToken, ^{
-        _attributesCache = [[NSCache alloc] init];
-    });
-
-    return _attributesCache;
-}
-
 + (NSDictionary<NSAttributedStringKey, id> *)attributesForFontStyle:(BPKFontStyle)fontStyle
                                                withCustomAttributes:(NSDictionary<NSAttributedStringKey,id> *)customAttributes {
     NSMutableDictionary<NSAttributedStringKey, id> *attributes = [[self attributesForFontStyle:fontStyle] mutableCopy];
@@ -225,26 +214,13 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSDictionary<NSAttributedStringKey, id> *)attributesForFontStyle:(BPKFontStyle)style {
-    NSString *cacheKey = [self cacheKeyForFontStyle:style];
-    NSDictionary *potentialCacheHit = [[self attributesCache] objectForKey:cacheKey];
-
-    if (potentialCacheHit) {
-        return potentialCacheHit;
-    }
-
     UIFont *font = [self fontForStyle:style];
     NSDictionary *result = @{
                    NSForegroundColorAttributeName: BPKColor.textPrimaryColor,
                    NSFontAttributeName: font,
                    };
 
-    [[self attributesCache] setObject:result forKey:cacheKey];
-
     return result;
-}
-
-+ (NSString *)cacheKeyForFontStyle:(BPKFontStyle)style {
-    return [NSString stringWithFormat:@"%ld", (unsigned long)style];
 }
 
 + (UIFont *)fontForStyle:(BPKFontStyle)style {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,9 +1,12 @@
 # Unreleased
 > Place your changes below this line.
 **Breaking:**
- - Backpack/Font:
-   - The `fontMapping` argument is now unused and will be removed in the future.
-   - To enable the Relative typeface, a preprocessor directive must be specified. If not, system font will be used instead of Skyscanner Relative.
+- Backpack/Font:
+  - The `fontMapping` argument is now unused and will be removed in the future.
+  - To enable the Relative typeface, a preprocessor directive must be specified. If not, system font will be used instead of Skyscanner Relative.
+
+- Backpack/Button
+  - Property `cornerRadius` is not longer available to customise.
 
 **Added:**
 - Backpack/NavigationBar
@@ -15,14 +18,10 @@
 **Fixed:**
 - Backpack/HorizontalNavigation:
   - Fixed issue where `HorizontalNavigation` would have an animation glitch when updating its options.
+  - Change spacing between items
 
-**Breaking:**
-- Backpack/Button
-  - Property `cornerRadius` is not longer available to customise.
-
-**Fixed:**
- - Backpack/HorizontalNavigation
-   - Change spacing between items
+- Backpack/Font:
+  - Removed caching as it seems to provide little/no performance benefits.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -26,7 +26,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BPKFont()
-@property(nonatomic, strong, readonly) NSCache<NSString *, NSDictionary *> *attributesCache;
 @end
 
 @implementation BPKFont
@@ -89,16 +88,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Private
 
-+ (NSCache<NSString *, NSDictionary *> *)attributesCache {
-    static dispatch_once_t onceToken;
-    static NSCache *_attributesCache = nil;
-    dispatch_once(&onceToken, ^{
-        _attributesCache = [[NSCache alloc] init];
-    });
-
-    return _attributesCache;
-}
-
 + (NSDictionary<NSAttributedStringKey, id> *)attributesForFontStyle:(BPKFontStyle)fontStyle
                                                withCustomAttributes:(NSDictionary<NSAttributedStringKey,id> *)customAttributes {
     NSMutableDictionary<NSAttributedStringKey, id> *attributes = [[self attributesForFontStyle:fontStyle] mutableCopy];
@@ -117,26 +106,13 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSDictionary<NSAttributedStringKey, id> *)attributesForFontStyle:(BPKFontStyle)style {
-    NSString *cacheKey = [self cacheKeyForFontStyle:style];
-    NSDictionary *potentialCacheHit = [[self attributesCache] objectForKey:cacheKey];
-
-    if (potentialCacheHit) {
-        return potentialCacheHit;
-    }
-
     UIFont *font = [self fontForStyle:style];
     NSDictionary *result = @{
                    NSForegroundColorAttributeName: BPKColor.textPrimaryColor,
                    NSFontAttributeName: font,
                    };
 
-    [[self attributesCache] setObject:result forKey:cacheKey];
-
     return result;
-}
-
-+ (NSString *)cacheKeyForFontStyle:(BPKFontStyle)style {
-    return [NSString stringWithFormat:@"%ld", (unsigned long)style];
 }
 
 + (UIFont *)fontForStyle:(BPKFontStyle)style {


### PR DESCRIPTION
+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


With cache:
![with cache](https://user-images.githubusercontent.com/30267516/70619497-08710a80-1c0d-11ea-94e3-ae73ed876742.png)

Without cache:
![without cache](https://user-images.githubusercontent.com/30267516/70619510-0dce5500-1c0d-11ea-9b89-91aea944fbdd.png)
