### PR TITLE
Add new 'tertiary' button style

### DIFF
--- a/Backpack/Button/Classes/BPKButton.h
+++ b/Backpack/Button/Classes/BPKButton.h
@@ -69,6 +69,11 @@ typedef NS_ENUM(NSUInteger, BPKButtonStyle) {
      * Outline button style, suitable for use on coloured backgrounds.
      */
     BPKButtonStyleOutline = 5,
+
+    /**
+     * Tertiary button style, suitable for use on map views
+     */
+    BPKButtonStyleTertiary = 6,
 };
 
 /**
@@ -132,6 +137,12 @@ IB_DESIGNABLE @interface BPKButton : UIButton
 
 /// :nodoc:
 @property(nullable, nonatomic, strong) UIColor *linkContentColor UI_APPEARANCE_SELECTOR;
+
+/// :nodoc:
+@property(nullable, nonatomic, strong) UIColor *tertiaryBackgroundColor UI_APPEARANCE_SELECTOR;
+
+/// :nodoc:
+@property(nullable, nonatomic, strong) UIColor *tertiaryContentColor UI_APPEARANCE_SELECTOR;
 
 /// :nodoc:
 - (void)setTitle:(NSString *_Nullable)title forState:(UIControlState)state __attribute__((unavailable("use setTitle: instead")));

--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -333,6 +333,7 @@ NS_ASSUME_NONNULL_BEGIN
     case BPKButtonStyleSecondary:
     case BPKButtonStyleDestructive:
     case BPKButtonStyleOutline:
+    case BPKButtonStyleTertiary:
         switch (size) {
         case BPKButtonSizeDefault: {
             if (self.isIconOnly) {
@@ -419,6 +420,11 @@ NS_ASSUME_NONNULL_BEGIN
             [self setLinkStyleWithColor:contentColor];
             break;
         }
+        case BPKButtonStyleTertiary: {
+            UIColor *backgroundColor = self.tertiaryBackgroundColor ? self.tertiaryBackgroundColor : self.class.tertiaryBackgroundColor;
+            [self setFilledStyleWithNormalBackgroundColorGradientOnTop:backgroundColor gradientOnBottom:backgroundColor];
+            break;
+        }
         default: {
             NSAssert(NO, @"Invalid style value %d", (int)self.style);
             break;
@@ -501,6 +507,13 @@ NS_ASSUME_NONNULL_BEGIN
     case BPKButtonStyleLink:
         highlightedContentColor = [self.currentContentColor colorWithAlphaComponent:0.2];
         break;
+    case BPKButtonStyleTertiary:
+        if (self.tertiaryContentColor != nil) {
+            highlightedContentColor = [self highlightedColor:self.tertiaryContentColor];
+        } else {
+            highlightedContentColor = BPKColor.textPrimaryColor;
+        }
+        break;
     default:
         highlightedContentColor = nil;
     }
@@ -554,6 +567,7 @@ NS_ASSUME_NONNULL_BEGIN
         case BPKButtonStyleFeatured:
         case BPKButtonStyleSecondary:
         case BPKButtonStyleDestructive:
+        case BPKButtonStyleTertiary:
             return self.class.disabledContentColor;
         case BPKButtonStyleLink:
             return self.class.disabledContentColor;
@@ -592,6 +606,11 @@ NS_ASSUME_NONNULL_BEGIN
         return BPKColor.systemRed;
     case BPKButtonStyleOutline:
         return BPKColor.white;
+    case BPKButtonStyleTertiary:
+        if (self.tertiaryContentColor != nil) {
+            return self.tertiaryContentColor;
+        }
+        return BPKColor.textPrimaryColor;
     default:
         NSAssert(NO, @"Unknown BPKButtonStyle %d", (int)self.style);
         return BPKColor.white;
@@ -664,6 +683,7 @@ NS_ASSUME_NONNULL_BEGIN
     case BPKButtonStyleFeatured:
     case BPKButtonStyleSecondary:
     case BPKButtonStyleDestructive:
+    case BPKButtonStyleTertiary:
         backgroundColor = self.class.disabledBackgroundColor;
         break;
     case BPKButtonStyleOutline:
@@ -869,6 +889,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (UIColor *)boxyBorderColor {
     return [BPKColor dynamicColorWithLightVariant:BPKColor.skyGrayTint06 darkVariant:BPKColor.skyGrayTint02];
+}
+
++ (UIColor *)tertiaryBackgroundColor {
+    return [BPKColor dynamicColorWithLightVariant:BPKColor.white darkVariant:BPKColor.blackTint02];
 }
 
 + (CGFloat)buttonTitleIconSpacing {

--- a/Example/Backpack/Stories/ButtonStory.swift
+++ b/Example/Backpack/Stories/ButtonStory.swift
@@ -25,6 +25,7 @@ enum ButtonStory: String, StoryGroup {
     case featured = "Featured"
     case link = "Link"
     case outline = "Outline"
+    case tertiary = "Tertiary"
 
     var buttonStyle: BPKButtonStyle {
         switch self {
@@ -40,6 +41,8 @@ enum ButtonStory: String, StoryGroup {
             return .link
         case .outline:
             return .outline
+        case .tertiary:
+            return .tertiary
         }
     }
 

--- a/Example/Backpack/ViewControllers/BPKButtonsViewController.m
+++ b/Example/Backpack/ViewControllers/BPKButtonsViewController.m
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setupButtons {
-    if (self.style == BPKButtonStyleOutline) {
+    if (self.style == BPKButtonStyleOutline || self.style == BPKButtonStyleTertiary) {
         for (UIView *contentView in self.contentViews) {
             [contentView setBackgroundColor:[BPKColor dynamicColorWithLightVariant:BPKColor.skyBlueShade03 darkVariant:BPKColor.backgroundDarkColor]];
         }

--- a/Example/SnapshotTests/BPKButtonSnapshotTest.m
+++ b/Example/SnapshotTests/BPKButtonSnapshotTest.m
@@ -227,6 +227,39 @@ NS_ASSUME_NONNULL_BEGIN
     BPKSnapshotVerifyViewDark(darkView, nil);
 }
 
+- (UIView *)createDefaultTertiary {
+    UIStackView *view = [self createAllVariantsOfSize:BPKButtonSizeDefault style:BPKButtonStyleTertiary applyTheme:NO loading:NO];
+    CGSize size = [view systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
+    view.frame = CGRectMake(0, 0, size.width, size.height);
+
+    return view;
+}
+
+- (void)testDefaultTertiary {
+    UIView *lightView = [self createDefaultTertiary];
+    UIView *darkView = [self createDefaultTertiary];
+
+    BPKSnapshotVerifyViewLight(lightView, nil);
+    BPKSnapshotVerifyViewDark(darkView, nil);
+}
+
+- (UIView *)createDefaultLoadingTertiary {
+    UIStackView *view = [self createAllVariantsOfSize:BPKButtonSizeDefault style:BPKButtonStyleTertiary applyTheme:NO loading:YES];
+    CGSize size = [view systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
+    view.frame = CGRectMake(0, 0, size.width, size.height);
+
+    return view;
+}
+
+- (void)testDefaultLoadingTertiary {
+    UIView *lightView = [self createDefaultLoadingTertiary];
+    UIView *darkView = [self createDefaultLoadingTertiary];
+
+    BPKSnapshotVerifyViewLight(lightView, nil);
+    BPKSnapshotVerifyViewDark(darkView, nil);
+}
+
+
 - (UIView *)createLargePrimary {
     UIStackView *view = [self createAllVariantsOfSize:BPKButtonSizeLarge style:BPKButtonStylePrimary applyTheme:NO loading:NO];
     CGSize size = [view systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
@@ -414,6 +447,38 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testLargeLoadingOutline {
     UIView *lightView = [self createLargeLoadingOutline];
     UIView *darkView = [self createLargeLoadingOutline];
+
+    BPKSnapshotVerifyViewLight(lightView, nil);
+    BPKSnapshotVerifyViewDark(darkView, nil);
+}
+
+- (UIView *)createLargeTertiary {
+    UIStackView *view = [self createAllVariantsOfSize:BPKButtonSizeLarge style:BPKButtonStyleTertiary applyTheme:NO loading:NO];
+    CGSize size = [view systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
+    view.frame = CGRectMake(0, 0, size.width, size.height);
+
+    return view;
+}
+
+- (void)testLargeTertiary {
+    UIView *lightView = [self createLargeTertiary];
+    UIView *darkView = [self createLargeTertiary];
+
+    BPKSnapshotVerifyViewLight(lightView, nil);
+    BPKSnapshotVerifyViewDark(darkView, nil);
+}
+
+- (UIView *)createLargeLoadingTertiary {
+    UIStackView *view = [self createAllVariantsOfSize:BPKButtonSizeLarge style:BPKButtonStyleTertiary applyTheme:NO loading:YES];
+    CGSize size = [view systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
+    view.frame = CGRectMake(0, 0, size.width, size.height);
+
+    return view;
+}
+
+- (void)testLargeLoadingTertiary {
+    UIView *lightView = [self createLargeLoadingTertiary];
+    UIView *darkView = [self createLargeLoadingTertiary];
 
     BPKSnapshotVerifyViewLight(lightView, nil);
     BPKSnapshotVerifyViewDark(darkView, nil);


### PR DESCRIPTION
Add a new button style that can be used on top of map views.

**Light mode **
![simulator_screenshot_6AC5F0DA-F059-45A5-B5AA-A30122AF06CC](https://user-images.githubusercontent.com/728889/121194737-9761f000-c8a1-11eb-876b-6a6850100f45.png)

**Dark mode**
![simulator_screenshot_C6766363-95D6-4AFF-B522-6CE7E119CD37](https://user-images.githubusercontent.com/728889/121194791-a5177580-c8a1-11eb-8753-dfc96d463ff6.png)



Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
