### PR TITLE
Feature/map marker fixes

### DIFF
--- a/Backpack/Map/Classes/BPKMapAnnotationView.h
+++ b/Backpack/Map/Classes/BPKMapAnnotationView.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * `BPKMapAnnotationView` is a subclass of `MKPinAnnotationView` which contains the Skyscanner map annotation style.
  */
-IB_DESIGNABLE @interface BPKMapAnnotationView : MKPinAnnotationView
+IB_DESIGNABLE @interface BPKMapAnnotationView : MKAnnotationView
 
 /**
  * Whether the annotation view has previously been selected by the user.

--- a/Backpack/Map/Classes/BPKMapAnnotationView.m
+++ b/Backpack/Map/Classes/BPKMapAnnotationView.m
@@ -159,5 +159,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)prepareForReuse {
+    self.hasBeenSelected = false;
+}
+
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Map/Classes/BPKMapAnnotationView.m
+++ b/Backpack/Map/Classes/BPKMapAnnotationView.m
@@ -160,6 +160,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)prepareForReuse {
+    [super prepareForReuse];
     self.hasBeenSelected = false;
 }
 


### PR DESCRIPTION
Changed the base class of BPKMapMarkerAnnotationView, when using it in a project the default pin marker would show up occasionally. 

Reset hasBeenSelected flag when the AnnotationView is reused by the system. This prevents a different annotation from showing the 'has visited before' state when a totally new set of markers is put on the map. 

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
