### PR TITLE
[BPK-4256] save snapshots on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
         run: bundle exec rake ci
         working-directory: Example
 
+      - name: Save assets
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: FailureDiffs
+          path: Example/BackpackTests/FailureDiffs
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: steps.extract_git_tag.outputs.GIT_TAG != ''


### PR DESCRIPTION
https://github.com/Skyscanner/backpack-ios/runs/1299369560?check_suite_focus=true

If the tests fail...
![Screenshot 2020-10-23 at 19 34 02](https://user-images.githubusercontent.com/30267516/97041065-d5a2dd00-1566-11eb-8afb-63368c97954f.png)

An asset is created...
![Screenshot 2020-10-23 at 19 34 05](https://user-images.githubusercontent.com/30267516/97041085-dcc9eb00-1566-11eb-97e1-1996c686a997.png)

Containing the failed snapshots...
![Screenshot 2020-10-23 at 19 34 25](https://user-images.githubusercontent.com/30267516/97041093-e18e9f00-1566-11eb-962f-f5d84cf01057.png)
