### PR TITLE
Add delegate for moving the bottom sheet position.

### DIFF
--- a/Backpack/BottomSheet/Classes/BPKFloatingPanelPosition.swift
+++ b/Backpack/BottomSheet/Classes/BPKFloatingPanelPosition.swift
@@ -19,7 +19,8 @@
 import FloatingPanel
 
 /// Enum values for specifying BottomSheet position
-public enum BPKFloatingPanelPosition {
+@objc(BPKFloatingPanelPosition)
+public enum BPKFloatingPanelPosition: Int {
     case full
     case half
     case tip
@@ -27,6 +28,19 @@ public enum BPKFloatingPanelPosition {
 }
 
 extension BPKFloatingPanelPosition {
+    init(floatinPanelPosition: FloatingPanelPosition) {
+        switch floatinPanelPosition {
+        case .full:
+            self = .full
+        case .half:
+            self = .half
+        case .tip:
+            self = .tip
+        case .hidden:
+            self = .hidden
+        }
+    }
+
     var asFloatingPanelPosition: FloatingPanelPosition {
         switch self {
         case .full:

--- a/Backpack/BottomSheet/Classes/BottomSheet.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheet.swift
@@ -19,9 +19,18 @@
 import UIKit
 import FloatingPanel
 
+@objc(BPKBottomSheetDelegate)
+public protocol BPKBottomSheetDelegate: AnyObject {
+    func bottomSheetDidChangePosition(_ position: BPKFloatingPanelPosition)
+}
+
 @objcMembers
 @objc(BPKBottomSheet)
 public final class BPKBottomSheet: NSObject {
+
+    /// Receive calls when the bottom sheet changes position by assigning your view
+    public weak var delegate: BPKBottomSheetDelegate?
+
     /// Enum values for specifying BottomSheet Presentation Style
     /// - modal: Dismissable BottomSheet. No interaction with parent ViewController. Creates an overlay in parent
     /// parent ViewController
@@ -228,6 +237,10 @@ extension BPKBottomSheet: FloatingPanelControllerDelegate {
         case .persistent:
             return PersistentBottomSheetLayout(insets: insets)
         }
+    }
+
+    public func floatingPanelDidChangePosition(_ viewController: FloatingPanelController) {
+        delegate?.bottomSheetDidChangePosition(.init(floatinPanelPosition: viewController.position))
     }
 }
 

--- a/Backpack/BottomSheet/Classes/BottomSheetInsets.swift
+++ b/Backpack/BottomSheet/Classes/BottomSheetInsets.swift
@@ -17,9 +17,9 @@
  */
 
 public struct BottomSheetInsets {
-    let full: CGFloat?
-    let half: CGFloat?
-    let tip: CGFloat?
+    public let full: CGFloat?
+    public let half: CGFloat?
+    public let tip: CGFloat?
     
     /// Default insets for the bottom sheet.
     public init() {

--- a/Example/Backpack/ViewControllers/Bottom Sheet/BottomSheetPersistentViewController.swift
+++ b/Example/Backpack/ViewControllers/Bottom Sheet/BottomSheetPersistentViewController.swift
@@ -35,12 +35,18 @@ final class BottomSheetPersistentViewController: UIViewController {
         closeButton.secondaryBorderColor = BPKColor.clear
         return closeButton
     }()
-    
-    override func loadView() {
-        super.loadView()
+
+    private lazy var mapView: MKMapView = {
         let mapView = MKMapView()
         mapView.delegate = self
         mapView.translatesAutoresizingMaskIntoConstraints = false
+
+        return mapView
+    }()
+
+    override func loadView() {
+        super.loadView()
+
         view.addSubview(mapView)
         view.addSubview(closeButton)
         
@@ -71,12 +77,27 @@ final class BottomSheetPersistentViewController: UIViewController {
                                          bottomSectionViewController: nil,
                                          presentationStyle: .persistent)
         bottomSheet?.addPanel(toParent: self)
+        bottomSheet?.delegate = self
     }
 }
 
 extension BottomSheetPersistentViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
         bottomSheet?.move(to: .tip)
+    }
+}
+
+extension BottomSheetPersistentViewController: BPKBottomSheetDelegate {
+    func bottomSheetDidChangePosition(_ position: BPKFloatingPanelPosition) {
+        let defaultInsets = BottomSheetInsets()
+        switch position {
+        case .half:
+            mapView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: defaultInsets.half ?? 0, right: 0)
+        case .tip:
+            mapView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: defaultInsets.tip ?? 0, right: 0)
+        default:
+            break
+        }
     }
 }
 


### PR DESCRIPTION
I have added a simple delegation passthrough for the moveToPosition call of FloatingPanel. The example is updated to show a possible use case. 

In order to not work with magic numbers I made the fields in BottomSheetInset public so they can be used to update underlaying views or in this example the layoutMargin for the mapView

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
