### PR TITLE
Fix BPKCalendar date selection crash

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -267,9 +267,7 @@ NSString *const HeaderDateFormat = @"MMMM";
         [self.calendarView deselectDate:[date dateForCalendar:self.gregorian]];
     }
 
-    if (selectedDates.count == 2 && [selectedDates.firstObject isEqual:selectedDates.lastObject]) {
-        self.sameDayRange = YES;
-    }
+    self.sameDayRange = selectedDates.count == 2 && [selectedDates.firstObject isEqual:selectedDates.lastObject];
 }
 
 #pragma mark - public methods

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,9 @@
 # Unreleased
 > Place your changes below this line.
+**Fixed:**
+
+- Backpack/Calendar:
+  - Fixed an issue where setting an empty date selection after same day selection would crash the calendar.
 
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
Fixed an issue when Calendar crashed after these steps:

- Same day is selected, therefore `self.sameDayRange` gets true.
- Selection gets cleared by setting an empty array to `self.selectedDates`, but `self.sameDayRange` remain true because it's not set in line 271
- When `selectedDates` gets called it crashes at line 233 because it tries to add `selectedDates.firstObject` (which has a `nil` value because an empty array was set in the previous step) to an array.

Fixed the issue by setting `self.sameDayRange` to false as well in line 271.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
