### PR TITLE
[NO-JIRA] Kill xcode 9 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ matrix:
   include:
     - osx_image: xcode11.2
       env: BUILD_SDK=iphonesimulator13.2 DESTINATION="OS=13.2.2,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="true" MAIN_STAGE="true"
-    - osx_image: xcode10.3
+    - osx_image: xcode11.2
       env: BUILD_SDK=iphonesimulator12.4 DESTINATION="OS=12.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
+    - osx_image: xcode11.2
+      env: BUILD_SDK=iphonesimulator11.4 DESTINATION="OS=11.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
 before_install:
   - sudo sntp -sS time.apple.com
   - brew install clang-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
     - osx_image: xcode11.2
       env: BUILD_SDK=iphonesimulator13.2 DESTINATION="OS=13.2.2,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="true" MAIN_STAGE="true"
     - osx_image: xcode11.2
-      env: BUILD_SDK=iphonesimulator12.4 DESTINATION="OS=12.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
+      env: BUILD_SDK=iphonesimulator13.2 DESTINATION="OS=12.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
     - osx_image: xcode11.2
-      env: BUILD_SDK=iphonesimulator11.4 DESTINATION="OS=11.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
+      env: BUILD_SDK=iphonesimulator13.2 DESTINATION="OS=11.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
 before_install:
   - sudo sntp -sS time.apple.com
   - brew install clang-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
       env: BUILD_SDK=iphonesimulator13.2 DESTINATION="OS=13.2.2,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="true" MAIN_STAGE="true"
     - osx_image: xcode10.3
       env: BUILD_SDK=iphonesimulator12.4 DESTINATION="OS=12.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
-    - osx_image: xcode9.4
-      env: BUILD_SDK=iphonesimulator11.4 DESTINATION="OS=11.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
 before_install:
   - sudo sntp -sS time.apple.com
   - brew install clang-format


### PR DESCRIPTION
This is what travis provides in the xcode 11.2 image:
https://docs.travis-ci.com/user/reference/osx/#xcode-1121

If we want to build using different SDKs, I think we need to keep using separate xcode images as before.

TL;DR: Don't merge unless @k0nserv is happy to.