### PR TITLE
[BPK-3546] Refactor calendar selection config

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -19,26 +19,7 @@
 @class BPKCalendar;
 @class BPKSimpleDate;
 @class BPKCalendarConfiguration;
-
-/**
- * Enum values for specifying calendar selection type
- */
-typedef NS_ENUM(NSUInteger, BPKCalendarSelection) {
-    /**
-     * Select a single date in the calendar.
-     */
-    BPKCalendarSelectionSingle = 0,
-
-    /**
-     * Select a range in the calendar by selecting a start and then an end date.
-     */
-    BPKCalendarSelectionRange = 1,
-
-    /**
-     * Select multiple individual dates.
-     */
-    BPKCalendarSelectionMultiple = 2,
-};
+@class BPKCalendarSelectionConfiguration;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -148,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Type of selection allowed
  */
-@property(nonatomic, assign) BPKCalendarSelection selectionType;
+@property(nonatomic, strong) BPKCalendarSelectionConfiguration *selectionConfiguration;
 
 /**
  * List of selected dates

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -39,6 +39,7 @@
 #import "BPKCalendarHeaderCell.h"
 #import "BPKCalendarStickyHeader.h"
 #import "BPKCalendarTrafficLightConfiguration.h"
+#import "BPKCalendarSelectionConfiguration.h"
 #import "BPKCalendarYearPill.h"
 #import "BPKCalendarCellSpacing.h"
 
@@ -198,7 +199,7 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     self.calendarView.scrollDirection = FSCalendarScrollDirectionVertical;
     self.calendarView.scrollEnabled = YES;
     self.calendarView.pagingEnabled = NO;
-    self.calendarView.allowsMultipleSelection = self.selectionType != BPKCalendarSelectionSingle;
+    self.calendarView.allowsMultipleSelection = self.selectionConfiguration.allowsMultipleSelection;
     self.calendarView.placeholderType = FSCalendarPlaceholderTypeNone;
     self.calendarView.delegate = self;
     self.calendarView.dataSource = self;
@@ -291,11 +292,11 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     [self.calendarWeekdayView configureAppearance];
 }
 
-- (void)setSelectionType:(BPKCalendarSelection)selectionType {
+- (void)setSelectionConfiguration:(BPKCalendarSelectionConfiguration *)selectionConfiguration {
     BPKAssertMainThread();
-    if (_selectionType != selectionType) {
-        _selectionType = selectionType;
-        self.calendarView.allowsMultipleSelection = _selectionType != BPKCalendarSelectionSingle;
+    if (_selectionConfiguration != selectionConfiguration) {
+        _selectionConfiguration = selectionConfiguration;
+        self.calendarView.allowsMultipleSelection = selectionConfiguration.allowsMultipleSelection;
         for (NSDate *date in self.calendarView.selectedDates) {
             [self.calendarView deselectDate:date];
         }
@@ -425,17 +426,11 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
         self.sameDayRange = NO;
     }
 
-    if (self.selectionType == BPKCalendarSelectionRange) {
-        if (calendar.selectedDates.count >= 2) {
-            for (NSDate *date in calendar.selectedDates) {
-                [calendar deselectDate:date];
-            }
-        }
+    BOOL shouldClearDates = [self.selectionConfiguration shouldClearSelectedDates:calendar.selectedDates whenSelectingDate:date];
 
-        for (NSDate *selectedDate in calendar.selectedDates) {
-            if ([date compare:selectedDate] == NSOrderedAscending) {
-                [calendar deselectDate:selectedDate];
-            }
+    if (shouldClearDates) {
+        for (NSDate *date in calendar.selectedDates) {
+            [calendar deselectDate:date];
         }
     }
 
@@ -443,7 +438,7 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
 }
 
 - (BOOL)calendar:(FSCalendar *)calendar shouldDeselectDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition {
-    if (self.sameDayRange || self.selectionType != BPKCalendarSelectionRange) {
+  if (self.sameDayRange || !self.selectionConfiguration.isRangeStyleSelection) {
         self.sameDayRange = NO;
         return YES;
     } else {
@@ -607,7 +602,7 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
         SelectionType selectionType = SelectionTypeNone;
         RowType rowType = RowTypeMiddle;
 
-        if (selectedDates.count > 1 && self.selectionType == BPKCalendarSelectionRange) {
+        if (selectedDates.count > 1 && self.selectionConfiguration.isRangeStyleSelection) {
             NSDate *minDate = [selectedDates firstObject];
             NSDate *maxDate = [selectedDates lastObject];
             BOOL dateInsideRange = [BPKCalendar date:date isBetweenDate:minDate andDate:maxDate];

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -426,7 +426,8 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
         self.sameDayRange = NO;
     }
 
-    BOOL shouldClearDates = [self.selectionConfiguration shouldClearSelectedDates:calendar.selectedDates whenSelectingDate:date];
+    BOOL shouldClearDates = self.selectionConfiguration.allowsMultipleSelection &&
+        [self.selectionConfiguration shouldClearSelectedDates:calendar.selectedDates whenSelectingDate:date];
 
     if (shouldClearDates) {
         for (NSDate *date in calendar.selectedDates) {

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
@@ -1,0 +1,46 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BPKCalendarSelectionConfiguration : NSObject
+
+/**
+ * Creates a `BPKCalendarSelectionConfiguration` with the specific classes.
+ *
+ * @param rangeStyleSelection Whether the selection configuration is a range style.
+ * @param allowsMultipleSelection Whether the selection configuration allows multiple simultaneous selections.
+ * @return `BPKCalendarSelectionConfiguration` instance.
+ */
+- (instancetype)initWithRangeStyleSelection:(BOOL)rangeStyleSelection allowMultipleSelection:(BOOL)allowsMultipleSelection;
+
+/**
+ * Whether the selection configuration is a range style (ie start date and end date with 0 or more dates between).
+ */
+@property(readonly)BOOL isRangeStyleSelection;
+
+/**
+ * Whether the selection configuration allows multiple dates to be selected simultaneously.
+ */
+@property(readonly)BOOL allowsMultipleSelection;
+
+-(BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
@@ -16,6 +16,26 @@
  * limitations under the License.
  */
 
+/**
+ * Enum values for specifying calendar selection style
+ */
+typedef NS_ENUM(NSUInteger, BPKCalendarSelectionStyle) {
+    /**
+     * Select a single date in the calendar.
+     */
+    BPKCalendarSelectionStyleSingle = 0,
+
+    /**
+     * Select a range in the calendar by selecting a start and then an end date.
+     */
+    BPKCalendarSelectionStyleRange = 1,
+
+    /**
+     * Select multiple individual dates.
+     */
+    BPKCalendarSelectionStyleMultiple = 2,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 /*
@@ -26,11 +46,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Creates a `BPKCalendarSelectionConfiguration` with the specific classes.
  *
- * @param rangeStyleSelection Whether the selection configuration is a range style.
- * @param allowsMultipleSelection Whether the selection configuration allows multiple simultaneous selections.
+ * @param selectionStyle The selection style of the config.
  * @return `BPKCalendarSelectionConfiguration` instance.
  */
-- (instancetype)initWithRangeStyleSelection:(BOOL)rangeStyleSelection allowMultipleSelection:(BOOL)allowsMultipleSelection;
+- (instancetype)initWithSelectionStyle:(BPKCalendarSelectionStyle)selectionStyle;
+
+/**
+ * The pre-defined selection style of the calendar.
+ */
+@property(readonly)BPKCalendarSelectionStyle selectionStyle;
 
 /**
  * Whether the selection configuration is a range style (ie start date and end date with 0 or more dates between).

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
@@ -18,6 +18,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*
+ * Defines how interaction with the calendar should behave.
+ */
 @interface BPKCalendarSelectionConfiguration : NSObject
 
 /**

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.m
@@ -1,0 +1,46 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BPKCalendarSelectionConfiguration.h"
+
+@interface BPKCalendarSelectionConfiguration ()
+
+@property(nonatomic)BOOL isRangeStyleSelection;
+@property(nonatomic)BOOL allowsMultipleSelection;
+
+@end
+
+@implementation BPKCalendarSelectionConfiguration
+
+- (instancetype)initWithRangeStyleSelection:(BOOL)rangeStyleSelection allowMultipleSelection:(BOOL)allowsMultipleSelection {
+    self = [super init];
+
+    if (self) {
+        _isRangeStyleSelection = rangeStyleSelection;
+        _allowsMultipleSelection = allowsMultipleSelection;
+    }
+
+    return self;
+}
+
+- (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {
+    NSAssert(false, @"BPKCalendarSelectionConfiguration shouldClearSelectedDates: should be overridden. The base class method should never be called.");
+    return NO;
+}
+
+@end

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.m
@@ -18,21 +18,13 @@
 
 #import "BPKCalendarSelectionConfiguration.h"
 
-@interface BPKCalendarSelectionConfiguration ()
-
-@property(nonatomic)BOOL isRangeStyleSelection;
-@property(nonatomic)BOOL allowsMultipleSelection;
-
-@end
-
 @implementation BPKCalendarSelectionConfiguration
 
-- (instancetype)initWithRangeStyleSelection:(BOOL)rangeStyleSelection allowMultipleSelection:(BOOL)allowsMultipleSelection {
+- (instancetype)initWithSelectionStyle:(BPKCalendarSelectionStyle)selectionStyle {
     self = [super init];
 
     if (self) {
-        _isRangeStyleSelection = rangeStyleSelection;
-        _allowsMultipleSelection = allowsMultipleSelection;
+        _selectionStyle = selectionStyle;
     }
 
     return self;
@@ -41,6 +33,14 @@
 - (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {
     NSAssert(false, @"BPKCalendarSelectionConfiguration shouldClearSelectedDates: should be overridden. The base class method should never be called.");
     return NO;
+}
+
+- (BOOL)isRangeStyleSelection {
+    return self.selectionStyle == BPKCalendarSelectionStyleRange;
+}
+
+- (BOOL)allowsMultipleSelection {
+    return self.selectionStyle == BPKCalendarSelectionStyleRange || self.selectionStyle == BPKCalendarSelectionStyleMultiple;
 }
 
 @end

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.h
@@ -1,0 +1,27 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BPKCalendarSelectionConfiguration.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BPKCalendarSelectionConfigurationMultiple : BPKCalendarSelectionConfiguration
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
@@ -16,23 +16,16 @@
  * limitations under the License.
  */
 
-#ifndef __BACKPACK_CALENDAR__
-#define __BACKPACK_CALENDAR__
-#import "BPKCalendar.h"
-#import "BPKCalendarCell.h"
-#import "BPKCalendarColor.h"
-#import "BPKCalendarConfiguration.h"
-#import "BPKCalendarHeaderCell.h"
-#import "BPKCalendarPriceLabelCell.h"
-#import "BPKCalendarPriceLabelCellData.h"
-#import "BPKCalendarPriceLabelConfiguration.h"
-#import "BPKCalendarPriceLabelStyle.h"
-#import "BPKCalendarStickyHeader.h"
-#import "BPKCalendarSelectionConfigurationSingle.h"
 #import "BPKCalendarSelectionConfigurationMultiple.h"
-#import "BPKCalendarSelectionConfigurationRange.h"
-#import "BPKCalendarTrafficLightCell.h"
-#import "BPKCalendarTrafficLightCellData.h"
-#import "BPKCalendarTrafficLightConfiguration.h"
-#import "BPKCalendarYearPill.h"
-#endif
+
+@implementation BPKCalendarSelectionConfigurationMultiple
+
+- (instancetype)init {
+    return [super initWithRangeStyleSelection:NO allowMultipleSelection:YES];
+}
+
+- (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {
+    return NO;
+}
+
+@end

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
@@ -21,7 +21,7 @@
 @implementation BPKCalendarSelectionConfigurationMultiple
 
 - (instancetype)init {
-    return [super initWithRangeStyleSelection:NO allowMultipleSelection:YES];
+    return [super initWithSelectionStyle:BPKCalendarSelectionStyleMultiple];
 }
 
 - (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.h
@@ -1,0 +1,27 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BPKCalendarSelectionConfiguration.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BPKCalendarSelectionConfigurationRange : BPKCalendarSelectionConfiguration
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.m
@@ -21,7 +21,7 @@
 @implementation BPKCalendarSelectionConfigurationRange
 
 - (instancetype)init {
-    return [super initWithRangeStyleSelection:YES allowMultipleSelection:YES];
+    return [super initWithSelectionStyle:BPKCalendarSelectionStyleRange];
 }
 
 - (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.m
@@ -1,0 +1,43 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BPKCalendarSelectionConfigurationRange.h"
+
+@implementation BPKCalendarSelectionConfigurationRange
+
+- (instancetype)init {
+    return [super initWithRangeStyleSelection:YES allowMultipleSelection:YES];
+}
+
+- (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {
+    NSDate *firstSelectedDate = selectedDates.count > 0 ? selectedDates[0] : nil;
+
+    BOOL shouldClearDates = NO;
+    if (selectedDates.count >= 2) {
+        // Two dates are selected already and a new one has been tapped
+        shouldClearDates = YES;
+    } else if (selectedDates.count == 1 && firstSelectedDate != nil &&
+               [date compare:firstSelectedDate] == NSOrderedAscending) {
+        // One date is selected already, but it is after the date that has been tapped
+        shouldClearDates = YES;
+    }
+
+    return shouldClearDates;
+}
+
+@end

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.h
@@ -1,0 +1,27 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BPKCalendarSelectionConfiguration.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BPKCalendarSelectionConfigurationSingle : BPKCalendarSelectionConfiguration
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
@@ -16,23 +16,16 @@
  * limitations under the License.
  */
 
-#ifndef __BACKPACK_CALENDAR__
-#define __BACKPACK_CALENDAR__
-#import "BPKCalendar.h"
-#import "BPKCalendarCell.h"
-#import "BPKCalendarColor.h"
-#import "BPKCalendarConfiguration.h"
-#import "BPKCalendarHeaderCell.h"
-#import "BPKCalendarPriceLabelCell.h"
-#import "BPKCalendarPriceLabelCellData.h"
-#import "BPKCalendarPriceLabelConfiguration.h"
-#import "BPKCalendarPriceLabelStyle.h"
-#import "BPKCalendarStickyHeader.h"
 #import "BPKCalendarSelectionConfigurationSingle.h"
-#import "BPKCalendarSelectionConfigurationMultiple.h"
-#import "BPKCalendarSelectionConfigurationRange.h"
-#import "BPKCalendarTrafficLightCell.h"
-#import "BPKCalendarTrafficLightCellData.h"
-#import "BPKCalendarTrafficLightConfiguration.h"
-#import "BPKCalendarYearPill.h"
-#endif
+
+@implementation BPKCalendarSelectionConfigurationSingle
+
+- (instancetype)init {
+    return [super initWithRangeStyleSelection:NO allowMultipleSelection:NO];
+}
+
+- (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {
+    return NO;
+}
+
+@end

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
@@ -21,7 +21,7 @@
 @implementation BPKCalendarSelectionConfigurationSingle
 
 - (instancetype)init {
-    return [super initWithRangeStyleSelection:NO allowMultipleSelection:NO];
+    return [super initWithSelectionStyle:BPKCalendarSelectionStyleSingle];
 }
 
 - (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
@@ -25,7 +25,7 @@
 }
 
 - (BOOL)shouldClearSelectedDates:(NSArray<NSDate *> *)selectedDates whenSelectingDate:(NSDate *)date {
-    return NO;
+    return YES;
 }
 
 @end

--- a/Backpack/Calendar/README.md
+++ b/Backpack/Calendar/README.md
@@ -24,7 +24,7 @@ and then run `pod install`.
 
 BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
-bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
 bpkCalendar.selectedDates = @[[bpkCalendar simpleDateFromDate:self.date1]];
 [bpkCalendar reloadData];
 
@@ -87,7 +87,7 @@ NSSet<BPKSimpleDate *> *highPrices = /* .... */;
 
 BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
-bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
 bpkCalendar.selectedDates = @[[bpkCalendar simpleDateFromDate:self.date1]];
 [bpkCalendar reloadData];
 
@@ -171,7 +171,7 @@ NSSet<BPKSimpleDate *> *highPrices = /* .... */;
 
 BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithConfiguration: [BPKCalendarPriceLabelConfiguration new]];
 
-bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
 bpkCalendar.selectedDates = @[[bpkCalendar simpleDateFromDate:self.date1]];
 [bpkCalendar reloadData];
 

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		D219C1E02163918B00C9968D /* DividedCardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D219C1DF2163918B00C9968D /* DividedCardsViewController.swift */; };
 		D21AF43C2539E7CE00C8ED04 /* BPKOverlayViewTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D21AF43B2539E7CE00C8ED04 /* BPKOverlayViewTest.m */; };
 		D21AF45D2539EB2C00C8ED04 /* BPKOverlayViewSnapshotTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D21AF44C2539EA8600C8ED04 /* BPKOverlayViewSnapshotTest.m */; };
+		D21EB4C125EA7F2F00B21A01 /* BPKCalendarSelectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D21EB4C025EA7F2F00B21A01 /* BPKCalendarSelectionTests.m */; };
 		D21FA97A22EA370500FD866D /* BPKProgressBarSnapshotTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D21FA97822EA370100FD866D /* BPKProgressBarSnapshotTest.m */; };
 		D2297C2A232A7F3F006E00E0 /* RatingSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2297C28232A7F3F006E00E0 /* RatingSelectorViewController.swift */; };
 		D2297C2B232A7F3F006E00E0 /* RatingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2297C29232A7F3F006E00E0 /* RatingsViewController.swift */; };
@@ -336,6 +337,7 @@
 		D219C1DF2163918B00C9968D /* DividedCardsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividedCardsViewController.swift; sourceTree = "<group>"; };
 		D21AF43B2539E7CE00C8ED04 /* BPKOverlayViewTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKOverlayViewTest.m; sourceTree = "<group>"; };
 		D21AF44C2539EA8600C8ED04 /* BPKOverlayViewSnapshotTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKOverlayViewSnapshotTest.m; sourceTree = "<group>"; };
+		D21EB4C025EA7F2F00B21A01 /* BPKCalendarSelectionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPKCalendarSelectionTests.m; sourceTree = "<group>"; };
 		D21FA97822EA370100FD866D /* BPKProgressBarSnapshotTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPKProgressBarSnapshotTest.m; sourceTree = "<group>"; };
 		D2297C28232A7F3F006E00E0 /* RatingSelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RatingSelectorViewController.swift; sourceTree = "<group>"; };
 		D2297C29232A7F3F006E00E0 /* RatingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RatingsViewController.swift; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 				D2DACAEC25A75EDF0004BE39 /* ExampleApp */,
 				D6CE74F821243A4500154D92 /* BPKBadgeTest.m */,
 				D22EB156239EA75A0090C65E /* BPKBorderWidthTest.m */,
+				D21EB4C025EA7F2F00B21A01 /* BPKCalendarSelectionTests.m */,
 				D246C1F3216643B8001CB366 /* BPKCardTest.m */,
 				D29349BE2199C7650099D2EC /* BPKChipTest.m */,
 				D613CE542006795400D60CC4 /* BPKColorTest.m */,
@@ -661,12 +664,12 @@
 				60127A712021B6BC00703622 /* BPKSpacingTest.m */,
 				589FD45422DE092800F252E9 /* BPKStarRatingTest.m */,
 				D251D2AB243664DF00E28B60 /* BPKTabBarControllerTest.m */,
+				D231E2B525AF312A0061E53E /* BPKTabBarItemTest.swift */,
 				D257C76B236AE402006683F5 /* BPKTappableLinkLabelTest.m */,
 				D2B6450B23A01CB7001001B8 /* BPKTestFontDefinition.h */,
 				D2B6450C23A01CB7001001B8 /* BPKTestFontDefinition.m */,
 				D257C76C236AE402006683F5 /* BPKTextFieldTest.m */,
 				D696CA21215CC1BD00682666 /* IconSwiftTest.swift */,
-				D231E2B525AF312A0061E53E /* BPKTabBarItemTest.swift */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -1435,6 +1438,7 @@
 				589FD45522DE092800F252E9 /* BPKStarRatingTest.m in Sources */,
 				6048F7762028B8CB00C53A8B /* BPKRadiiTest.m in Sources */,
 				D2DACAEE25A75F0C0004BE39 /* TableNavigationDataTest.swift in Sources */,
+				D21EB4C125EA7F2F00B21A01 /* BPKCalendarSelectionTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Backpack/ViewControllers/CalendarViewController.swift
+++ b/Example/Backpack/ViewControllers/CalendarViewController.swift
@@ -43,7 +43,7 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
         }
         if preselectedDates {
             segmentedControl.selectedSegmentIndex = 1
-            calendar.selectionType = .range
+            calendar.selectionConfiguration = BPKCalendarSelectionConfigurationRange()
 
             let currentDate = BPKSimpleDate(date: Date(), for: calendar.gregorian)
             let selectedDate1 = BPKSimpleDate(year: currentDate.year, month: currentDate.month + 2, day: 12)
@@ -75,7 +75,16 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
     // Pragma mark: SegmentedControlDelegate
 
     @IBAction func valueChanged(_ sender: Any) {
-        calendar.selectionType = BPKCalendarSelection(rawValue: UInt(segmentedControl!.selectedSegmentIndex))!
+        switch segmentedControl.selectedSegmentIndex {
+        case 0:
+            calendar.selectionConfiguration = BPKCalendarSelectionConfigurationSingle()
+        case 1:
+            calendar.selectionConfiguration = BPKCalendarSelectionConfigurationRange()
+        case 2:
+            calendar.selectionConfiguration = BPKCalendarSelectionConfigurationMultiple()
+        default:
+            calendar.selectionConfiguration = BPKCalendarSelectionConfigurationSingle()
+        }
         calendar.reloadData()
     }
 

--- a/Example/SnapshotTests/BPKCalendarSnapshotTest.m
+++ b/Example/SnapshotTests/BPKCalendarSnapshotTest.m
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
     [self configureParentView:parentView forCalendar:bpkCalendar];
 
-    bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
 
     bpkCalendar.selectedDates = @[[[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian]];
     [bpkCalendar reloadData];
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
     bpkCalendar.selectedDates = @[[[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian]];
     [bpkCalendar reloadData];
 
@@ -106,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
     bpkCalendar.selectedDates = @[[[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian]];
     bpkCalendar.delegate = self;
     [bpkCalendar reloadData];
@@ -119,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionRange;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationRange alloc] init];
     bpkCalendar.selectedDates = @[
         [[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian], [[BPKSimpleDate alloc] initWithDate:self.date2
                                                                                                                    forCalendar:bpkCalendar.gregorian]
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionRange;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationRange alloc] init];
     bpkCalendar.selectedDates = @[
         [[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian],
         [[BPKSimpleDate alloc] initWithDate:self.date3 forCalendar:bpkCalendar.gregorian]
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionRange;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationRange alloc] init];
     bpkCalendar.selectedDates = @[
         [[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian],
         [[BPKSimpleDate alloc] initWithDate:self.date2 forCalendar:bpkCalendar.gregorian]
@@ -179,7 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionMultiple;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationMultiple alloc] init];
     bpkCalendar.selectedDates = @[
         [[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian], [[BPKSimpleDate alloc] initWithDate:self.date2
                                                                                                                    forCalendar:bpkCalendar.gregorian]
@@ -194,7 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithFrame:CGRectZero];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
 
     bpkCalendar.selectedDates = @[[[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian]];
     self.isColoringDates = YES;
@@ -209,7 +209,7 @@ NS_ASSUME_NONNULL_BEGIN
     BPKCalendar *bpkCalendar = [[BPKCalendar alloc] initWithConfiguration:[BPKCalendarPriceLabelConfiguration new]];
 
     [self configureParentView:parentView forCalendar:bpkCalendar];
-    bpkCalendar.selectionType = BPKCalendarSelectionSingle;
+    bpkCalendar.selectionConfiguration = [[BPKCalendarSelectionConfigurationSingle alloc] init];
 
     bpkCalendar.selectedDates = @[[[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian]];
     self.isShowingPrices = YES;

--- a/Example/Tests/BPKCalendarSelectionTests.m
+++ b/Example/Tests/BPKCalendarSelectionTests.m
@@ -1,0 +1,100 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <Backpack/Calendar.h>
+
+@interface BPKCalendarSelectionTests : XCTestCase
+
+@property NSDate *date1;
+@property NSDate *date2;
+@property NSDate *date3;
+
+@end
+
+NS_ASSUME_NONNULL_BEGIN
+@implementation BPKCalendarSelectionTests
+
+- (void)setUp {
+    self.date1 = [NSDate dateWithTimeIntervalSince1970:2175785688];
+    self.date2 = [NSDate dateWithTimeIntervalSince1970:2176044888];
+    self.date3 = [NSDate dateWithTimeIntervalSince1970:2177772888];
+}
+
+- (void)singleConfigShouldHaveCorrectFeatures {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationSingle alloc] init];
+
+    XCTAssertFalse(c1.allowsMultipleSelection);
+    XCTAssertFalse(c1.isRangeStyleSelection);
+}
+
+- (void)multipleConfigShouldHaveCorrectFeatures {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationMultiple alloc] init];
+
+    XCTAssertTrue(c1.allowsMultipleSelection);
+    XCTAssertFalse(c1.isRangeStyleSelection);
+}
+
+- (void)rangeConfigShouldHaveCorrectFeatures {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationRange alloc] init];
+
+    XCTAssertTrue(c1.allowsMultipleSelection);
+    XCTAssertTrue(c1.isRangeStyleSelection);
+}
+
+- (void)singleConfigShouldNeverClearSelectedDates {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationSingle alloc] init];
+
+    XCTAssertFalse([c1 shouldClearSelectedDates:@[self.date1] whenSelectingDate:self.date2]);
+    XCTAssertFalse([c1 shouldClearSelectedDates:@[self.date2] whenSelectingDate:self.date1]);
+}
+
+- (void)multipleConfigShouldNeverClearSelectedDates {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationMultiple alloc] init];
+
+    XCTAssertFalse([c1 shouldClearSelectedDates:@[self.date1] whenSelectingDate:self.date2]);
+    XCTAssertFalse([c1 shouldClearSelectedDates:@[self.date2] whenSelectingDate:self.date1]);
+    XCTAssertFalse([c1 shouldClearSelectedDates:(@[self.date1, self.date2]) whenSelectingDate:self.date3]);
+    XCTAssertFalse([c1 shouldClearSelectedDates:(@[self.date1, self.date3]) whenSelectingDate:self.date2]);
+}
+
+- (void)rangeConfigShouldNotClearSelectedDatesWhenSelectingSecondDate {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationRange alloc] init];
+
+    XCTAssertFalse([c1 shouldClearSelectedDates:@[self.date1] whenSelectingDate:self.date2]);
+}
+
+- (void)rangeConfigShouldClearSelectedDatesWhenSelectingDateBeforeFirst {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationRange alloc] init];
+
+    XCTAssertTrue([c1 shouldClearSelectedDates:@[self.date2] whenSelectingDate:self.date1]);
+    XCTAssertTrue([c1 shouldClearSelectedDates:(@[self.date2, self.date3]) whenSelectingDate:self.date1]);
+}
+
+
+- (void)rangeConfigShouldClearSelectedDatesWhenSelectingThirdDate {
+    BPKCalendarSelectionConfiguration *c1 = [[BPKCalendarSelectionConfigurationRange alloc] init];
+
+    XCTAssertTrue([c1 shouldClearSelectedDates:(@[self.date1, self.date2]) whenSelectingDate:self.date3]);
+    XCTAssertTrue([c1 shouldClearSelectedDates:(@[self.date1, self.date3]) whenSelectingDate:self.date2]);
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Breaking:**
+ - Backpack/Calendar:
+   - `selectionType` has been removed in favour of `selectionConfiguration`. This is an instance that tells the calendar how selection should behave. Use an instance of `BPKCalendarSelectionConfigurationSingle`, `BPKCalendarSelectionConfigurationMultiple` or `BPKCalendarSelectionConfigurationRange` in place of the old enum values.
+   - Future change: Range configuration requires several accessibility labels to be provided to help users of assistive technology interact with the calendar.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
 - This PR doesn't change any behaviour.
 - The API of the calendar now requites a `selectionConfiguration` instance instead of a `selectionType` enum.
 - A follow-up PR will make another breaking change to enforce providing the additional a11y strings required to make this more accessible. 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
