### PR TITLE
[BPK-4359] Improve calendar dark-mode range color

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendarCell.m
+++ b/Backpack/Calendar/Classes/BPKCalendarCell.m
@@ -159,7 +159,7 @@ const CGFloat BPKCalendarCellSameDayXOffset = 3.75;
 - (void)configureAppearance {
     [super configureAppearance];
 
-    UIColor *rangeColor = [BPKColor blend:self.appearance.selectionColor with:BPKColor.backgroundColor weight:0.3];
+    UIColor *rangeColor = [BPKColor blend:self.appearance.selectionColor with:BPKColor.backgroundAlternativeSecondaryColor weight:0.3];
     UIColor *selectedColor = self.preferredTitleSelectionColor ?: self.appearance.titleColors[@(FSCalendarCellStateSelected)];
     UIColor *color = self.preferredTitleDefaultColor ?: [self colorForCurrentStateInDictionary:self.appearance.titleColors];
 

--- a/Example/Backpack/NavigationData.swift
+++ b/Example/Backpack/NavigationData.swift
@@ -45,6 +45,7 @@ class NavigationData: NSObject {
         case withMaxEnabledDate
         case withCustomStyles
         case withPrices
+        case alternativeBackgroundColor
     }
 
     static func setCalendarProperties(story: CalendarStory) -> (UIViewController) -> Void {
@@ -62,6 +63,8 @@ class NavigationData: NSObject {
                 calendarVC.customStylesForDates = true
             case .withPrices:
                 calendarVC.showPrices = true
+            case .alternativeBackgroundColor:
+                calendarVC.alternativeBackgroundColor = true
             }
         }
     }
@@ -112,6 +115,7 @@ class NavigationData: NSObject {
                 Item(name: "With max enabled date", value: .story(calendarStoryboard(story: .withMaxEnabledDate)))
                 Item(name: "Custom styles for specific dates", value: .story(calendarStoryboard(story: .withCustomStyles)))
                 Item(name: "With prices", value: .story(calendarStoryboard(story: .withPrices)))
+                Item(name: "With alternative background color", value: .story(calendarStoryboard(story: .alternativeBackgroundColor)))
             }
             Item(name: "Cards", value: .story(loadStoryboard(name: "Cards", identifier: "CardsViewController")))
             Item(name: "Flare views", value: .story(loadStoryboard(name: "FlareView", identifier: "FlareViewViewController")))

--- a/Example/Backpack/ViewControllers/CalendarViewController.swift
+++ b/Example/Backpack/ViewControllers/CalendarViewController.swift
@@ -25,6 +25,7 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
     var maxEnabledDate: Bool = false
     var customStylesForDates = false
     var showPrices = false
+    var alternativeBackgroundColor = false
     var currentMaxEnabledDate: Date?
     var calendar = BPKCalendar()
     @IBOutlet weak var myView: UIView!
@@ -50,6 +51,10 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
         calendar.minDate = BPKSimpleDate(date: Date(), for: calendar.gregorian)
         calendar.locale = Locale.current
         calendar.delegate = self
+        if alternativeBackgroundColor {
+            view.backgroundColor = BPKColor.backgroundSecondaryColor
+            myView.backgroundColor = BPKColor.backgroundSecondaryColor
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,7 +5,7 @@
 **Fixed:**
 
 - Backpack/Calendar:
-  - Fixed the range background colour so that it is more visible on dark-mode backgrounds.
+  - Fixed the range background colour so that it is more visible on dark mode backgrounds.
 
 ## How to write a good changelog entry
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- Backpack/Calendar:
+  - Fixed the range background colour so that it is more visible on dark-mode backgrounds.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

Before:
![Simulator Screen Shot - iPhone 8 - 2021-01-19 at 15 21 20](https://user-images.githubusercontent.com/30267516/105054512-01503900-5a6a-11eb-9e3f-7702787e2f72.png)

After:
![Simulator Screen Shot - iPhone 8 - 2021-01-19 at 15 20 56](https://user-images.githubusercontent.com/30267516/105054519-0319fc80-5a6a-11eb-9f9e-550acdc11f3e.png)

