### PR TITLE
[NO-JIRA] Add option to customize bottom sheet insets

### DIFF
--- a/Backpack/BottomSheet/Classes/BottomSheet.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheet.swift
@@ -62,6 +62,7 @@ public final class BPKBottomSheet: NSObject {
     }
 
     private let presentationStyle: PresentationStyle
+    private let insets: BottomSheetInsets
 
     private lazy var floatingPanelController: BPKFloatingPanelController = {
         var panel = BPKFloatingPanelController(delegate: self)
@@ -91,7 +92,7 @@ public final class BPKBottomSheet: NSObject {
 
     private var scrollView: UIScrollView?
 
-    /// Instantiates a `BPKBottomSheet` with a scrollable content. Default initial height is 386pt and can't be changed.
+    /// Instantiates a `BPKBottomSheet` with a scrollable content. Default initial height is 386pt and can be changed with the insets parameter..
     /// Optionally, an always visible bottom section can be added.
     ///
     /// - Parameters:
@@ -104,14 +105,18 @@ public final class BPKBottomSheet: NSObject {
     ///     that should be accessible at all times. A top shadow is automatically added so that
     ///     it integrates better with the content of the bottom sheet.
     ///     Note: Safe Area should be taken into account in the bottom section's inner constraints.
-    ///   - presentationStyle: .modal if you nedd a modal interaction with the BottomSheet. .persistent if
+    ///   - presentationStyle: .modal if you need a modal interaction with the BottomSheet. .persistent if
     ///     you need a persistent BottomSheet and being able to interact with what is behind the BottomSheet
+    ///   - insets: The spacing used when the bottom sheet is presented at various heifghts.
+    ///     The .modal presentation style will only use `half` and ignore all other insets provided.
     
     public init(contentViewController: UIViewController,
                 scrollViewToTrack: UIScrollView,
                 bottomSectionViewController: UIViewController? = nil,
-                presentationStyle: PresentationStyle = .modal) {
+                presentationStyle: PresentationStyle = .modal,
+                insets: BottomSheetInsets = .init()) {
         self.presentationStyle = presentationStyle
+        self.insets = insets
         super.init()
 
         self.scrollView = scrollViewToTrack
@@ -128,6 +133,7 @@ public final class BPKBottomSheet: NSObject {
     /// - Parameter contentViewController: Content of the bottom sheet.
     public init(contentViewController: UIViewController) {
         self.presentationStyle = .modal
+        self.insets = .init()
         super.init()
         floatingPanelController.contentViewController = contentViewController
     }
@@ -217,9 +223,9 @@ extension BPKBottomSheet: FloatingPanelControllerDelegate {
                               layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
         switch self.presentationStyle {
         case .modal:
-            return scrollView == nil ? IntrinsicLayout() : ModalBottomSheetLayout()
+            return scrollView == nil ? IntrinsicLayout() : ModalBottomSheetLayout(insets: insets)
         case .persistent:
-            return PersistentBottomSheetLayout()
+            return PersistentBottomSheetLayout(insets: insets)
         }
     }
 }

--- a/Backpack/BottomSheet/Classes/BottomSheet.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheet.swift
@@ -107,7 +107,7 @@ public final class BPKBottomSheet: NSObject {
     ///     Note: Safe Area should be taken into account in the bottom section's inner constraints.
     ///   - presentationStyle: .modal if you need a modal interaction with the BottomSheet. .persistent if
     ///     you need a persistent BottomSheet and being able to interact with what is behind the BottomSheet
-    ///   - insets: The spacing used when the bottom sheet is presented at various heifghts.
+    ///   - insets: The spacing used when the bottom sheet is presented at various heights.
     ///     The .modal presentation style will only use `half` and ignore all other insets provided.
     
     public init(contentViewController: UIViewController,

--- a/Backpack/BottomSheet/Classes/BottomSheetInsets.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheetInsets.swift
@@ -1,0 +1,22 @@
+
+public struct BottomSheetInsets {
+    let full: CGFloat?
+    let half: CGFloat?
+    let tip: CGFloat?
+    
+    /// Default insets for the bottom sheet.
+    public init() {
+        self.init(full: nil, half: 386.0, tip: 120.0)
+    }
+    
+    /// Use this initializer to have full control over the heights and spacing of your bottom sheet
+    /// - Parameters:
+    ///   - full: A top inset from the safe area
+    ///   - half: A bottom inset from the safe area
+    ///   - tip:  A bottom inset from the safe area
+    public init(full: CGFloat?, half: CGFloat?, tip: CGFloat?) {
+        self.full = full
+        self.half = half
+        self.tip = tip
+    }
+}

--- a/Backpack/BottomSheet/Classes/ModalBottomSheetLayout.swift
+++ b/Backpack/BottomSheet/Classes/ModalBottomSheetLayout.swift
@@ -31,11 +31,18 @@ public final class ModalBottomSheetLayout: FloatingPanelLayout {
     public var supportedPositions: Set<FloatingPanelPosition> {
         return [.full, .half]
     }
+    
+    /// Insets that will be used for the modal presentation
+    private let insets: BottomSheetInsets
+    
+    public init(insets: BottomSheetInsets) {
+        self.insets = insets
+    }
 
     /// Method to describe the height of BPKBottomSheet in each position
     public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
-        case .half: return Constants.bottomSheetHeightInHalfPosition
+        case .half: return insets.half
         default: return nil
         }
     }
@@ -52,6 +59,5 @@ public final class ModalBottomSheetLayout: FloatingPanelLayout {
 }
 
 private enum Constants {
-    static let bottomSheetHeightInHalfPosition: CGFloat = 386.0
     static let backdropAlpha: CGFloat = 0.3
 }

--- a/Backpack/BottomSheet/Classes/PersistentBottomSheetLayout.swift
+++ b/Backpack/BottomSheet/Classes/PersistentBottomSheetLayout.swift
@@ -30,16 +30,22 @@ public final class PersistentBottomSheetLayout: FloatingPanelLayout {
     public var supportedPositions: Set<FloatingPanelPosition> {
         return [.half, .full, .tip]
     }
+    
+    private let insets: BottomSheetInsets
+    
+    public init(insets: BottomSheetInsets) {
+        self.insets = insets
+    }
 
     /// Method to describe the height of BPKBottomSheet in each position
     public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
         case .half:
-            return Constants.bottomSheetHeightInHalfPosition
+            return insets.half
         case .tip:
-            return Constants.bottomSheetHeightInTipPosition
+            return insets.tip
         default:
-            return nil
+            return insets.full
         }
     }
 

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -7,14 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-D28F6B8923A1091D001A188F /* SkyscannerRelativeiOS-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8123A1091D001A188F /* SkyscannerRelativeiOS-Black.ttf */; };
-D28F6B8A23A1091D001A188F /* SkyscannerRelativeiOS-Book.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8223A1091D001A188F /* SkyscannerRelativeiOS-Book.ttf */; };
-D28F6B8B23A1091D001A188F /* SkyscannerRelativeiOS-BlackItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8323A1091D001A188F /* SkyscannerRelativeiOS-BlackItalic.ttf */; };
-D28F6B8C23A1091D001A188F /* SkyscannerRelativeiOS-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8423A1091D001A188F /* SkyscannerRelativeiOS-Italic.ttf */; };
-D28F6B8D23A1091D001A188F /* SkyscannerRelativeiOS-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8523A1091D001A188F /* SkyscannerRelativeiOS-Bold.ttf */; };
-D28F6B8E23A1091D001A188F /* SkyscannerRelativeiOS-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8623A1091D001A188F /* SkyscannerRelativeiOS-BoldItalic.ttf */; };
-D28F6B8F23A1091D001A188F /* SkyscannerRelativeiOS-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8723A1091D001A188F /* SkyscannerRelativeiOS-Medium.ttf */; };
-D28F6B9023A1091D001A188F /* SkyscannerRelativeiOS-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8823A1091D001A188F /* SkyscannerRelativeiOS-MediumItalic.ttf */; };
 		006034DBB76C671434F6252A /* Pods_Backpack_Native.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDBC7CA36756032862B5D581 /* Pods_Backpack_Native.framework */; };
 		2F3F86CF20E1069200DAB2DD /* BPKGradientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F3F86CE20E1069200DAB2DD /* BPKGradientTest.m */; };
 		3A7D2D47214AB9F400ECBD5B /* BPKButtonsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A7D2D46214AB9F400ECBD5B /* BPKButtonsViewController.m */; };
@@ -242,14 +234,6 @@ D28F6B9023A1091D001A188F /* SkyscannerRelativeiOS-MediumItalic.ttf in Resources 
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-D28F6B8123A1091D001A188F /* SkyscannerRelativeiOS-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Black.ttf"; sourceTree = "<group>"; };
-D28F6B8223A1091D001A188F /* SkyscannerRelativeiOS-Book.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Book.ttf"; sourceTree = "<group>"; };
-D28F6B8323A1091D001A188F /* SkyscannerRelativeiOS-BlackItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-BlackItalic.ttf"; sourceTree = "<group>"; };
-D28F6B8423A1091D001A188F /* SkyscannerRelativeiOS-Italic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Italic.ttf"; sourceTree = "<group>"; };
-D28F6B8523A1091D001A188F /* SkyscannerRelativeiOS-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Bold.ttf"; sourceTree = "<group>"; };
-D28F6B8623A1091D001A188F /* SkyscannerRelativeiOS-BoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-BoldItalic.ttf"; sourceTree = "<group>"; };
-D28F6B8723A1091D001A188F /* SkyscannerRelativeiOS-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Medium.ttf"; sourceTree = "<group>"; };
-D28F6B8823A1091D001A188F /* SkyscannerRelativeiOS-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-MediumItalic.ttf"; sourceTree = "<group>"; };
 		090E9C65F965012C0DF5C1E3 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		0F386FFD6327F785FBB09093 /* Pods-Backpack-Native.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack-Native.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack-Native/Pods-Backpack-Native.debug.xcconfig"; sourceTree = "<group>"; };
 		11F0F39D8252943CD3B0C19D /* Pods-Backpack_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack_Example/Pods-Backpack_Example.release.xcconfig"; sourceTree = "<group>"; };

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+D28F6B8923A1091D001A188F /* SkyscannerRelativeiOS-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8123A1091D001A188F /* SkyscannerRelativeiOS-Black.ttf */; };
+D28F6B8A23A1091D001A188F /* SkyscannerRelativeiOS-Book.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8223A1091D001A188F /* SkyscannerRelativeiOS-Book.ttf */; };
+D28F6B8B23A1091D001A188F /* SkyscannerRelativeiOS-BlackItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8323A1091D001A188F /* SkyscannerRelativeiOS-BlackItalic.ttf */; };
+D28F6B8C23A1091D001A188F /* SkyscannerRelativeiOS-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8423A1091D001A188F /* SkyscannerRelativeiOS-Italic.ttf */; };
+D28F6B8D23A1091D001A188F /* SkyscannerRelativeiOS-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8523A1091D001A188F /* SkyscannerRelativeiOS-Bold.ttf */; };
+D28F6B8E23A1091D001A188F /* SkyscannerRelativeiOS-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8623A1091D001A188F /* SkyscannerRelativeiOS-BoldItalic.ttf */; };
+D28F6B8F23A1091D001A188F /* SkyscannerRelativeiOS-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8723A1091D001A188F /* SkyscannerRelativeiOS-Medium.ttf */; };
+D28F6B9023A1091D001A188F /* SkyscannerRelativeiOS-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D28F6B8823A1091D001A188F /* SkyscannerRelativeiOS-MediumItalic.ttf */; };
 		006034DBB76C671434F6252A /* Pods_Backpack_Native.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDBC7CA36756032862B5D581 /* Pods_Backpack_Native.framework */; };
 		2F3F86CF20E1069200DAB2DD /* BPKGradientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F3F86CE20E1069200DAB2DD /* BPKGradientTest.m */; };
 		3A7D2D47214AB9F400ECBD5B /* BPKButtonsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A7D2D46214AB9F400ECBD5B /* BPKButtonsViewController.m */; };
@@ -234,6 +242,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+D28F6B8123A1091D001A188F /* SkyscannerRelativeiOS-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Black.ttf"; sourceTree = "<group>"; };
+D28F6B8223A1091D001A188F /* SkyscannerRelativeiOS-Book.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Book.ttf"; sourceTree = "<group>"; };
+D28F6B8323A1091D001A188F /* SkyscannerRelativeiOS-BlackItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-BlackItalic.ttf"; sourceTree = "<group>"; };
+D28F6B8423A1091D001A188F /* SkyscannerRelativeiOS-Italic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Italic.ttf"; sourceTree = "<group>"; };
+D28F6B8523A1091D001A188F /* SkyscannerRelativeiOS-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Bold.ttf"; sourceTree = "<group>"; };
+D28F6B8623A1091D001A188F /* SkyscannerRelativeiOS-BoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-BoldItalic.ttf"; sourceTree = "<group>"; };
+D28F6B8723A1091D001A188F /* SkyscannerRelativeiOS-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-Medium.ttf"; sourceTree = "<group>"; };
+D28F6B8823A1091D001A188F /* SkyscannerRelativeiOS-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SkyscannerRelativeiOS-MediumItalic.ttf"; sourceTree = "<group>"; };
 		090E9C65F965012C0DF5C1E3 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		0F386FFD6327F785FBB09093 /* Pods-Backpack-Native.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack-Native.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack-Native/Pods-Backpack-Native.debug.xcconfig"; sourceTree = "<group>"; };
 		11F0F39D8252943CD3B0C19D /* Pods-Backpack_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack_Example/Pods-Backpack_Example.release.xcconfig"; sourceTree = "<group>"; };


### PR DESCRIPTION
This PR introduces an extra `insets` parameter to the BottomSheet initialization call. This allows for greater customization. 

The defaults that were used in ModalBottomSheetLayout and PersistentBottomSheetLayout have been copied over to a new BottomSheetInset struct. 

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/master/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/master/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
