### PR TITLE
[NO-JIRA] Exclude RN tokens from gulp token generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,6 +55,8 @@ const VALID_TEXT_STYLES = new Set([
 ]);
 const VALID_SHADOWS = new Set(['sm', 'lg']);
 const VALID_SPACINGS = new Set(['none', 'sm', 'md', 'base', 'lg', 'xl', 'xxl']);
+const VALID_RADII = new Set(['xs', 'sm', 'md', 'lg', 'pill']);
+const VALID_BORDER_WIDTHS = new Set(['sm', 'lg', 'xl']);
 const WEIGHT_MAP = {
   normal: 'UIFontWeightRegular',
   bold: 'UIFontWeightBold',
@@ -421,6 +423,9 @@ const parseTokens = tokensData => {
 
   const radii = _.chain(tokensData.properties)
     .filter(({ category }) => category === 'radii')
+    .filter(({ name }) =>
+      VALID_RADII.has(name.replace('cornerRadius', '').toLowerCase()),
+    )
     .map(({ name, value }) =>
       generatePrefixedConst({
         type: 'radii',
@@ -433,6 +438,9 @@ const parseTokens = tokensData => {
 
   const borderWidths = _.chain(tokensData.properties)
     .filter(({ category }) => category === 'borders')
+    .filter(({ name }) =>
+      VALID_BORDER_WIDTHS.has(name.replace('borderWidth', '').toLowerCase()),
+    )
     .map(({ name, value }) =>
       generatePrefixedConst({
         type: 'borders',


### PR DESCRIPTION
Related to https://github.com/Skyscanner/backpack/pull/2006.

Once those tokens are reinstated, this change will ensure we're still generating and exposing the same set in Objective-C.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
