### PR TITLE
[BPK-4180] Allow custom UITabBar for BPKTabBarController

### DIFF
--- a/Backpack/TabBarController/Classes/BPKTabBarController.h
+++ b/Backpack/TabBarController/Classes/BPKTabBarController.h
@@ -26,6 +26,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 IB_DESIGNABLE @interface BPKTabBarController : UITabBarController
 
+/**
+*  Creates a new BPKTabBarController instance with a custom UITabBar
+*
+*  @param tabBar Custom UITabBar instance to be used as the default tabBar
+*/
+- (instancetype)initWithTabBar:(UITabBar *)tabBar;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/TabBarController/Classes/BPKTabBarController.m
+++ b/Backpack/TabBarController/Classes/BPKTabBarController.m
@@ -29,8 +29,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface BPKTabBarController ()
+@property (nonatomic, strong) UITabBar *customTabBar;
+@end
+
 @implementation BPKTabBarController
+
+- (instancetype)initWithTabBar:(UITabBar *)tabBar {
+    if (self = [super init]) {
+        self.customTabBar = tabBar;
+    }
+
+    return self;
+}
+
+- (UITabBar *)tabBar {
+    if (!_customTabBar) {
+        _customTabBar = [[UITabBar alloc] init];
+    }
+
+    return _customTabBar;
+}
 
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/Example/Tests/BPKTabBarControllerTest.m
+++ b/Example/Tests/BPKTabBarControllerTest.m
@@ -34,6 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
     XCTAssertTrue([tabBarController isKindOfClass:UITabBarController.class], "BPKTabBarController should be a subclass of UITabBarController");
 }
 
+- (void)testUITabBarControllerWithCustomUITabBar {
+    UITabBar *customTabBar = [[UITabBar alloc] init];
+    BPKTabBarController *tabBarController = [[BPKTabBarController alloc] initWithTabBar:customTabBar];
+
+    XCTAssertTrue(tabBarController.tabBar == customTabBar, "tabBarController.tabBar should be the same instance injected through the initializer");
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Added:**
+
+- Backpack/BPKTabBarController:
+  - New initialiser to inject a custom UITabBar instance.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
https://gojira.skyscanner.net/browse/BPK-4180

We need to keep using [this subclass of UITabBar](https://github.skyscannertools.net/apps-tribe/skyscanner-app/blob/79afba3651f2c672e29fd1a3c180dafc2dc30c42/ios/Modules/Skyscanner.UICore/Headers/SkyUICore/SKYTabBar.h#L4) for the Native Navigation Roadmap, in order to do so, we need to add the capability to inject a custom UITabBar into our BPKTabBarController component.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
