### PR TITLE
[BPK-3249] Make rating component an accessibility element

### DIFF
--- a/Backpack/Rating/Classes/BPKRating.m
+++ b/Backpack/Rating/Classes/BPKRating.m
@@ -87,6 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.textWrapper.accessibilityElementsHidden = YES;
     [self addSubview:self.textWrapper];
 
+    self.isAccessibilityElement = YES;
+
     [self setUpConstraints];
     [self updateConstraints];
     [self updateStyle];

--- a/Backpack/Rating/README.md
+++ b/Backpack/Rating/README.md
@@ -29,6 +29,7 @@ rating.subtitle = [[BPKRatingTextDefinition alloc] initWithHighRatingText:@"Some
                                   lowRatingText:@"Some subtitle to display when the value is low"];
 rating.ratingValue = 9.7;
 rating.size = BPKRatingSizeSmall;
+rating.accessibilityLabel = "Rated 5 out of 10. Exceptional hotel."
 ```
 
 ### Appearance attributes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,8 @@
 # Unreleased
 > Place your changes below this line.
+**Fixed:**
+- Backpack/Rating:
+  - Made the outer container an accessibility element so that an accessibility label can be set.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)