### PR TITLE
[BPK-3415] Calendar month heading RTL alignment

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
+++ b/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
@@ -37,7 +37,6 @@
     self = [super initWithFrame:frame];
 
     if (self) {
-        self.titleLabel.textAlignment = NSTextAlignmentLeft;
         [self.weekdayView removeFromSuperview];
         [self.bottomBorder removeFromSuperview];
     }
@@ -47,7 +46,7 @@
 
 - (void)configureAppearance {
     [super configureAppearance];
-    [self.titleLabel setTextAlignment:NSTextAlignmentLeft];
+    self.titleLabel.textAlignment = NSTextAlignmentNatural;
 }
 
 - (void)layoutSubviews {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,12 +1,15 @@
 # Unreleased
 > Place your changes below this line.
+**Breaking:**
+- Backpack/Font:
+  - `FontMapping` class removed. `fontMapping` argument is no longer accepted by `BPKFont`.
+
 **Fixed:**
 - Backpack/Rating:
   - Made the outer container an accessibility element so that an accessibility label can be set.
 
-**Breaking:**
-- Backpack/Font:
-  - `FontMapping` class removed. `fontMapping` argument is no longer accepted by `BPKFont`.
+ - Backpack/Calendar:
+   - Fixed alignment of month headings in RTL languages.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)