### PR TITLE
[NO-JIRA] Fix Calendar snapping issue

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -178,6 +178,7 @@ NSString *const HeaderDateFormat = @"MMMM";
     CGRect bounds = self.bounds;
     CGFloat width = CGRectGetWidth(bounds);
     CGFloat height = CGRectGetHeight(bounds);
+    CGFloat calendarWidth = CGRectGetWidth(self.calendarView.frame);
     CGFloat weekdayViewHeight = 6 * BPKSpacingMd;
 
     self.calendarView.frame =
@@ -192,7 +193,9 @@ NSString *const HeaderDateFormat = @"MMMM";
         CGRectMake(width / 2.0 - yearPillWidth / 2.0, CGRectGetHeight(self.calendarWeekdayView.frame) + BPKSpacingLg,
                    yearPillWidth, yearPillHeight);
 
-    [self.calendarView.collectionViewLayout invalidateLayout];
+    if (calendarWidth != CGRectGetWidth(self.calendarView.frame)) {
+        [self.calendarView.collectionViewLayout invalidateLayout];
+    }
 }
 
 #pragma mark - property getters/setters

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -193,7 +193,7 @@ NSString *const HeaderDateFormat = @"MMMM";
         CGRectMake(width / 2.0 - yearPillWidth / 2.0, CGRectGetHeight(self.calendarWeekdayView.frame) + BPKSpacingLg,
                    yearPillWidth, yearPillHeight);
 
-    if (calendarWidth != CGRectGetWidth(self.calendarView.frame)) {
+    if (fabs(calendarWidth - CGRectGetWidth(self.calendarView.frame)) > 0.1) {
         [self.calendarView.collectionViewLayout invalidateLayout];
     }
 }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,11 @@
 - Backpack/HorizontalNavigation
   - Via `makeItem` in `BPKHorizontalNavigationOptionType` it's possible to provide custom rendering for the items in the horizontal navigation.
 
+**Fixed:**
+
+- Backpack/Calendar
+  - Calendar now doesn't snap to month name anymore when its height changes.
+
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).
 2. Add the package name.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,7 +15,7 @@
 **Fixed:**
 
 - Backpack/Calendar
-  - Calendar now doesn't snap to month name anymore when its height changes.
+  - Calendar now doesn't snap to month name when its height changes.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
This change fixes an issue of Calendar snapping to the closes month header whenever its height changes. The [previous fix](https://github.com/Skyscanner/backpack-ios/pull/218) is only needed when the calendar's width changes, so this fix won't break it.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
