### PR TITLE
[BPK-3747] Customize horizontal navigation items

### DIFF
--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.h
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.h
@@ -21,26 +21,11 @@
 
 #import <Backpack/Font.h>
 
+#import "BPKHorizontalNavigationSize.h"
 #import "BPKHorizontalNavigationDelegate.h"
+#import "BPKHorizontalNavigationOptionType.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-@class BPKHorizontalNavigationItem;
-@class BPKHorizontalNavigationOption;
-/**
- * Enum values for specifying the navigation size
- */
-typedef NS_ENUM(NSUInteger, BPKHorizontalNavigationSize) {
-    /**
-     * Large, default, size horizontal navigation.
-     */
-    BPKHorizontalNavigationSizeDefault = 0,
-
-    /**
-     * Small size horizontal navigation.
-     */
-    BPKHorizontalNavigationSizeSmall = 1,
-};
 
 /**
  * A `BPKHorizontalNavigation` is a control comprising of multiple segments, where each acts as a discrete button.
@@ -53,9 +38,9 @@ NS_SWIFT_NAME(HorizontalNavigation) IB_DESIGNABLE @interface BPKHorizontalNaviga
 /**
  * The options to display within the navigation.
  *
- * see BPKHorizontalNavigationOption
+ * see BPKHorizontalNavigationOptionType
  */
-@property(nonatomic, copy) NSArray<BPKHorizontalNavigationOption *> *options;
+@property(nonatomic, copy) NSArray<id<BPKHorizontalNavigationOptionType>> *options;
 
 /**
  * The size of the horizontal navigation.
@@ -84,10 +69,10 @@ NS_SWIFT_NAME(HorizontalNavigation) IB_DESIGNABLE @interface BPKHorizontalNaviga
 /**
  * Create a `BPKHorizontalNavigation` with a set of options and an initally selected option.
  *
- * @param options NSArray<NSString> the options available to the useR
- * @param selectedItemIndex NSInteger the initially selected item
+ * @param options NSArray<id<BPKHorizontalNavigationOptionType>> the options displayed.
+ * @param selectedItemIndex NSInteger the initially selected item.
  */
-- (instancetype)initWithOptions:(NSArray<BPKHorizontalNavigationOption *> *)options
+- (instancetype)initWithOptions:(NSArray<id<BPKHorizontalNavigationOptionType>> *)options
                        selected:(NSInteger)selectedItemIndex NS_DESIGNATED_INITIALIZER;
 
 /// :nodoc:

--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationItemDefault.h
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationItemDefault.h
@@ -1,0 +1,65 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2020 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <Backpack/Button.h>
+#import <Backpack/Icon.h>
+
+#import "BPKHorizontalNavigation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class BPKHorizontalNavigationOption;
+NS_SWIFT_NAME(HorizontalNavigationItemDefault) IB_DESIGNABLE @interface BPKHorizontalNavigationItemDefault : UIButton<BPKHorizontalNavigationItem>
+
+@property(nullable, nonatomic, strong) UIColor *selectedColor UI_APPEARANCE_SELECTOR;
+
+/**
+ * The size of the horizontal navigation.
+ *
+ * see BPKHorizontalNavigationSize
+ */
+@property(nonatomic) BPKHorizontalNavigationSize size;
+
+/**
+ * The icon to display within the item.
+ *
+ * see BPKIconName
+ */
+@property(nonatomic, strong, nullable) BPKIconName iconName;
+
+/**
+ * The name to display within the item.
+ */
+@property(nonatomic, copy) NSString *name;
+
+/**
+ * Create a `BPKHorizontalNavigationItem` with a set of options and an optionaly selected option.
+ *
+ * @param name NSString the name for the navigation item
+ * @param iconName BPKIconName the icon for the navigation item
+ */
+- (instancetype)initWithName:(NSString *)name iconName:(BPKIconName)iconName NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithFrame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithSize:(BPKButtonSize)size style:(BPKButtonStyle)style NS_UNAVAILABLE;
+
+@end
+NS_ASSUME_NONNULL_END

--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationItemDefault.m
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationItemDefault.m
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#import "BPKHorizontalNavigationItem.h"
+#import "BPKHorizontalNavigationItemDefault.h"
 
 #import <Backpack/Color.h>
 #import <Backpack/Common.h>
@@ -27,7 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BPKHorizontalNavigationItem ()
+@interface BPKHorizontalNavigationItemDefault ()
 
 @property(readonly) UIColor *contentColor;
 @property(nonatomic) CGFloat horizontalSpacing;
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation BPKHorizontalNavigationItem
+@implementation BPKHorizontalNavigationItemDefault
 
 - (instancetype)initWithName:(NSString *)name iconName:(BPKIconName)iconName {
     BPKAssertMainThread();

--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOption.h
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOption.h
@@ -20,6 +20,8 @@
 
 #import <Backpack/Icon.h>
 
+#import "BPKHorizontalNavigationOptionType.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -27,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Can be configured to show an optional icon, always includes a name.
  */
-@interface BPKHorizontalNavigationOption : NSObject
+@interface BPKHorizontalNavigationOption : NSObject<BPKHorizontalNavigationOptionType>
 
 /**
  * Name of the optional icon used in the option.

--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOption.m
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOption.m
@@ -17,6 +17,8 @@
  */
 #import "BPKHorizontalNavigationOption.h"
 
+#import "BPKHorizontalNavigationItemDefault.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BPKHorizontalNavigationOption ()
@@ -82,6 +84,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqual:(BPKHorizontalNavigationOption *)other {
     return self.tag == other.tag && [self.name isEqualToString:other.name] &&
            [(self.iconName ?: @"") isEqualToString:(other.iconName ?: @"")];
+}
+
+- (UIControl *)makeItem {
+    return [[BPKHorizontalNavigationItemDefault alloc] initWithName:self.name iconName:self.iconName];
 }
 
 @end

--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOptionType.h
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationOptionType.h
@@ -1,0 +1,51 @@
+/*
+* Backpack - Skyscanner's Design System
+*
+* Copyright 2018-2020 Skyscanner Ltd
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import <Foundation/Foundation.h>
+
+#import "BPKHorizontalNavigationItem.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Represents a single navigation option in `BPKHorizontalNavigation`.
+ * For common use cases `BPKHorizontalNavigationOption` is provided but
+ * by implementing a custom type that conform to this protocol you can
+ * implement custom navigation items.
+ *
+ * @see BPKHorizontalNavigationItem
+ * @see BPKHorizontalNavigationOption
+ */
+@protocol BPKHorizontalNavigationOptionType <NSObject>
+@required
+
+/**
+ * A tag representing the option, can be used to distinguish options from
+ * eachother.
+ */
+@property(nonatomic, readonly) NSInteger tag;
+
+/**
+ * Creates a `UIControl` sublcass to use for rendering this item
+ * in a `BPKHorizontalNavigation`. In addition to being a `UIControl`
+ * subclass it should implement the `BPKHorizontalNavigationItem` protocol.
+ */
+- (UIControl<BPKHorizontalNavigationItem> *)makeItem;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationSize.h
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigationSize.h
@@ -16,32 +16,22 @@
 * limitations under the License.
 */
 
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
-
-#import "BPKHorizontalNavigationSize.h"
-
-
-NS_ASSUME_NONNULL_BEGIN
-
-@protocol BPKHorizontalNavigationItem
-@required
+#ifndef BPK_HORIZONTAL_NAVIGATION_SIZE_H
+#define BPK_HORIZONTAL_NAVIGATION_SIZE_H
 
 /**
- * The size of the horizontal navigation.
- *
- * see BPKHorizontalNavigationSize
+ * Enum values for specifying the navigation size
  */
-@property(nonatomic, assign) BPKHorizontalNavigationSize size;
+typedef NS_ENUM(NSUInteger, BPKHorizontalNavigationSize) {
+    /**
+     * Large, default, size horizontal navigation.
+     */
+    BPKHorizontalNavigationSizeDefault = 0,
 
-/**
- * The selected colour to use.
- *
- * This colour should be used to change the UI to make it clear
- * that the item is selected.
- */
-@property(nonatomic, nullable, strong) UIColor *selectedColor;
+    /**
+     * Small size horizontal navigation.
+     */
+    BPKHorizontalNavigationSizeSmall = 1,
+};
 
-@end
-
-NS_ASSUME_NONNULL_END
+#endif /* BPK_HORIZONTAL_NAVIGATION_SIZE_H */

--- a/Backpack/HorizontalNavigation/Classes/HorizontalNavigation.h
+++ b/Backpack/HorizontalNavigation/Classes/HorizontalNavigation.h
@@ -21,5 +21,7 @@
 #import "BPKHorizontalNavigation.h"
 #import "BPKHorizontalNavigationDelegate.h"
 #import "BPKHorizontalNavigationOption.h"
+#import "BPKHorizontalNavigationOptionType.h"
+#import "BPKHorizontalNavigationSize.h"
 
 #endif

--- a/Backpack/HorizontalNavigation/README.md
+++ b/Backpack/HorizontalNavigation/README.md
@@ -33,6 +33,9 @@ let horizontalNavigation = Backpack.HorizontalNavigation(options: options, selec
 horizontalNavigation.showsSelectedBar = false
 ```
 
+## Custom Horizontal Navigation Segments
+
+Horizontal Navigation can use custom segments. To achieve this, implement a custom type that conforms to `BPKHorizontalNavigationOptionType` and return your own view (a subclass of `UIControl` that implements the protocol `BPKHorizontalNavigationItem`) for `makeItem`. Ensure the height of your view is similar to that of those rendered when `BPKHorizontalNavigationOption` is used directly for all the sizes that the component supports.
+
 ### Appearance attributes
 `(UIColor)contentColor`
-

--- a/Example/Tests/BPKHorizontalNavigationTest.m
+++ b/Example/Tests/BPKHorizontalNavigationTest.m
@@ -35,10 +35,12 @@ NS_ASSUME_NONNULL_BEGIN
     ]
                                                                                             selected:0];
 
+    // This cast is safe because we know the underlying type
+    NSArray<BPKHorizontalNavigationOption *> *options = (NSArray<BPKHorizontalNavigationOption *> *)horizontalNavigation.options;
     XCTAssertEqual(horizontalNavigation.selectedItemIndex, 0);
-    XCTAssertEqual(horizontalNavigation.options[0].name, @"Flights");
-    XCTAssertEqual(horizontalNavigation.options[1].name, @"Hotels");
-    XCTAssertEqual(horizontalNavigation.options[2].name, @"Car hire");
+    XCTAssertEqual(options[0].name, @"Flights");
+    XCTAssertEqual(options[1].name, @"Hotels");
+    XCTAssertEqual(options[2].name, @"Car hire");
     XCTAssertEqual(horizontalNavigation.options[0].tag, 0);
     XCTAssertEqual(horizontalNavigation.options[1].tag, 1);
     XCTAssertEqual(horizontalNavigation.options[2].tag, 2);
@@ -51,11 +53,12 @@ NS_ASSUME_NONNULL_BEGIN
         [[BPKHorizontalNavigationOption alloc] initWithName:@"Car hire" tag:2]
     ]
                                                                                             selected:2];
-
+    // This cast is safe because we know the underlying type
+    NSArray<BPKHorizontalNavigationOption *> *options = (NSArray<BPKHorizontalNavigationOption *> *)horizontalNavigation.options;
     XCTAssertEqual(horizontalNavigation.selectedItemIndex, 2);
-    XCTAssertEqual(horizontalNavigation.options[0].name, @"Flights");
-    XCTAssertEqual(horizontalNavigation.options[1].name, @"Hotels");
-    XCTAssertEqual(horizontalNavigation.options[2].name, @"Car hire");
+    XCTAssertEqual(options[0].name, @"Flights");
+    XCTAssertEqual(options[1].name, @"Hotels");
+    XCTAssertEqual(options[2].name, @"Car hire");
 }
 
 - (void)testSetSelectedIndex {
@@ -68,10 +71,12 @@ NS_ASSUME_NONNULL_BEGIN
 
     horizontalNavigation.selectedItemIndex = 1;
 
+    // This cast is safe because we know the underlying type
+    NSArray<BPKHorizontalNavigationOption *> *options = (NSArray<BPKHorizontalNavigationOption *> *)horizontalNavigation.options;
     XCTAssertEqual(horizontalNavigation.selectedItemIndex, 1);
-    XCTAssertEqual(horizontalNavigation.options[0].name, @"Flights");
-    XCTAssertEqual(horizontalNavigation.options[1].name, @"Hotels");
-    XCTAssertEqual(horizontalNavigation.options[2].name, @"Car hire");
+    XCTAssertEqual(options[0].name, @"Flights");
+    XCTAssertEqual(options[1].name, @"Hotels");
+    XCTAssertEqual(options[2].name, @"Car hire");
 }
 
 - (void)testSetOptions {
@@ -89,10 +94,12 @@ NS_ASSUME_NONNULL_BEGIN
         [[BPKHorizontalNavigationOption alloc] initWithName:@"Car hire 2" tag:5]
     ];
 
+    // This cast is safe because we know the underlying type
+    NSArray<BPKHorizontalNavigationOption *> *options = (NSArray<BPKHorizontalNavigationOption *> *)horizontalNavigation.options;
     XCTAssertEqual(horizontalNavigation.selectedItemIndex, 0);
-    XCTAssertEqual(horizontalNavigation.options[0].name, @"Flights 2");
-    XCTAssertEqual(horizontalNavigation.options[1].name, @"Hotels 2");
-    XCTAssertEqual(horizontalNavigation.options[2].name, @"Car hire 2");
+    XCTAssertEqual(options[0].name, @"Flights 2");
+    XCTAssertEqual(options[1].name, @"Hotels 2");
+    XCTAssertEqual(options[2].name, @"Car hire 2");
     XCTAssertEqual(horizontalNavigation.options[0].tag, 3);
     XCTAssertEqual(horizontalNavigation.options[1].tag, 4);
     XCTAssertEqual(horizontalNavigation.options[2].tag, 5);

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,17 @@
 # Unreleased
 > Place your changes below this line.
 
+**Breaking:**
+
+- Backpack/HorizontalNavigation
+  - `options` on `BPKHorizontalNavigation` is now an `NSArray<id<BPKHorizontalNavigationOptionType>> *` was previously `NSArray<BPKHorizontalNavigationOption *> *`.
+  - `initWithOptions:selected:` on `BPKHorizontalNavigation` now takes `NSArray<id<BPKHorizontalNavigationOptionType>> *` as its first argument rather than `NSArray<BPKHorizontalNavigationOption *> *`.
+
+**Added:**
+
+- Backpack/HorizontalNavigation
+  - Via `makeItem` in `BPKHorizontalNavigationOptionType` it's possible to provide custom rendering for the items in the horizontal navigation.
+
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).
 2. Add the package name.


### PR DESCRIPTION
Here's the suggested evolution to the current `BPKHorizontalNavigation`
API. It ends up being a breaking change unfortunately but I think in
practice no one relies on the aspects that will break, mainly the change
in type of `options`.

## Badge Example

To implement the new badge type we'd create a new option type
`BPKHorizontalNavigationOptionBadge` which adopts the
`BPKHorizontalNavigationOptionType` protocol and returns a new
`UIControl` subclass, `BPKHorizontalNavigationItemWithBadge` from `makeItem`.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)