### PR TITLE
[no jira] Update DANGER_GITHUB_API_TOKEN to GITHUB_TOKEN

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@ Thanks for contributing to Backpack :pray:
 Please include a description of the changes you are introducing and some screenshots if appropriate.
 -->
 
++ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)
+
 Remember to include the following changes:
 + [ ] `UNRELEASED.md`
 + [ ] `README.md`
@@ -11,3 +13,5 @@ Remember to include the following changes:
 + [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
 + [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
 + [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
+
+_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Run danger
         run: npm run danger:ci
         env:
-          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and verify docs
         if: steps.extract_git_tag.outputs.GIT_TAG == '' && github.ref == 'refs/heads/main'

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -25,65 +25,15 @@ import fs from 'fs';
 
 import { danger, fail, warn, markdown, schedule } from 'danger';
 
-const getRandomFromArray = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
 const currentYear = new Date().getFullYear();
 // Applies to js, css, scss and sh files that are not located in dist or flow-typed folders.
 const shouldContainLicensingInformation = (filePath) =>
   filePath.match(/\.(js|sh|swift|h|m|njk)$/);
 
-const author = danger.github.pr.user.login;
-const isPrExternal = async () => {
-  try {
-    await danger.github.api.orgs.checkMembership({
-      org: 'backpack',
-      username: author,
-    });
-    return false;
-  } catch (err) {
-    return true;
-  }
-};
-
 const createdFiles = danger.git.created_files;
 const modifiedFiles = danger.git.modified_files;
 const fileChanges = [...modifiedFiles, ...createdFiles];
-
-const thanksGifs = [
-  'https://media.giphy.com/media/KJ1f5iTl4Oo7u/giphy.gif', // T.Hanks
-  'https://media.giphy.com/media/6tHy8UAbv3zgs/giphy.gif', // Spongebob
-  'https://media.giphy.com/media/xULW8v7LtZrgcaGvC0/giphy.gif', // Dog
-  'https://media.giphy.com/media/GghJ32T5oPR8Q/giphy.gif', // Leslie Knope
-  'https://media.giphy.com/media/26AHAw0aMmWwRI4Hm/giphy.gif', // David Mitchell
-  'https://media.giphy.com/media/mbhseRYedlG5W/giphy.gif', // That guy from Who's Line Is It Anyway who looks like Bill Murray
-  'https://media.giphy.com/media/3o6ZsXRBB9E67nUjL2/giphy.gif', // We love you
-  'https://media.giphy.com/media/l3V0sNZ0NGomeurCM/giphy.gif', // Bowie
-  'https://media.giphy.com/media/3rgXBvoeXt3MXlqhO0/giphy.gif', // Amazement
-  'https://media.giphy.com/media/1OnDp7RwgphjG/giphy.gif', // Kumamon
-  'https://media.giphy.com/media/1lk1IcVgqPLkA/giphy.gif', // Cap salute
-  'https://media.giphy.com/media/l3V0lN5bUX7AKtdW8/giphy.gif', // Moira Schitt's Creek
-  'https://media.giphy.com/media/3osxYdXvsGw6wT5lIY/giphy.gif', // OMG thanks
-  'https://media.giphy.com/media/nEMmyUp4hl1QOzovKh/giphy.gif', // thanks dude
-  'https://media.giphy.com/media/l0G192kSMLwTpO1CE/giphy.gif', // moe simpsons
-];
-
-// Be nice to our neighbours.
-schedule(async () => {
-  if (await isPrExternal()) {
-    markdown(`
-# Hi ${author}!
-
-Thanks for the PR 🎉! Contributions like yours help to improve the design system
-for everybody and we appreciate you taking the effort to create this PR.
-
-![Thanks](${getRandomFromArray(thanksGifs)})
-
-- [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)
-
-If you're curious about how we review, please read through the
-[code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md).
-`);
-  }
-});
 
 const pbxprojFilePath = 'Example/Backpack.xcodeproj/project.pbxproj';
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -23,7 +23,7 @@
 // Globals provided by Danger
 import fs from 'fs';
 
-import { danger, fail, warn, markdown, schedule } from 'danger';
+import { danger, fail, warn, schedule } from 'danger';
 
 
 const currentYear = new Date().getFullYear();


### PR DESCRIPTION
Updated the danger CI token in the PR workflow.

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
