### PR TITLE
[KOA-4442] Fix blinking on reloadData

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -375,7 +375,7 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
 }
 
 - (void)reloadData {
-    [self.calendarView reloadData];
+    [self invalidateVisibleCells];
 }
 
 - (void)refreshDateAppearance {
@@ -698,10 +698,14 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     // If the consumer is dynamically disabling dates, we will need to invalidate all cells to ensure that the change is
     // visually reflected.
     if ([self.delegate respondsToSelector:@selector(calendar:isDateEnabled:)]) {
-        // This works, but it prevents the selection animation from working 😞
-        NSArray<NSIndexPath *> *indexPathsForVisibleItems = [self.calendarView.collectionView indexPathsForVisibleItems];
-        [self.calendarView.collectionView reloadItemsAtIndexPaths:indexPathsForVisibleItems];
+        [self invalidateVisibleCells];
     }
+}
+
+- (void)invalidateVisibleCells {
+    // This works, but it prevents the selection animation from working 😞
+    NSArray<NSIndexPath *> *indexPathsForVisibleItems = [self.calendarView.collectionView indexPathsForVisibleItems];
+    [self.calendarView.collectionView reloadItemsAtIndexPaths:indexPathsForVisibleItems];
 }
 
 - (BOOL)isDateEnabled:(NSDate *)date {

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -374,6 +374,10 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     }
 }
 
+- (void)reloadCalendarData {
+    [self.calendarView reloadData];
+}
+
 - (void)reloadData {
     [self invalidateVisibleCells];
 }

--- a/Example/SnapshotTests/BPKCalendarSnapshotTest.m
+++ b/Example/SnapshotTests/BPKCalendarSnapshotTest.m
@@ -188,9 +188,9 @@ NS_ASSUME_NONNULL_BEGIN
         [[BPKSimpleDate alloc] initWithDate:self.date1 forCalendar:bpkCalendar.gregorian],
         [[BPKSimpleDate alloc] initWithDate:self.date2 forCalendar:bpkCalendar.gregorian]
     ];
-    [bpkCalendar reloadData];
     bpkCalendar.dateSelectedContentColor = UIColor.orangeColor;
     bpkCalendar.dateSelectedBackgroundColor = UIColor.greenColor;
+    [bpkCalendar reloadData];
 
     FBSnapshotVerifyView(parentView, nil);
 }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+ - Backpack/Calendar:
+   - `reloadData` will now reload all visible cells without causing random cells to blink.
 
 ## How to write a good changelog entry
 


### PR DESCRIPTION
Calling `reoadData` on the FSCalendar causes flashing/blinking as found by other consumers:
https://github.com/WenchaoD/FSCalendar/issues/1012
https://github.com/WenchaoD/FSCalendar/issues/1047

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
