### PR TITLE
[BPK-4344] Upgrade FSCalendar to 2.8.2

### DIFF
--- a/Backpack.podspec
+++ b/Backpack.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
     'Icon' => 'Backpack/Icon/Assets/*'
   }
   s.dependency 'FloatingPanel', '1.6.6'
-  s.dependency 'FSCalendar', '~> 2.8'
+  s.dependency 'FSCalendar', '~> 2.8.2'
   s.dependency 'TTTAttributedLabel', '~> 1.13.4'
   s.dependency 'MBProgressHUD', '~> 1.2.0'
   s.frameworks = 'UIKit', 'Foundation', 'CoreText'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
     - AppCenter/Core
   - Backpack (40.0.0):
     - FloatingPanel (= 1.6.6)
-    - FSCalendar (~> 2.8)
+    - FSCalendar (~> 2.8.2)
     - MBProgressHUD (~> 1.2.0)
     - TTTAttributedLabel (~> 1.13.4)
   - FloatingPanel (1.6.6)
@@ -47,7 +47,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppCenter: 513d32888854d67d8cfbd3a8db16aeb5fb2e2a75
-  Backpack: 6968b2abee53fa09ded5b90563bf5cd05ab42e41
+  Backpack: f7c09d7477b88f58743df9ad5b799cc5e75adf2d
   FloatingPanel: 5fe605e073e60395bc4bb416fd513d0fa38a6558
   FSCalendar: e6a2eb9c571bf0719ed797ef807e08426753c241
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,9 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+ - Upgraded `FSCalendar` to the latest version (2.8.2).
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
No changelog entries: https://github.com/WenchaoD/FSCalendar/blob/master/CHANGELOG.md
All changes: https://github.com/WenchaoD/FSCalendar/compare/2.8.0...2.8.2

Everything seems to work as expected 🤷 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
