### PR TITLE
[NO-JIRA] Fix HorizontalNavigation color and size setting bug

### DIFF
--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.m
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.m
@@ -274,6 +274,10 @@ NS_ASSUME_NONNULL_BEGIN
     for (id<BPKHorizontalNavigationOptionType> option in self.options) {
         UIControl<BPKHorizontalNavigationItem> *newItem = [self createHorizontalNavigationItemWithDefinition:option];
         [newItem addTarget:self action:@selector(updateSelection:) forControlEvents:UIControlEventTouchUpInside];
+        if (self.selectedColor != nil) {
+            newItem.selectedColor = self.selectedColor;
+        }
+        newItem.size = self.size;
         [self.stackView addArrangedSubview:newItem];
     }
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,10 @@
 # Unreleased
 > Place your changes below this line.
 
+**Fixed:**
+
+- Backpack/HorizontalNavigation
+  - HorizontalNavigation now applies its color and size to changed options.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
Fix a bug where if you set color or size first and then modify navigation options, they will not apply to the new options.

When navigation options change it creates new objects for the new options, but didn't set the correct color and size to these options.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
