### PR TITLE
[NO-JIRA]: Make Calendar contentOffset mutable

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -206,7 +206,7 @@ NS_SWIFT_NAME(Calendar) @interface BPKCalendar : UIView
 /**
  * The underlying scrollView's content offset
  */
-@property(readonly, assign) CGPoint contentOffset;
+@property(nonatomic, assign) CGPoint contentOffset;
 
 /**
  * The underlying scrollView's content inset

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -220,6 +220,10 @@ NSString *const HeaderDateFormat = @"MMMM";
     }
 }
 
+- (void)setContentOffset:(CGPoint)contentOffset {
+    self.calendarView.collectionView.contentOffset = contentOffset;
+}
+
 - (NSArray<BPKSimpleDate *> *)selectedDates {
     if (self.sameDayRange) {
         NSArray<NSDate *> *dates =

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,8 @@
 
 - Backpack/HorizontalNavigation
   - Via `makeItem` in `BPKHorizontalNavigationOptionType` it's possible to provide custom rendering for the items in the horizontal navigation.
+- Backpack/Calendar
+  - Via `contentOffset` in `BPKCalendar` it's possible to modify the underlying collection view's content offset.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
This change makes it possible to modify the calendar's underlying collectionView's contentOffset.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
