### PR TITLE
[No Jira] Bump tests to run on iOS 13.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ cache:
     - node_modules
 matrix:
   include:
-    - osx_image: xcode11.3
+    - osx_image: xcode11.5
       env: BUILD_SDK=iphonesimulator13.5 DESTINATION="OS=13.5,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="true" MAIN_STAGE="true"
-    - osx_image: xcode11.3
+    - osx_image: xcode11.5
       env: BUILD_SDK=iphonesimulator13.5 DESTINATION="OS=12.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
 before_install:
   - sudo sntp -sS time.apple.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ cache:
 matrix:
   include:
     - osx_image: xcode11.3
-      env: BUILD_SDK=iphonesimulator13.2 DESTINATION="OS=13.3,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="true" MAIN_STAGE="true"
+      env: BUILD_SDK=iphonesimulator13.5 DESTINATION="OS=13.5,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="true" MAIN_STAGE="true"
     - osx_image: xcode11.3
-      env: BUILD_SDK=iphonesimulator13.2 DESTINATION="OS=12.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
+      env: BUILD_SDK=iphonesimulator13.5 DESTINATION="OS=12.4,platform=iOS Simulator,name=iPhone 8" FULL_TESTS="false" MAIN_STAGE="false"
 before_install:
   - sudo sntp -sS time.apple.com
   - brew install clang-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 [Unreleased changes](./UNRELEASED.md).
 
+# 33.0.0
+
+**Breaking:**
+  - The minimum deployment target is now iOS 12.0 (previously iOS 11.0).
+
 # 32.3.1
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 
 [Unreleased changes](./UNRELEASED.md).
 
-# 33.0.0
-
-**Breaking:**
-  - The minimum deployment target is now iOS 12.0 (previously iOS 11.0).
-
 # 32.3.1
 
 **Fixed:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,11 @@ If you don't work for Skyscanner don't worry - the Example app will still work j
 
 ## Testing
 
-Tests can be ran as usual from Xcode(Product -> Test or cmd+U). Snapshot tests should be run on an iPhone 8 running iOS 13.3 to match what is used on CI.
+Tests can be ran as usual from Xcode(Product -> Test or cmd+U). Snapshot tests should be run on an iPhone 8 running iOS 13.5 to match what is used on CI.
 
 ### Snapshot testing
 
-Snapshot tests are used to capture images of components under different configurations. When you add or change a snapshot test, test images will need to be recaptured. To do this, change `self.recordMode = NO` to `self.recordMode = YES` in the relevant test file and re-run the tests on an iPhone 8 running iOS 13.3. This will update the images on disk. Remember to revert `recordMode` afterwards otherwise the tests will fail.
+Snapshot tests are used to capture images of components under different configurations. When you add or change a snapshot test, test images will need to be recaptured. To do this, change `self.recordMode = NO` to `self.recordMode = YES` in the relevant test file and re-run the tests on an iPhone 8 running iOS 13.5. This will update the images on disk. Remember to revert `recordMode` afterwards otherwise the tests will fail.
 
 ## Git
 

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -1691,7 +1691,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Backpack Screenshot/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1720,7 +1720,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Backpack Screenshot/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;

--- a/Example/SnapshotTests/BPKSnapshotTest.h
+++ b/Example/SnapshotTests/BPKSnapshotTest.h
@@ -23,11 +23,11 @@
         if (deviceOSVersion.majorVersion != 13.0) {                                                                    \
             validDevice = NO;                                                                                          \
         }                                                                                                              \
-        if (deviceOSVersion.minorVersion != 3.0) {                                                                     \
+        if (deviceOSVersion.minorVersion != 5.0) {                                                                     \
             validDevice = NO;                                                                                          \
         }                                                                                                              \
                                                                                                                        \
-        XCTAssertTrue(validDevice, @"Snapshot tests are only valid when testing on an iPhone 8 running iOS 13.3");     \
+        XCTAssertTrue(validDevice, @"Snapshot tests are only valid when testing on an iPhone 8 running iOS 13.5");     \
     }
 
 #if __BPK_DARK_MODE_SUPPORTED

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'semver'
 
 FULL_TESTS = ENV['FULL_TESTS'] != 'false'
-BUILD_SDK = ENV['BUILD_SDK'] || 'iphonesimulator13.2'
+BUILD_SDK = ENV['BUILD_SDK'] || 'iphonesimulator13.5'
 TEST_DEVICE_NAME = ENV['TEST_DEVICE_NAME'] || 'iPhone 8'
 DESTINATION = ENV['DESTINATION'] || 'platform=iOS Simulator,name=iPhone 8'
 EXAMPLE_WORKSPACE = 'Example/Backpack.xcworkspace'

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,9 +1,6 @@
 # Unreleased
 > Place your changes below this line.
 
-**Breaking:**
-  - Bumped deployment target to iOS 12.0.
-
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).
 2. Add the package name.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,9 @@
 # Unreleased
 > Place your changes below this line.
 
+**Breaking:**
+  - The minimum deployment target is now iOS 12.0 (previously iOS 11.0).
+
 ## How to write a good changelog entry
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).
 2. Add the package name.


### PR DESCRIPTION
Snapshots tests pass now. This is a precursor to releasing the new iOS 12 deployment target.