### PR TITLE
[No JIRA] Fix runtime crash in iOS 15

### DIFF
--- a/Example/Backpack/BPKAppDelegate.m
+++ b/Example/Backpack/BPKAppDelegate.m
@@ -69,10 +69,8 @@
     [BPKAppearance apply];
 
     self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
-    UINavigationController *navigationController = [UINavigationController new];
-
-    BPKRootTableViewController *rootTableViewController = [BPKRootTableViewController new];
-    navigationController.viewControllers = @[rootTableViewController];
+    BPKRootTableViewController *rootTableViewController = [[BPKRootTableViewController alloc] init];
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:rootTableViewController];
     self.window.rootViewController = navigationController;
 
     if ([ThemeHelpers isThemingSupported]) {

--- a/Example/Backpack/ViewControllers/BPKRootTableViewController.swift
+++ b/Example/Backpack/ViewControllers/BPKRootTableViewController.swift
@@ -20,6 +20,14 @@ import UIKit
 import Backpack
 
 class BPKRootTableViewController: BPKNavigationViewController {
+    init() {
+        super.init(structure: NavigationData.appStructure)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
The init behaviour in `BPKRootTableViewController` and
`BPKNavigationViewController` was not correct and crashes
with an assertion under iOS 15. We need to explicitly ovveride `init` in
`BPKRootTableViewController`.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
