### PR TITLE
Snackbar support UITabBar

### DIFF
--- a/Backpack/Snackbar/Classes/BPKSnackbar.m
+++ b/Backpack/Snackbar/Classes/BPKSnackbar.m
@@ -201,8 +201,8 @@ static int const BPKSnackbarHeight = 60;
 
     if (self.superview) {
         [NSLayoutConstraint activateConstraints:@[
-            [self.leftAnchor constraintEqualToAnchor:self.superview.leftAnchor],
-            [self.rightAnchor constraintEqualToAnchor:self.superview.rightAnchor]
+            [self.leadingAnchor constraintEqualToAnchor:self.superview.leadingAnchor],
+            [self.trailingAnchor constraintEqualToAnchor:self.superview.trailingAnchor]
         ]];
 
         NSLayoutYAxisAnchor *bottomAnchor = self.superview.safeAreaLayoutGuide.bottomAnchor;
@@ -335,13 +335,16 @@ static int const BPKSnackbarHeight = 60;
 
     while (current) {
         UIViewController *parent = current.parentViewController;
+        NSArray *subviews = [parent.view subviews];
 
-        if ([parent isKindOfClass:[UITabBarController class]]) {
-            return ((UITabBarController *)parent).tabBar;
+        for (UIView *subview in subviews) {
+            if ([subview isKindOfClass:[UITabBar class]]) {
+                return (UITabBar *)subview;
+            }
         }
-
         current = parent;
     }
+
     return nil;
 }
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,6 +5,9 @@
 - Backpack/Badge:
   - Lightened the dark-mode colours used for `success` and `warning` badges to make them more visually appealing.
 
+- Backpack/Snackbar:
+  - The logic to search the Tab Bar has changed to support `UITabBar`.
+
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).
 2. Add the package name.


### PR DESCRIPTION
The logic to search the Tab Bar has changed to support `UITabBar` which is the class that we currently inherit from in the `SKYTabBar` class.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_