### PR TITLE
[BPK-4347] Skip comment if tagged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,13 +172,13 @@ jobs:
   comment_on_pr:
     needs: CI
     name: Comment on PR
-    if: github.ref != 'refs/heads/master'
+    # Only run if there is no tag, and the commit is not on master
+    if: contains('refs/tags/', github.ref) && github.ref != 'refs/heads/master'
     runs-on: ubuntu-20.04
 
     steps:
       - name: Link to the pull request build
         uses: unsplash/comment-on-pr@master
-        if: github.ref != 'refs/heads/master'
         with:
           msg: 'Visit https://backpack.github.io/ios-prs/${{ env.PR_NUMBER }} to see the docs for this PR.'
         env:


### PR DESCRIPTION
When we do a release, two CI jobs run. One for the push to master, and one for the push to the tag (because tags are just special branches).
The master run doesn't try to comment on the PR, but the tag one does. I've added an additional check to counter this.