### PR TITLE
Update Same-Day-Return selection UI to match other platforms

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendarCell.m
+++ b/Backpack/Calendar/Classes/BPKCalendarCell.m
@@ -59,6 +59,7 @@ const CGFloat BPKCalendarCellSameDayXOffset = 3.75;
     [super layoutSubviews];
 
     CGFloat paddingX = (CGRectGetWidth(self.bounds) - BPKCalendarCellSpacing.cellCircleHeight) / 2.0;
+    CGFloat paddingInnerCircle = 6;
 
     self.shapeLayer.hidden = NO;
     self.selectionLayer.hidden = NO;
@@ -71,7 +72,7 @@ const CGFloat BPKCalendarCellSameDayXOffset = 3.75;
     CGFloat height = BPKCalendarCellSpacing.cellCircleHeight;
 
     self.samedayLayer.hidden = YES;
-    self.samedayLayer.frame = CGRectMake(paddingX - BPKCalendarCellSameDayXOffset, 0, BPKCalendarCellSpacing.cellCircleHeight, BPKCalendarCellSpacing.cellCircleHeight);
+    self.samedayLayer.frame = CGRectMake(paddingX, 0, BPKCalendarCellSpacing.cellCircleHeight, BPKCalendarCellSpacing.cellCircleHeight);
     UIBezierPath *sameDayPath = [UIBezierPath bezierPathWithRoundedRect:self.samedayLayer.bounds
                                                       byRoundingCorners:UIRectCornerAllCorners
                                                             cornerRadii:self.shapeLayer.frame.size];
@@ -154,8 +155,7 @@ const CGFloat BPKCalendarCellSameDayXOffset = 3.75;
     case SelectionTypeSameDay:
         self.samedayLayer.hidden = NO;
         self.selectionLayer.hidden = YES;
-        self.shapeLayer.frame = CGRectMake(CGRectGetMinX(self.shapeLayer.frame) + BPKCalendarCellSameDayXOffset, CGRectGetMinY(self.shapeLayer.frame),
-                                           CGRectGetWidth(self.shapeLayer.frame), CGRectGetHeight(self.shapeLayer.frame));
+            self.shapeLayer.frame = CGRectMake(paddingX + paddingInnerCircle / 2, paddingInnerCircle / 2, BPKCalendarCellSpacing.cellCircleHeight - paddingInnerCircle, BPKCalendarCellSpacing.cellCircleHeight - paddingInnerCircle);
         break;
 
     default:

--- a/Backpack/Calendar/Classes/BPKCalendarCell.m
+++ b/Backpack/Calendar/Classes/BPKCalendarCell.m
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ const CGFloat BPKCalendarCellSameDayXOffset = 3.75;
     case SelectionTypeSameDay:
         self.samedayLayer.hidden = NO;
         self.selectionLayer.hidden = YES;
-            self.shapeLayer.frame = CGRectMake(paddingX + paddingInnerCircle / 2, paddingInnerCircle / 2, BPKCalendarCellSpacing.cellCircleHeight - paddingInnerCircle, BPKCalendarCellSpacing.cellCircleHeight - paddingInnerCircle);
+        self.shapeLayer.frame = CGRectMake(paddingX + paddingInnerCircle / 2, paddingInnerCircle / 2, BPKCalendarCellSpacing.cellCircleHeight - paddingInnerCircle, BPKCalendarCellSpacing.cellCircleHeight - paddingInnerCircle);
         break;
 
     default:


### PR DESCRIPTION
The current UI for same-day return selection isn't consistent with the other platforms. We want to bring these in line so there's consistency with the different calendars

https://gojira.skyscanner.net/browse/WASABI-6040

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_