### PR TITLE
[BPK-4416] Fix annotation size

### DIFF
--- a/Backpack/Map/Classes/BPKMapAnnotationView.m
+++ b/Backpack/Map/Classes/BPKMapAnnotationView.m
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, nullable, readonly) BPKMapAnnotation *bpk_annotation;
 @property(nonatomic, nullable, strong) UIView *dotView;
 @property(nonatomic, strong) BPKMapAnnotationViewCalloutView *calloutView;
+@property(nonatomic, readonly) CGFloat annotationHitAreaHeight;
+@property(nonatomic, readonly) CGFloat annotationDotHeight;
+
 @end
 
 @implementation BPKMapAnnotationView
@@ -72,27 +75,21 @@ NS_ASSUME_NONNULL_BEGIN
     self.hasBeenSelected = false;
     [self updateImage];
 
-    CGFloat dotSize = BPKSpacingBase;
-    // This padding ensures that the tappable area of the annotation is large enough to use easily
-    CGFloat padding = (44 - dotSize) / 2;
-
-    self.layoutMargins = UIEdgeInsetsMake(padding, padding, padding, padding);
-
     self.dotView = [[UIView alloc] initWithFrame:CGRectZero];
     [self addSubview:self.dotView];
     self.dotView.translatesAutoresizingMaskIntoConstraints = NO;
     [NSLayoutConstraint activateConstraints:@[
-        [self.dotView.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor],
-        [self.dotView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor],
-        [self.dotView.trailingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor],
-        [self.dotView.bottomAnchor constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor],
-        [self.dotView.widthAnchor constraintEqualToConstant:dotSize],
-        [self.dotView.heightAnchor constraintEqualToConstant:dotSize]
+        [self.dotView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [self.dotView.topAnchor constraintEqualToAnchor:self.topAnchor],
+        [self.trailingAnchor constraintEqualToAnchor:self.dotView.trailingAnchor],
+        [self.bottomAnchor constraintEqualToAnchor:self.dotView.bottomAnchor],
+        [self.dotView.widthAnchor constraintEqualToConstant:self.annotationDotHeight],
+        [self.dotView.heightAnchor constraintEqualToConstant:self.annotationDotHeight]
     ]];
     self.dotView.backgroundColor = BPKColor.skyBlue;
     self.dotView.layer.borderColor = BPKColor.white.CGColor;
     self.dotView.layer.borderWidth = BPKSpacingSm/2;
-    self.dotView.layer.cornerRadius = dotSize/2;
+    self.dotView.layer.cornerRadius = self.annotationDotHeight/2;
     [self updateAppearance];
 }
 
@@ -169,6 +166,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)prepareForReuse {
     [super prepareForReuse];
     self.hasBeenSelected = false;
+}
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *_Nullable)event {
+    CGFloat insetBy = self.annotationHitAreaHeight - self.annotationDotHeight;
+    CGRect hitArea = CGRectInset(self.bounds, insetBy, insetBy);
+    return CGRectContainsPoint(hitArea, point);
+}
+
+#pragma mark - constants
+
+- (CGFloat)annotationDotHeight {
+    return BPKSpacingBase;
+}
+
+- (CGFloat)annotationHitAreaHeight {
+    return 44;
 }
 
 @end

--- a/Example/SnapshotTests/BPKMapAnnotationSnapshotTest.m
+++ b/Example/SnapshotTests/BPKMapAnnotationSnapshotTest.m
@@ -54,8 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
     [wrapper addSubview:annotationView];
     annotationView.translatesAutoresizingMaskIntoConstraints = NO;
     [NSLayoutConstraint activateConstraints:@[
-        [annotationView.leadingAnchor constraintEqualToAnchor:wrapper.leadingAnchor constant:33],
-        [annotationView.topAnchor constraintEqualToAnchor:wrapper.topAnchor constant:26],
+        [annotationView.leadingAnchor constraintEqualToAnchor:wrapper.leadingAnchor constant:47],
+        [annotationView.topAnchor constraintEqualToAnchor:wrapper.topAnchor constant:40],
         [wrapper.widthAnchor constraintEqualToConstant:annotationWidth],
         [wrapper.heightAnchor constraintEqualToConstant:annotationHeight]
     ]];


### PR DESCRIPTION
Before:
<img width="664" alt="Screenshot 2021-03-08 at 11 50 59" src="https://user-images.githubusercontent.com/30267516/110317889-acaa5280-8004-11eb-8440-b0aefe9bcd3d.png">

After:
<img width="591" alt="Screenshot 2021-03-08 at 11 50 18" src="https://user-images.githubusercontent.com/30267516/110317900-b0d67000-8004-11eb-85d2-2fe2be14c0c9.png">

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
