### PR TITLE
[NO-JIRA] Deploy tagged docs from any ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/head/master' && steps.extract_git_tag.outputs.GIT_TAG != ''
+        if: steps.extract_git_tag.outputs.GIT_TAG != ''
         with:
           personal_token: ${{ secrets.IOS_DOCS_DEPLOY_TOKEN }}
           publish_dir: docs/


### PR DESCRIPTION
When there is a tag, the branch is the tag. So having both these checks results in an always-falsy check.

![Screenshot 2020-10-23 at 13 52 06](https://user-images.githubusercontent.com/30267516/97035144-cf5c3300-155d-11eb-9456-cd22127faab9.png)

![Screenshot 2020-10-23 at 18 28 18](https://user-images.githubusercontent.com/30267516/97035150-d08d6000-155d-11eb-817d-b0033662e122.png)
