### PR TITLE
fix: change content inset when expanding/collapsing navigation bar

### DIFF
--- a/Backpack/NavigationBar/Classes/BPKNavigationBar.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBar.m
@@ -166,6 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
         // are only executed a single time per transition.
         if (!self.isCollapsed) {
             self.heightConstraint.constant = BPKNavigationBarTitleHeight;
+            scrollView.contentInset = UIEdgeInsetsMake(BPKNavigationBarTitleHeight, 0, 0, 0);
             scrollView.scrollIndicatorInsets = scrollView.contentInset;
             self.titleView.showsContent = YES;
             self.borderView.alpha = 1.0;
@@ -175,9 +176,14 @@ NS_ASSUME_NONNULL_BEGIN
         }
     } else {
         // Expanded state
-        self.heightConstraint.constant = fabs(adjustedYOffset);
-        scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(fabs(adjustedYOffset), 0, 0, 0);
-
+        CGFloat absAdjustedYOffset = fabs(adjustedYOffset);
+        self.heightConstraint.constant = absAdjustedYOffset;
+        scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(absAdjustedYOffset, 0, 0, 0);
+        
+        if (absAdjustedYOffset <= BPKNavigationBarExpandedFullHeight) {
+            scrollView.contentInset = UIEdgeInsetsMake(absAdjustedYOffset, 0, 0, 0);
+        }
+        
         // Making modifications on each scroll is very expensive.
         // To prevent extra work the changes between collapsed and expanded
         // are only executed a single time per transition.

--- a/Backpack/NavigationBar/Classes/BPKNavigationBar.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBar.m
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Example/Backpack/Stories/NavigationBarStory.swift
+++ b/Example/Backpack/Stories/NavigationBarStory.swift
@@ -2,7 +2,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Example/Backpack/Stories/NavigationBarStory.swift
+++ b/Example/Backpack/Stories/NavigationBarStory.swift
@@ -22,6 +22,7 @@ import Foundation
 enum NavigationBarStory: String, StoryGroup {
     case `default` = "Default"
     case withButtons = "With buttons"
+    case witHeaders = "With headers"
 
     var title: String {
         self.rawValue
@@ -39,6 +40,8 @@ enum NavigationBarStory: String, StoryGroup {
                 break
             case .withButtons:
                 navVc?.showButtons = true
+            case .witHeaders:
+                navVc?.showHeaders = true
             }
         }
     }

--- a/Example/Backpack/ViewControllers/NavigationBarViewController.swift
+++ b/Example/Backpack/ViewControllers/NavigationBarViewController.swift
@@ -2,7 +2,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Example/Backpack/ViewControllers/NavigationBarViewController.swift
+++ b/Example/Backpack/ViewControllers/NavigationBarViewController.swift
@@ -22,6 +22,8 @@ import Backpack
 
 class NavigationBarViewController: UIViewController {
     var showButtons: Bool = false
+    var showHeaders: Bool = false
+    
     private static let CellIdentifier = "CellIdentifier"
 
     @IBOutlet weak var navigationButton: UIButton!
@@ -109,6 +111,32 @@ extension NavigationBarViewController: UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let view = UIView()
+        view.backgroundColor = .bpk_backgroundSecondary
+        let label = BPKLabel(fontStyle: .textBase)
+        label.text = "Header \(section)"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: BPKSpacingBase),
+            label.topAnchor.constraint(equalTo: view.topAnchor),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            label.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        return view
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if !showHeaders {
+            return 0
+        }
+        
+        return BPKSpacingXl
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

When a tableview with headers is scrolled, the content inset was not changed. This causes the header view to 'float' in the wrong location.

Old behaviour:
![simulator_screenshot_1095E334-12DC-43B8-B244-0E1793348EBA](https://user-images.githubusercontent.com/728889/148016142-8bfb8a5a-f504-4e22-8f22-5387fe9747a3.png)

Fixed behaviour:
![simulator_screenshot_2ED43A35-6E07-46BA-B615-4C34414D725B](https://user-images.githubusercontent.com/728889/148016062-39209a4d-8e21-4b51-823b-e2935be73431.png)



+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_