### PR TITLE
KOA 4726 tweak dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,11 @@ updates:
     - dependency-type: "direct"
   labels:
   - dependabot
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependabot

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,14 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependabot
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
+  allow:
+    - dependency-type: "direct"
+  labels:
+  - dependabot


### PR DESCRIPTION
Adds suppport for NPM and GitHub Actions for dependabot.

Unfortunately dependabot doesn't currently support CocoaPods.
