### PR TITLE
[BPKR-121] [AMT-4360] Add API for Bottom Sheet with intrinsic size

### DIFF
--- a/Backpack/BottomSheet/Classes/BottomSheet.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheet.swift
@@ -107,6 +107,8 @@ public final class BottomSheet: NSObject {
     
     /// Instantiates a `BottomSheet` with a non-scrollable content. Height of the bottom sheet will be
     /// calculated based on the content.
+    /// If the content height might not fit the screen, then `init(contentViewController: _, scrollViewToTrack: _)`
+    /// should be used instead.
     /// - Parameter contentViewController: Content of the bottom sheet.
     public init(contentViewController: UIViewController) {
         super.init()

--- a/Backpack/BottomSheet/Classes/BottomSheet.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheet.swift
@@ -71,7 +71,10 @@ public final class BottomSheet: NSObject {
         return panel
     }()
     
-    /// Instantiates a `BottomSheet`.
+    private var scrollView: UIScrollView?
+    
+    /// Instantiates a `BottomSheet` with a scrollable content. Default initial height is 386pt and can't be changed.
+    /// Optionally, an always visible bottom section can be added.
     ///
     /// - Parameters:
     ///   - contentViewController: Content of the bottom sheet.
@@ -87,9 +90,21 @@ public final class BottomSheet: NSObject {
                 scrollViewToTrack: UIScrollView,
                 bottomSectionViewController: UIViewController? = nil) {
         super.init()
+        
+        self.scrollView = scrollViewToTrack
+        
         floatingPanelController.contentViewController = contentViewController
         floatingPanelController.track(scrollView: scrollViewToTrack)
         floatingPanelController.bottomSectionViewController = bottomSectionViewController
+    }
+    
+    /// Instantiates a `BottomSheet` with a non-scrollable content. Height of the bottom sheet will be
+    /// calculated based on the content.
+    /// - Parameter contentViewController: Content of the bottom sheet.
+    public init(contentViewController: UIViewController) {
+        super.init()
+        floatingPanelController.contentViewController = contentViewController
+        floatingPanelController.surfaceView.backgroundColor = contentViewController.view.backgroundColor
     }
 
     /// This presents the bottom sheet. It is just a wrapper of native API
@@ -153,9 +168,15 @@ extension BottomSheet: FloatingPanelControllerDelegate {
             }
         }
     }
+    
+    final class IntrinsicLayout: FloatingPanelIntrinsicLayout {
+        func backdropAlphaFor(position: FloatingPanelPosition) -> CGFloat {
+            return Constants.backdropAlpha
+        }
+    }
 
     public func floatingPanel(_ viewController: FloatingPanelController,
                               layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
-        return Layout()
+        return scrollView == nil ? IntrinsicLayout() : Layout()
     }
 }

--- a/Backpack/BottomSheet/Classes/BottomSheet.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheet.swift
@@ -26,6 +26,7 @@ public final class BottomSheet: NSObject {
     private enum Constants {
         static let bottomSheetHeightInHalfPosition: CGFloat = 386.0
         static let backdropAlpha: CGFloat = 0.3
+        static let grabberHandleWidth: CGFloat = 60.0
     }
 
     /// View controller that will be presented when calling
@@ -59,9 +60,15 @@ public final class BottomSheet: NSObject {
     
     private lazy var floatingPanelController: BackpackFloatingPanelController = {
         let panel = BackpackFloatingPanelController(delegate: self)
+        panel.surfaceView.backgroundColor = Color.backgroundTertiaryColor
         panel.surfaceView.cornerRadius = BPKBorderRadiusLg
+        panel.surfaceView.grabberTopPadding = BPKSpacingMd
+        panel.surfaceView.grabberHandleHeight = BPKSpacingSm
+        panel.surfaceView.grabberHandleWidth = Constants.grabberHandleWidth
+        panel.surfaceView.grabberHandle.barColor = Color.skyGrayTint06
+        
         panel.isRemovalInteractionEnabled = true
-
+        
         // We do this to hold a strong reference to `BottomSheet` and force it
         // to exist as long as `floatingPanelController` exists.
         // Reference will be cleaned up by `floatingPanelController` when
@@ -104,7 +111,6 @@ public final class BottomSheet: NSObject {
     public init(contentViewController: UIViewController) {
         super.init()
         floatingPanelController.contentViewController = contentViewController
-        floatingPanelController.surfaceView.backgroundColor = contentViewController.view.backgroundColor
     }
 
     /// This presents the bottom sheet. It is just a wrapper of native API

--- a/Example/Backpack NativeUITests/BottomSheetUITest.swift
+++ b/Example/Backpack NativeUITests/BottomSheetUITest.swift
@@ -29,7 +29,7 @@ class BottomSheetUITest: BackpackUITestCase {
         }
         
         XCTContext.runActivity(named: "Second Bottom Sheet") { _ in
-            let sheet = app.tables.matching(identifier: "SheetPresentingSheet.SecondSheet.tableView").firstMatch
+            let sheet = app.otherElements.matching(identifier: "SheetPresentingSheet.SecondSheet.view").firstMatch
             _ = sheet.waitForExistence(timeout: 10)
         }
     }

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -172,7 +172,8 @@
 		E359366C240FFE680046FD4C /* BottomSheetUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E359366B240FFE680046FD4C /* BottomSheetUITest.swift */; };
 		E38947D222F5CB3300A357DB /* BottomSheet.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E38947D122F5CB3300A357DB /* BottomSheet.storyboard */; };
 		E38947D422F5F0E900A357DB /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38947D322F5F0E900A357DB /* BottomSheetViewController.swift */; };
-		E397BEA222F5F59000C8EC04 /* BottomSheetContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E397BEA122F5F59000C8EC04 /* BottomSheetContentViewController.swift */; };
+		E38E82EC24165A40004273E9 /* BottomSheetContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38E82EB24165A40004273E9 /* BottomSheetContentViewController.swift */; };
+		E397BEA222F5F59000C8EC04 /* BottomSheetScrollableContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E397BEA122F5F59000C8EC04 /* BottomSheetScrollableContentViewController.swift */; };
 		E397BEA422F5FCE500C8EC04 /* BottomSheetBottomSectionVIewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E397BEA322F5FCE500C8EC04 /* BottomSheetBottomSectionVIewController.swift */; };
 		E397BEA622F5FFDD00C8EC04 /* Storyboards.swift in Sources */ = {isa = PBXBuildFile; fileRef = E397BEA522F5FFDD00C8EC04 /* Storyboards.swift */; };
 /* End PBXBuildFile section */
@@ -400,7 +401,8 @@
 		E359366B240FFE680046FD4C /* BottomSheetUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetUITest.swift; sourceTree = "<group>"; };
 		E38947D122F5CB3300A357DB /* BottomSheet.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BottomSheet.storyboard; sourceTree = "<group>"; };
 		E38947D322F5F0E900A357DB /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
-		E397BEA122F5F59000C8EC04 /* BottomSheetContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentViewController.swift; sourceTree = "<group>"; };
+		E38E82EB24165A40004273E9 /* BottomSheetContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentViewController.swift; sourceTree = "<group>"; };
+		E397BEA122F5F59000C8EC04 /* BottomSheetScrollableContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetScrollableContentViewController.swift; sourceTree = "<group>"; };
 		E397BEA322F5FCE500C8EC04 /* BottomSheetBottomSectionVIewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetBottomSectionVIewController.swift; sourceTree = "<group>"; };
 		E397BEA522F5FFDD00C8EC04 /* Storyboards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storyboards.swift; sourceTree = "<group>"; };
 		E9BCCEB5F97CE209BCB4B278 /* Pods-Backpack_SnapshotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack_SnapshotTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack_SnapshotTests/Pods-Backpack_SnapshotTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -816,7 +818,8 @@
 			children = (
 				E38947D122F5CB3300A357DB /* BottomSheet.storyboard */,
 				E38947D322F5F0E900A357DB /* BottomSheetViewController.swift */,
-				E397BEA122F5F59000C8EC04 /* BottomSheetContentViewController.swift */,
+				E397BEA122F5F59000C8EC04 /* BottomSheetScrollableContentViewController.swift */,
+				E38E82EB24165A40004273E9 /* BottomSheetContentViewController.swift */,
 				E397BEA322F5FCE500C8EC04 /* BottomSheetBottomSectionVIewController.swift */,
 			);
 			path = "Bottom Sheet";
@@ -1194,7 +1197,7 @@
 				D20470402347875900A1BE48 /* BPKExampleAppTitleAttributes.m in Sources */,
 				D28784922250FCBD00353E32 /* Settings.swift in Sources */,
 				D6391600202CAAC8006E8329 /* BPKShadowViewController.m in Sources */,
-				E397BEA222F5F59000C8EC04 /* BottomSheetContentViewController.swift in Sources */,
+				E397BEA222F5F59000C8EC04 /* BottomSheetScrollableContentViewController.swift in Sources */,
 				D6B8CEB6217786F100BA52E8 /* LabelsViewController.swift in Sources */,
 				D27396F922CA5C9D002E9E40 /* LabelMultiFontStyleViewController.swift in Sources */,
 				D2161D522146B8F40097D0B1 /* ColorPreviewCollectionViewCell.swift in Sources */,
@@ -1245,6 +1248,7 @@
 				D28443EC22FC42A30066F88B /* FlareViewSelectorViewController.swift in Sources */,
 				3A335C0A214BCC19009034A6 /* BPKButtonSelectorViewController.m in Sources */,
 				D649E8EC212F0A2A00B25A9E /* BPKRootListTableViewController.m in Sources */,
+				E38E82EC24165A40004273E9 /* BottomSheetContentViewController.swift in Sources */,
 				D23E2C13219204A900A15AAE /* BPKBadgeContainer.swift in Sources */,
 				D24B548F22EA3E1E00ECD829 /* ProgressBarViewController.swift in Sources */,
 				60CE0F992189F99200309211 /* SwitchesViewController.swift in Sources */,

--- a/Example/Backpack/View Controllers/Bottom Sheet/BottomSheet.storyboard
+++ b/Example/Backpack/View Controllers/Bottom Sheet/BottomSheet.storyboard
@@ -70,6 +70,23 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Tdp-w9-kER" style="IBUITableViewCellStyleDefault" id="EqG-Sx-odO">
+                                        <rect key="frame" x="0.0" y="150" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EqG-Sx-odO" id="DXg-ku-vhI">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Bottom Sheet with a non-scrollable content" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Tdp-w9-kER" customClass="BPKLabel">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -81,18 +98,51 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="bottomSectionBottomSheet" destination="HER-cm-gYJ" id="bYv-kT-cOO"/>
+                        <outlet property="nonScrollableContentBottomSheet" destination="EqG-Sx-odO" id="qZF-Wx-01Q"/>
                         <outlet property="scrollViewBottomSheet" destination="0Ol-zf-yKy" id="Bna-Fu-MLo"/>
                         <outlet property="sheetPresentingSheet" destination="cne-nF-KUb" id="9X8-dk-HDa"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TNe-8k-ZDS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="76" y="-47"/>
+            <point key="canvasLocation" x="55" y="-100"/>
         </scene>
         <!--Bottom Sheet Content View Controller-->
+        <scene sceneID="mge-lo-Ueg">
+            <objects>
+                <viewController storyboardIdentifier="BottomSheetContentViewController" id="Y0v-h1-uIN" customClass="BottomSheetContentViewController" customModule="Backpack_Native" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="jKE-Kn-L0Z">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6lx-mt-Lpe" customClass="BPKLabel">
+                                <rect key="frame" x="16" y="60" width="382" height="786"/>
+                                <mutableString key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id imperdiet nibh. Donec consequat dui justo, ac pharetra felis vehicula ac. Suspendisse finibus gravida scelerisque. Integer elementum massa id elit eleifend viverra. Sed sit amet tortor tellus. Curabitur a lectus risus. Cras eget aliquam tellus. Nam molestie eu quam a rhoncus. Nam aliquet felis non facilisis vestibulum.
+
+Mauris pharetra magna sit amet ipsum dictum imperdiet. Aenean vitae luctus est. Integer lectus tellus, tincidunt quis commodo eget, feugiat non leo. Fusce congue rhoncus ipsum in tristique. Etiam dolor dolor, accumsan a ex in, fermentum consequat lorem. Proin eu sodales neque. Phasellus sodales diam vel odio euismod, a lobortis sem ultricies. Praesent in mi ex. Ut eu enim vitae augue tempus mattis. Etiam lacus dui, laoreet sit amet pulvinar finibus, placerat nec odio. Nam a dictum diam. Cras sagittis elit ut lorem consectetur, sed tristique massa faucibus. Aliquam sed nisl id nisl consectetur congue ut id risus.</mutableString>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="6lx-mt-Lpe" firstAttribute="top" secondItem="8iH-jL-fOF" secondAttribute="top" constant="34" id="6Xq-k6-CCw"/>
+                            <constraint firstItem="6lx-mt-Lpe" firstAttribute="leading" secondItem="8iH-jL-fOF" secondAttribute="leading" constant="16" id="mBr-3O-F7G"/>
+                            <constraint firstItem="8iH-jL-fOF" firstAttribute="trailing" secondItem="6lx-mt-Lpe" secondAttribute="trailing" constant="16" id="rO5-dN-Ccm"/>
+                            <constraint firstItem="8iH-jL-fOF" firstAttribute="bottom" secondItem="6lx-mt-Lpe" secondAttribute="bottom" constant="16" id="tBP-JH-qAp"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="8iH-jL-fOF"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tuu-ZL-aO4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1099" y="252"/>
+        </scene>
+        <!--Bottom Sheet Scrollable Content View Controller-->
         <scene sceneID="jeq-fo-b4J">
             <objects>
-                <tableViewController storyboardIdentifier="BottomSheetContentViewController" id="gBR-CP-h2O" customClass="BottomSheetContentViewController" customModule="Backpack_Native" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="BottomSheetScrollableContentViewController" id="gBR-CP-h2O" customClass="BottomSheetScrollableContentViewController" customModule="Backpack_Native" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="hmx-Gf-Iu6">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -437,7 +487,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7Fe-gx-8Qw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1035" y="-47"/>
+            <point key="canvasLocation" x="1100" y="-439"/>
         </scene>
         <!--Bottom Sheet Bottom Section View Controller-->
         <scene sceneID="2fS-8h-AUV">
@@ -471,7 +521,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VOE-ca-VEG" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1034.7826086956522" y="414.50892857142856"/>
+            <point key="canvasLocation" x="1846" y="-439"/>
         </scene>
     </scenes>
 </document>

--- a/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetScrollableContentViewController.swift
+++ b/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetScrollableContentViewController.swift
@@ -19,10 +19,11 @@
 
 import Backpack
 
-final class BottomSheetContentViewController: UIViewController {
+// swiftlint:disable:next type_name
+final class BottomSheetScrollableContentViewController: UITableViewController {
 
 }
 
-extension BottomSheetContentViewController: StoryboardInstantiable {
+extension BottomSheetScrollableContentViewController: StoryboardInstantiable {
     static var storyboardType: Storyboard { return .bottomSheet }
 }

--- a/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetViewController.swift
+++ b/Example/Backpack/View Controllers/Bottom Sheet/BottomSheetViewController.swift
@@ -24,13 +24,14 @@ final class BottomSheetViewController: UITableViewController {
     @IBOutlet var scrollViewBottomSheet: UITableViewCell!
     @IBOutlet var bottomSectionBottomSheet: UITableViewCell!
     @IBOutlet var sheetPresentingSheet: UITableViewCell!
+    @IBOutlet var nonScrollableContentBottomSheet: UITableViewCell!
     
 }
 
 // MARK: - UITableViewDelegate
 extension BottomSheetViewController {
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let rootViewController =  UIApplication.shared.keyWindow?.rootViewController as?
             ThemeContainerController else {
@@ -42,7 +43,7 @@ extension BottomSheetViewController {
         let cell = tableView.cellForRow(at: indexPath)
         switch cell {
         case scrollViewBottomSheet:
-            guard let content = BottomSheetContentViewController.make() else { return }
+            guard let content = BottomSheetScrollableContentViewController.make() else { return }
 
             let wrappedContent = rootViewController.createIdenticalContainerController(forRootController: content)
 
@@ -50,7 +51,7 @@ extension BottomSheetViewController {
                                     scrollViewToTrack: content.tableView)
             sheet.present(in: self, animated: true, completion: nil)
         case bottomSectionBottomSheet:
-            guard let content = BottomSheetContentViewController.make(),
+            guard let content = BottomSheetScrollableContentViewController.make(),
                 let bottomSection = BottomSheetBottomSectionViewController.make() else { return }
 
             let wrappedContent = rootViewController.createIdenticalContainerController(forRootController: content)
@@ -73,7 +74,7 @@ extension BottomSheetViewController {
 
             sheet.present(in: self, animated: true, completion: nil)
         case sheetPresentingSheet:
-            guard let content = BottomSheetContentViewController.make(),
+            guard let content = BottomSheetScrollableContentViewController.make(),
                 let bottomSection = BottomSheetBottomSectionViewController.make() else { return }
 
             let wrappedContent = rootViewController.createIdenticalContainerController(forRootController: content)
@@ -92,15 +93,21 @@ extension BottomSheetViewController {
 
             bottomSection.buttonClickedClosure = {
                 guard let content = BottomSheetContentViewController.make() else { return }
-                content.tableView.accessibilityIdentifier = "SheetPresentingSheet.SecondSheet.tableView"
+                content.view.accessibilityIdentifier = "SheetPresentingSheet.SecondSheet.view"
                 
                 let wrappedContent = rootViewController.createIdenticalContainerController(forRootController: content)
-                let nextSheet = BottomSheet(contentViewController: wrappedContent,
-                                        scrollViewToTrack: content.tableView)
+                let nextSheet = BottomSheet(contentViewController: wrappedContent)
                 sheet.present(nextSheet, animated: true)
             }
             
             sheet.present(in: self, animated: true, completion: nil)
+        case nonScrollableContentBottomSheet:
+            guard let content = BottomSheetContentViewController.make() else { return }
+            
+            let wrappedContent = rootViewController.createIdenticalContainerController(forRootController: content)
+            
+            let sheet = BottomSheet(contentViewController: wrappedContent)
+            sheet.present(in: self, animated: true)
         default: break
         }
     }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,11 @@
 # Unreleased
 > Place your changes below this line.
 
+**Added:**
+
+- Backpack/BottomSheet:
+  - New API for presenting a Bottom Sheet without scrollable content. The height of the bottom sheet will be automatically calculated based on its intrinsic height.
+
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).
 2. Add the package name.


### PR DESCRIPTION
This PR adds an API that allows instantiating and presenting a Bottom Sheet without scrollable content. The height of the bottom sheet will be automatically calculated based on its intrinsic height.

![Screen-Recording-2020-03-09-at-15 57 48](https://user-images.githubusercontent.com/3900360/76226965-e04e7300-621e-11ea-8bba-5e9133bafb70.gif)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
