### PR TITLE
[No JIRA] Reinstate `UIFont` apis in `BPKFont`

### DIFF
--- a/Backpack/Font/Classes/Generated/BPKFont.h
+++ b/Backpack/Font/Classes/Generated/BPKFont.h
@@ -139,6 +139,17 @@ NS_SWIFT_NAME(Font) @interface BPKFont: NSObject
 */
 + (void)setFontDefinition:(id<BPKFontDefinitionProtocol>_Nullable)fontDefinition;
 
+/**
+ * Create a `UIFont` instance for a specific text style.
+ *
+ *
+ * @param fontStyle The desired fontStyle.
+ * @return An instance of `UIFont` for the specificed style.
+ *
+ * @warning Prefer using `BPKLabel`, `BPKTextField`, or `BPKTextView` for rendering text when possible.
+ */
++ (UIFont *)fontForFontStyle:(BPKFontStyle)fontStyle NS_SWIFT_NAME(makeFont(fontStyle:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Font/Classes/Generated/BPKFont.m
+++ b/Backpack/Font/Classes/Generated/BPKFont.m
@@ -55,6 +55,10 @@ NS_ASSUME_NONNULL_BEGIN
     return attributedString;
 }
 
++ (UIFont *)fontForFontStyle:(BPKFontStyle)fontStyle {
+    return [self fontForStyle:fontStyle fontManager:[BPKFontManager sharedInstance]];
+}
+
 #pragma mark - Private
 
 + (NSDictionary<NSAttributedStringKey, id> *)attributesForFontStyle:(BPKFontStyle)fontStyle

--- a/Example/Tests/BPKFontTest.m
+++ b/Example/Tests/BPKFontTest.m
@@ -102,26 +102,36 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testFontWithStyle {
-    /*
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextXs], [BPKFont textXs]);
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextXsEmphasized], [BPKFont textXsEmphasized]);
+    BPKFontStyle styles[] = {
+        BPKFontStyleTextBase,
+        BPKFontStyleTextBaseEmphasized,
+        BPKFontStyleTextCaps,
+        BPKFontStyleTextCapsEmphasized,
+        BPKFontStyleTextLg,
+        BPKFontStyleTextLgEmphasized,
+        BPKFontStyleTextSm,
+        BPKFontStyleTextSmEmphasized,
+        BPKFontStyleTextXl,
+        BPKFontStyleTextXlEmphasized,
+        BPKFontStyleTextXlHeavy,
+        BPKFontStyleTextXs,
+        BPKFontStyleTextXsEmphasized,
+        BPKFontStyleTextXxl,
+        BPKFontStyleTextXxlEmphasized,
+        BPKFontStyleTextXxlHeavy,
+        BPKFontStyleTextXxxl,
+        BPKFontStyleTextXxxlEmphasized,
+        BPKFontStyleTextXxxlHeavy
+    };
 
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextSm], [BPKFont textSm]);
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextSmEmphasized], [BPKFont textSmEmphasized]);
+    for (NSUInteger i = 0; i < sizeof(styles) / sizeof(styles[0]); i++) {
+        BPKFontStyle style = styles[i];
+        UIFont *font = [BPKFont fontForFontStyle:style];
+        NSDictionary<NSAttributedStringKey, id> *attributes = [BPKFont attributesForFontStyle:style];
 
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextBase], [BPKFont textBase]);
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextBaseEmphasized], [BPKFont textBaseEmphasized]);
-
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextLg], [BPKFont textLg]);
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextLgEmphasized], [BPKFont textLgEmphasized]);
-
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextXl], [BPKFont textXl]);
-    XCTAssertEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextXlEmphasized], [BPKFont textXlEmphasized]);
-
-    // Small sanity checks
-    XCTAssertNotEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextXl], [BPKFont fontWithStyle:BPKFontStyleTextLg]);
-    XCTAssertNotEqualObjects([BPKFont fontWithStyle:BPKFontStyleTextSm], [BPKFont fontWithStyle:BPKFontStyleTextBase]);
-     */
+        XCTAssertNotNil([BPKFont fontForFontStyle:style]);
+        XCTAssertEqualObjects(font, attributes[NSFontAttributeName]);
+    }
 }
 
 - (void)testStableFontStyles {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,13 @@
 # Unreleased
 > Place your changes below this line.
 
+
+**Added:**
+
+- Backpack/Font
+  - Reinstated `BPKFont`'s APIs for constructing `UIFont` instances. Back in version [2.0](#2200) we removed these `BPKFont` methods because the new type scale required us to render text only via attributed strings. With our new typeface, Relative, we have baked these rendering concerns into the typeface itself and we can again use `UIFont` instances directly. As always we recommend you prefer higher level components such as `BPKLabel` for you text rendering needs.
+
+
 **Fixed:**
 
 - Backpack

--- a/templates/BPKFont.h.njk
+++ b/templates/BPKFont.h.njk
@@ -103,6 +103,17 @@ NS_SWIFT_NAME(Font) @interface BPKFont: NSObject
 */
 + (void)setFontDefinition:(id<BPKFontDefinitionProtocol>_Nullable)fontDefinition;
 
+/**
+ * Create a `UIFont` instance for a specific text style.
+ *
+ *
+ * @param fontStyle The desired fontStyle.
+ * @return An instance of `UIFont` for the specificed style.
+ *
+ * @warning Prefer using `BPKLabel`, `BPKTextField`, or `BPKTextView` for rendering text when possible.
+ */
++ (UIFont *)fontForFontStyle:(BPKFontStyle)fontStyle NS_SWIFT_NAME(makeFont(fontStyle:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -55,6 +55,10 @@ NS_ASSUME_NONNULL_BEGIN
     return attributedString;
 }
 
++ (UIFont *)fontForFontStyle:(BPKFontStyle)fontStyle {
+    return [self fontForStyle:fontStyle fontManager:[BPKFontManager sharedInstance]];
+}
+
 #pragma mark - Private
 
 + (NSDictionary<NSAttributedStringKey, id> *)attributesForFontStyle:(BPKFontStyle)fontStyle


### PR DESCRIPTION
These APIs were removed because our type scale required us to do all
text rendering via attributed string. This is no longer the case so we
can reinstate these APIs.


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)