### PR TITLE
Change constraints of dot annotationView

### DIFF
--- a/Backpack/Map/Classes/BPKMapAnnotationView.m
+++ b/Backpack/Map/Classes/BPKMapAnnotationView.m
@@ -68,6 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 -(void)setupAppearance {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
     self.hasBeenSelected = false;
     [self updateImage];
 
@@ -75,10 +76,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self addSubview:self.dotView];
     self.dotView.translatesAutoresizingMaskIntoConstraints = NO;
     [NSLayoutConstraint activateConstraints:@[
-        // These constraints use magic numbers to ensure that the dot appears in the correct position on the map.
-        // The UIKit PinAnnotationView isn't centered by default.
-        [self.dotView.centerXAnchor constraintEqualToAnchor:self.leadingAnchor constant:8],
-        [self.dotView.centerYAnchor constraintEqualToAnchor:self.bottomAnchor constant:-2],
+        [self.dotView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [self.dotView.topAnchor constraintEqualToAnchor:self.topAnchor],
+        [self.dotView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [self.dotView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
         [self.dotView.widthAnchor constraintEqualToConstant:BPKSpacingLg],
         [self.dotView.heightAnchor constraintEqualToConstant:BPKSpacingLg]
     ]];


### PR DESCRIPTION
I have updated the constraints for the circleview in the BPKMapAnnotationView.
The way the constraints were setup made it so that the 'parent' view was 0x0 pixels. This made tapping the annotationView almost impossible.

There is still a bug remaining right now, it is not possible to tap the callout price view, as it is 'outside' of the frame of the MKAnnotationView.

I have tried to solve this as well, but my attempts have been fruitless.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
