### PR TITLE
[BPK-4417] Migrate chip to new navigation story format

### DIFF
--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		600E2AD0218B119000E959B3 /* BPKSwitchSnapshotTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 600E2ACE218B119000E959B3 /* BPKSwitchSnapshotTest.m */; };
 		60127A722021B6BC00703622 /* BPKSpacingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 60127A712021B6BC00703622 /* BPKSpacingTest.m */; };
+		603658D025E3E15D00A94126 /* Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603658CF25E3E15D00A94126 /* Story.swift */; };
+		603658D825E3E1CF00A94126 /* ChipStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603658D725E3E1CF00A94126 /* ChipStory.swift */; };
 		6048F7762028B8CB00C53A8B /* BPKRadiiTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6048F7752028B8CB00C53A8B /* BPKRadiiTest.m */; };
 		6048F77D2028BCE000C53A8B /* BPKRadiiViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6048F77C2028BCE000C53A8B /* BPKRadiiViewController.m */; };
 		6055821721523A1300BF9F3E /* IconsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6055821621523A1300BF9F3E /* IconsViewController.swift */; };
@@ -268,6 +270,8 @@
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		600E2ACE218B119000E959B3 /* BPKSwitchSnapshotTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPKSwitchSnapshotTest.m; sourceTree = "<group>"; };
 		60127A712021B6BC00703622 /* BPKSpacingTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPKSpacingTest.m; sourceTree = "<group>"; };
+		603658CF25E3E15D00A94126 /* Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Story.swift; sourceTree = "<group>"; };
+		603658D725E3E1CF00A94126 /* ChipStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipStory.swift; sourceTree = "<group>"; };
 		6048F7752028B8CB00C53A8B /* BPKRadiiTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPKRadiiTest.m; sourceTree = "<group>"; };
 		6048F77B2028BCE000C53A8B /* BPKRadiiViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BPKRadiiViewController.h; sourceTree = "<group>"; };
 		6048F77C2028BCE000C53A8B /* BPKRadiiViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPKRadiiViewController.m; sourceTree = "<group>"; };
@@ -556,6 +560,8 @@
 		6003F593195388D20070C39A /* Example for Backpack */ = {
 			isa = PBXGroup;
 			children = (
+				603658D625E3E1BD00A94126 /* Stories */,
+				603658CF25E3E15D00A94126 /* Story.swift */,
 				D217702325ACCC9700C0FD8C /* AppStructure.swift */,
 				D217701725ACCC5E00C0FD8C /* Presentable.swift */,
 				D217700B25ACCC0400C0FD8C /* TableNavigationData.swift */,
@@ -659,6 +665,14 @@
 				606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		603658D625E3E1BD00A94126 /* Stories */ = {
+			isa = PBXGroup;
+			children = (
+				603658D725E3E1CF00A94126 /* ChipStory.swift */,
+			);
+			path = Stories;
 			sourceTree = "<group>";
 		};
 		60FF7A9C1954A5C5007DD14C /* Podspec Metadata */ = {
@@ -1284,6 +1298,7 @@
 				E35EA59624212F9900373CE4 /* BottomSheetResizableContentViewController.swift in Sources */,
 				D27EE92C2193163900C877EA /* ChipsViewController.swift in Sources */,
 				D2BBC1C922560FDD002DA71A /* BPKTableViewSelectableCell.swift in Sources */,
+				603658D025E3E15D00A94126 /* Story.swift in Sources */,
 				D61ACE052306E238001C976E /* NavigationBarViewController.swift in Sources */,
 				D2A350BA2214435A00DEA01F /* SettingsViewController.swift in Sources */,
 				D26B8B86219EAC72006FE706 /* BadgesViewController.swift in Sources */,
@@ -1358,6 +1373,7 @@
 				60CE0F992189F99200309211 /* SwitchesViewController.swift in Sources */,
 				58CFF14922D383C300C45B0B /* StarRatingsViewController.swift in Sources */,
 				D2D624AC231586F600D8ED38 /* PanelViewController.swift in Sources */,
+				603658D825E3E1CF00A94126 /* ChipStory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Backpack/Chips.storyboard
+++ b/Example/Backpack/Chips.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,13 +12,13 @@
         <!--Chips View Controller-->
         <scene sceneID="9rk-Eg-xdt">
             <objects>
-                <viewController id="SHl-Oi-FFr" customClass="ChipsViewController" customModule="Backpack_Native" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ChipsViewController" id="SHl-Oi-FFr" customClass="ChipsViewController" customModule="Backpack_Native" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Kec-l1-3BA">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="716"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="HBs-ET-Q43">
-                                <rect key="frame" x="0.0" y="358" width="414" height="0.0"/>
+                                <rect key="frame" x="0.0" y="368" width="414" height="0.0"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="fzz-zD-5ga"/>
@@ -56,151 +56,7 @@
             </objects>
             <point key="canvasLocation" x="-55" y="-542"/>
         </scene>
-        <!--Chips-->
-        <scene sceneID="7fB-TL-UOZ">
-            <objects>
-                <tableViewController storyboardIdentifier="ChipsViewController" title="Chips" id="biG-sv-ldA" customClass="ChipSelectorViewController" customModule="Backpack_Native" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="be7-GK-OWL">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <sections>
-                            <tableViewSection id="cJp-Nd-rPk">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="UEj-MB-EF3" style="IBUITableViewCellStyleDefault" id="zuY-TN-P0y">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zuY-TN-P0y" id="H5q-bk-Pao">
-                                            <rect key="frame" x="0.0" y="0.0" width="382.66666666666669" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Default" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UEj-MB-EF3" customClass="BPKLabel">
-                                                    <rect key="frame" x="20" y="0.0" width="354.66666666666669" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="SHl-Oi-FFr" kind="show" identifier="Outline" id="Je2-L0-BDF"/>
-                                        </connections>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="1iQ-p7-han" style="IBUITableViewCellStyleDefault" id="J2M-Zq-ObM">
-                                        <rect key="frame" x="0.0" y="72" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="J2M-Zq-ObM" id="99T-ke-1eh">
-                                            <rect key="frame" x="0.0" y="0.0" width="382.66666666666669" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="With icons" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1iQ-p7-han" customClass="BPKLabel">
-                                                    <rect key="frame" x="20" y="0.0" width="354.66666666666669" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="SHl-Oi-FFr" kind="show" identifier="FilledWithIcons" id="AP3-Dw-Mz1"/>
-                                        </connections>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="d77-VH-TQw" style="IBUITableViewCellStyleDefault" id="Rlq-VJ-RPa">
-                                        <rect key="frame" x="0.0" y="116" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Rlq-VJ-RPa" id="4ZQ-cB-oeh">
-                                            <rect key="frame" x="0.0" y="0.0" width="382.66666666666669" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="With background color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="d77-VH-TQw" customClass="BPKLabel">
-                                                    <rect key="frame" x="20" y="0.0" width="354.66666666666669" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="SHl-Oi-FFr" kind="show" identifier="WithBackgroundColor" id="Xx1-bc-hs4"/>
-                                        </connections>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="VV4-Io-H0s" style="IBUITableViewCellStyleDefault" id="7BS-H8-COo">
-                                        <rect key="frame" x="0.0" y="160" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7BS-H8-COo" id="sHm-xT-Umf">
-                                            <rect key="frame" x="0.0" y="0.0" width="382.66666666666669" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Filled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VV4-Io-H0s" customClass="BPKLabel">
-                                                    <rect key="frame" x="20" y="0.0" width="354.66666666666669" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="SHl-Oi-FFr" kind="show" identifier="Filled" id="KXi-b3-2Hq"/>
-                                        </connections>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="mmh-11-7xa" style="IBUITableViewCellStyleDefault" id="n6n-ZK-ih6">
-                                        <rect key="frame" x="0.0" y="204" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="n6n-ZK-ih6" id="HMH-6N-9UK">
-                                            <rect key="frame" x="0.0" y="0.0" width="382.66666666666669" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Filled with background color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mmh-11-7xa" customClass="BPKLabel">
-                                                    <rect key="frame" x="20" y="0.0" width="354.66666666666669" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="SHl-Oi-FFr" kind="show" identifier="FilledWithBackgroundColor" id="PsY-tD-f9V"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                        </sections>
-                        <connections>
-                            <outlet property="dataSource" destination="biG-sv-ldA" id="Nog-j4-IzY"/>
-                            <outlet property="delegate" destination="biG-sv-ldA" id="Jmr-Z4-Y6e"/>
-                        </connections>
-                    </tableView>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="uLz-kv-OwU" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-875" y="-542"/>
-        </scene>
     </scenes>
-    <designables>
-        <designable name="1iQ-p7-han">
-            <size key="intrinsicContentSize" width="80" height="20.333333333333332"/>
-        </designable>
-        <designable name="UEj-MB-EF3">
-            <size key="intrinsicContentSize" width="55" height="20.333333333333332"/>
-        </designable>
-        <designable name="VV4-Io-H0s">
-            <size key="intrinsicContentSize" width="40.333333333333336" height="20.333333333333332"/>
-        </designable>
-        <designable name="d77-VH-TQw">
-            <size key="intrinsicContentSize" width="173" height="20.333333333333332"/>
-        </designable>
-        <designable name="mmh-11-7xa">
-            <size key="intrinsicContentSize" width="214" height="20.333333333333332"/>
-        </designable>
-    </designables>
-    <inferredMetricsTieBreakers>
-        <segue reference="PsY-tD-f9V"/>
-    </inferredMetricsTieBreakers>
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Example/Backpack/NavigationData.swift
+++ b/Example/Backpack/NavigationData.swift
@@ -16,11 +16,13 @@
  * limitations under the License.
  */
 
+// swiftlint:disable type_body_length
 class NavigationData: NSObject {
     static var mainStoryboard = loadStoryboard(name: "Main")
     static var buttonsStoryboard = loadStoryboard(name: "Buttons")
     static var calendarStoryboard = loadStoryboard(name: "Calendar")
     static var cardStoryboard = loadStoryboard(name: "Cards")
+    static var chipStoryboard = loadStoryboard(name: "Chips")
 
     static func setButtonStyle(style: BPKButtonStyle) -> (UIViewController) -> Void {
         return {storyboardVC in
@@ -157,6 +159,34 @@ class NavigationData: NSObject {
         )
     }
 
+  enum ChipStory: String {
+    case `default`
+    case withIcons
+    case withBackgroundColor
+    case filled
+    case filledWithBackgroundColor
+  }
+
+  static func chipStory(story: ChipStory) -> Presentable {
+    return CustomPresentable(generateViewController: enrich(chipStoryboard("ChipsViewController").makeViewController, {
+      let target = $0 as? ChipsViewController
+      let filledBackgroundColor: UIColor = .bpk_petra
+
+      switch story {
+      case .withIcons:
+        target?.icons = true
+      case .withBackgroundColor:
+        target?.backgroundTint = filledBackgroundColor
+      case .filled:
+        target?.style = .filled
+      case .filledWithBackgroundColor:
+        target?.style = .filled
+        target?.backgroundTint = filledBackgroundColor
+      default: break
+      }
+    }))
+  }
+
     enum FlareViewStory: String {
         case `default`
         case flareAtTop
@@ -236,6 +266,13 @@ class NavigationData: NSObject {
                 Item(name: "With divider without padding", value: .story(dividedCardStoryboard(story: .dividedVerticalNoPadding)))
                 Item(name: "With divider and corner style large", value: .story(dividedCardStoryboard(story: .dividedHorizontalCornerStyleLarge)))
             }
+            Group(name: "Chips") {
+              Item(name: "Default", value: .story(chipStory(story: .default)))
+              Item(name: "With icons", value: .story(chipStory(story: .withIcons)))
+              Item(name: "With background colour", value: .story(chipStory(story: .withBackgroundColor)))
+              Item(name: "Filled", value: .story(chipStory(story: .filled)))
+              Item(name: "Filled with background colour", value: .story(chipStory(story: .filledWithBackgroundColor)))
+            }
             Group(name: "Flare views") {
                 Item(name: "Default", value: .story(flareStory(story: .default)))
                 Item(name: "Flare at Top", value: .story(flareStory(story: .flareAtTop)))
@@ -243,7 +280,6 @@ class NavigationData: NSObject {
                 Item(name: "Background image", value: .story(flareStory(story: .backgroundImage)))
                 Item(name: "Animated", value: .story(flareStory(story: .animated)))
             }
-            Item(name: "Chips", value: .story(loadStoryboard(name: "Chips", identifier: "ChipsViewController")))
             Item(name: "Dialogs", value: .story(loadStoryboard(name: "Dialogs", identifier: "DialogsViewController")))
             Item(name: "Horizontal navigation", value: .story(loadStoryboard(name: "HorizontalNavigation", identifier: "HorizontalNavigationViewController")))
             Item(name: "Icons", value: .story(mainStoryboard("IconsViewController")))

--- a/Example/Backpack/NavigationData.swift
+++ b/Example/Backpack/NavigationData.swift
@@ -238,11 +238,7 @@ class NavigationData: NSObject {
                 Item(name: "With divider and corner style large", value: .story(dividedCardStoryboard(story: .dividedHorizontalCornerStyleLarge)))
             }
             Group(name: "Chips") {
-              Item(name: "Default", value: .story(ChipStory.default.presentableStory))
-              Item(name: "With icons", value: .story(ChipStory.withIcons.presentableStory))
-              Item(name: "With background colour", value: .story(ChipStory.withBackgroundColor.presentableStory))
-              Item(name: "Filled", value: .story(ChipStory.filled.presentableStory))
-              Item(name: "Filled with background colour", value: .story(ChipStory.filledWithBackgroundColor.presentableStory))
+              ChipStory.storyStructure
             }
             Group(name: "Flare views") {
                 Item(name: "Default", value: .story(flareStory(story: .default)))

--- a/Example/Backpack/NavigationData.swift
+++ b/Example/Backpack/NavigationData.swift
@@ -170,7 +170,7 @@ class NavigationData: NSObject {
   static func chipStory(story: ChipStory) -> Presentable {
     return CustomPresentable(generateViewController: enrich(chipStoryboard("ChipsViewController").makeViewController, {
       let target = $0 as? ChipsViewController
-      let filledBackgroundColor: UIColor = .bpk_petra
+      let filledBackgroundColor: UIColor = .bpk_abisko
 
       switch story {
       case .withIcons:

--- a/Example/Backpack/NavigationData.swift
+++ b/Example/Backpack/NavigationData.swift
@@ -21,7 +21,6 @@ class NavigationData: NSObject {
     static var buttonsStoryboard = loadStoryboard(name: "Buttons")
     static var calendarStoryboard = loadStoryboard(name: "Calendar")
     static var cardStoryboard = loadStoryboard(name: "Cards")
-    static var chipStoryboard = loadStoryboard(name: "Chips")
 
     static func setButtonStyle(style: BPKButtonStyle) -> (UIViewController) -> Void {
         return {storyboardVC in

--- a/Example/Backpack/NavigationData.swift
+++ b/Example/Backpack/NavigationData.swift
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-// swiftlint:disable type_body_length
 class NavigationData: NSObject {
     static var mainStoryboard = loadStoryboard(name: "Main")
     static var buttonsStoryboard = loadStoryboard(name: "Buttons")
@@ -159,34 +158,6 @@ class NavigationData: NSObject {
         )
     }
 
-  enum ChipStory: String {
-    case `default`
-    case withIcons
-    case withBackgroundColor
-    case filled
-    case filledWithBackgroundColor
-  }
-
-  static func chipStory(story: ChipStory) -> Presentable {
-    return CustomPresentable(generateViewController: enrich(chipStoryboard("ChipsViewController").makeViewController, {
-      let target = $0 as? ChipsViewController
-      let filledBackgroundColor: UIColor = .bpk_abisko
-
-      switch story {
-      case .withIcons:
-        target?.icons = true
-      case .withBackgroundColor:
-        target?.backgroundTint = filledBackgroundColor
-      case .filled:
-        target?.style = .filled
-      case .filledWithBackgroundColor:
-        target?.style = .filled
-        target?.backgroundTint = filledBackgroundColor
-      default: break
-      }
-    }))
-  }
-
     enum FlareViewStory: String {
         case `default`
         case flareAtTop
@@ -267,11 +238,11 @@ class NavigationData: NSObject {
                 Item(name: "With divider and corner style large", value: .story(dividedCardStoryboard(story: .dividedHorizontalCornerStyleLarge)))
             }
             Group(name: "Chips") {
-              Item(name: "Default", value: .story(chipStory(story: .default)))
-              Item(name: "With icons", value: .story(chipStory(story: .withIcons)))
-              Item(name: "With background colour", value: .story(chipStory(story: .withBackgroundColor)))
-              Item(name: "Filled", value: .story(chipStory(story: .filled)))
-              Item(name: "Filled with background colour", value: .story(chipStory(story: .filledWithBackgroundColor)))
+              Item(name: "Default", value: .story(ChipStory.default.presentableStory))
+              Item(name: "With icons", value: .story(ChipStory.withIcons.presentableStory))
+              Item(name: "With background colour", value: .story(ChipStory.withBackgroundColor.presentableStory))
+              Item(name: "Filled", value: .story(ChipStory.filled.presentableStory))
+              Item(name: "Filled with background colour", value: .story(ChipStory.filledWithBackgroundColor.presentableStory))
             }
             Group(name: "Flare views") {
                 Item(name: "Default", value: .story(flareStory(story: .default)))

--- a/Example/Backpack/Stories/ChipStory.swift
+++ b/Example/Backpack/Stories/ChipStory.swift
@@ -26,7 +26,8 @@ enum ChipStory: String, Story {
   case filledWithBackgroundColor = "Filled with background colour"
 
   var presentableStory: Presentable {
-    let viewController = NavigationData.chipStoryboard("ChipsViewController").makeViewController
+    let storyboard = loadStoryboard(name: "Chips")
+    let viewController = storyboard("ChipsViewController").makeViewController
     return CustomPresentable(generateViewController: enrich(viewController, {
       let target = $0 as? ChipsViewController
       let filledBackgroundColor: UIColor = .bpk_abisko

--- a/Example/Backpack/Stories/ChipStory.swift
+++ b/Example/Backpack/Stories/ChipStory.swift
@@ -1,0 +1,49 @@
+//
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright © 2021 Skyscanner Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+enum ChipStory: Story {
+  case `default`
+  case withIcons
+  case withBackgroundColor
+  case filled
+  case filledWithBackgroundColor
+
+  var presentableStory: Presentable {
+    let viewController = NavigationData.chipStoryboard("ChipsViewController").makeViewController
+    return CustomPresentable(generateViewController: enrich(viewController, {
+      let target = $0 as? ChipsViewController
+      let filledBackgroundColor: UIColor = .bpk_abisko
+
+      switch self {
+      case .withIcons:
+        target?.icons = true
+      case .withBackgroundColor:
+        target?.backgroundTint = filledBackgroundColor
+      case .filled:
+        target?.style = .filled
+      case .filledWithBackgroundColor:
+        target?.style = .filled
+        target?.backgroundTint = filledBackgroundColor
+      default: break
+      }
+    }))
+  }
+}

--- a/Example/Backpack/Stories/ChipStory.swift
+++ b/Example/Backpack/Stories/ChipStory.swift
@@ -1,4 +1,3 @@
-//
 /*
  * Backpack - Skyscanner's Design System
  *
@@ -19,12 +18,12 @@
 
 import Foundation
 
-enum ChipStory: Story {
-  case `default`
-  case withIcons
-  case withBackgroundColor
-  case filled
-  case filledWithBackgroundColor
+enum ChipStory: String, Story {
+  case `default` = "Default"
+  case withIcons = "With icons"
+  case withBackgroundColor = "With background colour"
+  case filled = "Filled"
+  case filledWithBackgroundColor = "Filled with background colour"
 
   var presentableStory: Presentable {
     let viewController = NavigationData.chipStoryboard("ChipsViewController").makeViewController

--- a/Example/Backpack/Story.swift
+++ b/Example/Backpack/Story.swift
@@ -1,0 +1,24 @@
+//
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright © 2021 Skyscanner Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+protocol Story {
+  var presentableStory: Presentable { get }
+}

--- a/Example/Backpack/Story.swift
+++ b/Example/Backpack/Story.swift
@@ -1,4 +1,3 @@
-//
 /*
  * Backpack - Skyscanner's Design System
  *
@@ -19,6 +18,14 @@
 
 import Foundation
 
-protocol Story {
+protocol Story: RawRepresentable, CaseIterable {
   var presentableStory: Presentable { get }
+}
+
+extension Story where Self.RawValue == String {
+  static var storyStructure: [Item] {
+    return self.allCases.map({ story in
+      return Item(name: story.rawValue, value: .story(story.presentableStory))
+    })
+  }
 }


### PR DESCRIPTION
I've added a new `Story` protocol and `ChipStory` which implements it. The protocol ensures that `presentableStory: Presentable` is implemented, and it also adds adherence to `CaseIterable` and a `storyStructure` property that returns `[Item]`.

This means that the code to add a story can be very simple and all the relevant things – like naming the stories – are abstracted out of `NavigationData`.

The only thing I couldn't figure out was how to make `Story` adhere to `String` so that we don't need to manually add it to each instance.