### PR TITLE
[BPK-4342] Parallelise tests

### DIFF
--- a/Example/Backpack.xcodeproj/xcshareddata/xcschemes/Backpack Native.xcscheme
+++ b/Example/Backpack.xcodeproj/xcshareddata/xcschemes/Backpack Native.xcscheme
@@ -43,7 +43,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6003F5AD195388D20070C39A"
@@ -53,7 +54,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D6D81D42213FEE800013BB96"
@@ -63,7 +65,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D6517B3E216DF5F800D85FF9"

--- a/Example/SnapshotTests/BPKSnapshotTest.h
+++ b/Example/SnapshotTests/BPKSnapshotTest.h
@@ -22,7 +22,7 @@
         int correctMinorVersion = 0;                                                                                                                 \
         NSString *deviceName = [[UIDevice currentDevice] name];                                                                                      \
         NSOperatingSystemVersion deviceOSVersion = [[NSProcessInfo processInfo] operatingSystemVersion];                                             \
-        BOOL validDevice = [deviceName isEqual:correctDeviceName];                                                                                   \
+        BOOL validDevice = [deviceName hasSuffix:correctDeviceName];                                                                                   \
         if (deviceOSVersion.majorVersion != correctMajorVersion) {                                                                                   \
             validDevice = NO;                                                                                                                        \
         }                                                                                                                                            \


### PR DESCRIPTION
Turns out the way XCode handles concurrent tests is to just boot multiple clones of the simulator, so there are no concurrency issues in our code 🙌

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
