### PR TITLE
KOA-4834 new label api

### DIFF
--- a/Example/Backpack/Labels.storyboard
+++ b/Example/Backpack/Labels.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,10 +17,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SnF-iz-Qcg">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SnF-iz-Qcg">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="eiy-Lw-ehx">
+                                    <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="375" placeholderIntrinsicHeight="647" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="eiy-Lw-ehx">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                                     </stackView>
                                 </subviews>
@@ -28,7 +28,6 @@
                                     <constraint firstAttribute="trailing" secondItem="eiy-Lw-ehx" secondAttribute="trailing" id="9xG-xv-b6J"/>
                                     <constraint firstItem="eiy-Lw-ehx" firstAttribute="leading" secondItem="SnF-iz-Qcg" secondAttribute="leading" id="Mcg-Y1-N6D"/>
                                     <constraint firstItem="eiy-Lw-ehx" firstAttribute="top" secondItem="SnF-iz-Qcg" secondAttribute="top" id="Vzo-dx-Wtv"/>
-                                    <constraint firstItem="eiy-Lw-ehx" firstAttribute="width" secondItem="SnF-iz-Qcg" secondAttribute="width" id="epe-HY-Y7A"/>
                                     <constraint firstAttribute="bottom" secondItem="eiy-Lw-ehx" secondAttribute="bottom" id="haD-LS-J7Y"/>
                                 </constraints>
                             </scrollView>
@@ -58,81 +57,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PKZ-lM-BuN">
-                                <rect key="frame" x="167" y="223.5" width="41.5" height="220"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VVy-QZ-Udq">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pKC-qV-wgG" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pmq-0z-umu" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="28.5" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s5b-cz-jEV" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="57" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="McG-aU-m0S" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="85.5" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LFq-9m-UFQ" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="114" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ezk-Vk-jZz" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="142.5" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PV1-fj-hQN" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="171" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M9N-YJ-EcP" customClass="BPKLabel">
-                                        <rect key="frame" x="0.0" y="199.5" width="41.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="375" placeholderIntrinsicHeight="400" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="tpi-r5-YQu">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="400"/>
+                                    </stackView>
                                 </subviews>
-                            </stackView>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="tpi-r5-YQu" secondAttribute="bottom" id="Nfr-dC-6IV"/>
+                                    <constraint firstAttribute="trailing" secondItem="tpi-r5-YQu" secondAttribute="trailing" id="TsF-Ck-03v"/>
+                                    <constraint firstItem="tpi-r5-YQu" firstAttribute="leading" secondItem="VVy-QZ-Udq" secondAttribute="leading" id="XDf-4r-Aa2"/>
+                                    <constraint firstItem="tpi-r5-YQu" firstAttribute="width" secondItem="VVy-QZ-Udq" secondAttribute="width" id="yEG-bU-8sv"/>
+                                    <constraint firstItem="tpi-r5-YQu" firstAttribute="top" secondItem="VVy-QZ-Udq" secondAttribute="top" id="ysT-cM-WC1"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="x8D-IJ-kqp"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="6cf-wQ-rU6"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="p4p-AQ-Idj"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="PKZ-lM-BuN" firstAttribute="centerX" secondItem="p4p-AQ-Idj" secondAttribute="centerX" id="Jil-6l-Bhv"/>
-                            <constraint firstItem="PKZ-lM-BuN" firstAttribute="centerY" secondItem="p4p-AQ-Idj" secondAttribute="centerY" id="rs9-9p-wg0"/>
+                            <constraint firstItem="p4p-AQ-Idj" firstAttribute="trailing" secondItem="VVy-QZ-Udq" secondAttribute="trailing" id="4NQ-Xl-Mhc"/>
+                            <constraint firstItem="VVy-QZ-Udq" firstAttribute="top" secondItem="p4p-AQ-Idj" secondAttribute="top" id="6Ny-Zl-CTB"/>
+                            <constraint firstItem="VVy-QZ-Udq" firstAttribute="leading" secondItem="p4p-AQ-Idj" secondAttribute="leading" id="NFB-9I-Gwu"/>
+                            <constraint firstItem="p4p-AQ-Idj" firstAttribute="bottom" secondItem="VVy-QZ-Udq" secondAttribute="bottom" id="fj1-UW-Iuo"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outletCollection property="labels" destination="pKC-qV-wgG" collectionClass="NSMutableArray" id="W7f-sq-p5m"/>
-                        <outletCollection property="labels" destination="Pmq-0z-umu" collectionClass="NSMutableArray" id="njR-BS-s2g"/>
-                        <outletCollection property="labels" destination="s5b-cz-jEV" collectionClass="NSMutableArray" id="JaX-2o-SIO"/>
-                        <outletCollection property="labels" destination="McG-aU-m0S" collectionClass="NSMutableArray" id="3jV-ro-91k"/>
-                        <outletCollection property="labels" destination="LFq-9m-UFQ" collectionClass="NSMutableArray" id="yyP-kV-gld"/>
-                        <outletCollection property="labels" destination="Ezk-Vk-jZz" collectionClass="NSMutableArray" id="LaE-cf-F6N"/>
-                        <outletCollection property="labels" destination="PV1-fj-hQN" collectionClass="NSMutableArray" id="0x6-CD-dmk"/>
-                        <outletCollection property="labels" destination="M9N-YJ-EcP" collectionClass="NSMutableArray" id="Z8u-cS-uCx"/>
+                        <outlet property="stack" destination="tpi-r5-YQu" id="gQP-px-Tq2"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WJt-Wn-uNM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="9" y="906"/>
+            <point key="canvasLocation" x="8.8000000000000007" y="905.3973013493254"/>
         </scene>
         <!--Mutliple font styles-->
         <scene sceneID="Bbe-CL-PQD">
@@ -168,31 +126,7 @@
         </scene>
     </scenes>
     <designables>
-        <designable name="Ezk-Vk-jZz">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
-        <designable name="LFq-9m-UFQ">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
-        <designable name="M9N-YJ-EcP">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
-        <designable name="McG-aU-m0S">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
-        <designable name="PV1-fj-hQN">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
-        <designable name="Pmq-0z-umu">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
-        <designable name="pKC-qV-wgG">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
         <designable name="qZc-H7-0Iq">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
-        </designable>
-        <designable name="s5b-cz-jEV">
             <size key="intrinsicContentSize" width="41.5" height="20.5"/>
         </designable>
     </designables>

--- a/Example/Backpack/Stories/LabelStory.swift
+++ b/Example/Backpack/Stories/LabelStory.swift
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import Foundation
 
 enum LabelStory: String, StoryGroup {
     case `default` = "Default"
-    case emphasized = "Emphasised"
-    case heavy = "Heavy"
     case performance = "Performance"
     case multipleFontStyle = "Multiple font styles"
 
@@ -33,41 +31,12 @@ enum LabelStory: String, StoryGroup {
         let storyboard = loadStoryboard(name: "Labels")
 
         switch self {
-        case .default, .emphasized, .heavy:
-            let presentable = storyboard("LabelsViewController")
-
-            return presentable.enrich {
-                let labelsVc = $0 as? LabelsViewController
-                labelsVc?.type = type
-            }
+        case .default:
+            return storyboard("LabelsViewController")
         case .performance:
             return storyboard("LabelsPerformanceViewController")
         case .multipleFontStyle:
             return storyboard("LabelMultiFontStyleViewController")
-        }
-    }
-
-    private var useLabelsViewController: Bool {
-        switch self {
-        case .default, .emphasized, .heavy:
-            return true
-        default:
-            return false
-        }
-    }
-
-    private var type: LabelsDisplayType {
-        switch self {
-        case.default:
-            return .normal
-        case .emphasized:
-            return .emphasized
-        case .heavy:
-            return .heavy
-        case .performance:
-            return .normal
-        case .multipleFontStyle:
-            return .normal
         }
     }
 }

--- a/Example/Backpack/ViewControllers/LabelMultiFontStyleViewController.swift
+++ b/Example/Backpack/ViewControllers/LabelMultiFontStyleViewController.swift
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,15 +27,15 @@ class LabelMultiFontStyleViewController: UIViewController {
         super.viewDidLoad()
 
         label.numberOfLines = 15
-        label.fontStyle = .textBase
+        label.fontStyle = .textBodyDefault
 
         label.text = "This is a BPKLabel which supports multiple different font styles. You can simply create" +
         "a BPKLabel, and then set the FontStyle to use for any given range.\nALWAYS INK RESPONSIBLY."
-        label.setFontStyle(.textLg, range: NSRange(location: 10, length: 8))
-        label.setFontStyle(.textXlEmphasized, range: NSRange(location: 33, length: 32))
-        label.setFontStyle(.textCaps, range: NSRange(location: 97, length: 14))
-        label.setFontStyle(.textXlEmphasized, range: NSRange(location: 116, length: 9))
-        label.setFontStyle(.textXxxlHeavy, range: NSRange(location: 141, length: 12))
-        label.setFontStyle(.textCapsEmphasized, range: NSRange(location: 154, length: 23))
+        label.setFontStyle(.textHeading4, range: NSRange(location: 10, length: 8))
+        label.setFontStyle(.textHero5, range: NSRange(location: 33, length: 32))
+        label.setFontStyle(.textCaption, range: NSRange(location: 97, length: 14))
+        label.setFontStyle(.textBodyLongform, range: NSRange(location: 116, length: 9))
+        label.setFontStyle(.textFootnote, range: NSRange(location: 141, length: 12))
+        label.setFontStyle(.textSubheading, range: NSRange(location: 154, length: 23))
     }
 }

--- a/Example/Backpack/ViewControllers/LabelMultiFontStyleViewController.swift
+++ b/Example/Backpack/ViewControllers/LabelMultiFontStyleViewController.swift
@@ -27,12 +27,12 @@ class LabelMultiFontStyleViewController: UIViewController {
         super.viewDidLoad()
 
         label.numberOfLines = 15
-        label.fontStyle = .textBodyDefault
+        label.fontStyle = .textHeading1
 
         label.text = "This is a BPKLabel which supports multiple different font styles. You can simply create" +
         "a BPKLabel, and then set the FontStyle to use for any given range.\nALWAYS INK RESPONSIBLY."
-        label.setFontStyle(.textHeading4, range: NSRange(location: 10, length: 8))
-        label.setFontStyle(.textHero5, range: NSRange(location: 33, length: 32))
+        label.setFontStyle(.textHero5, range: NSRange(location: 10, length: 8))
+        label.setFontStyle(.textBodyDefault, range: NSRange(location: 33, length: 32))
         label.setFontStyle(.textCaption, range: NSRange(location: 97, length: 14))
         label.setFontStyle(.textBodyLongform, range: NSRange(location: 116, length: 9))
         label.setFontStyle(.textFootnote, range: NSRange(location: 141, length: 12))

--- a/Example/Backpack/ViewControllers/LabelsPerformanceViewController.swift
+++ b/Example/Backpack/ViewControllers/LabelsPerformanceViewController.swift
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,37 +22,33 @@ import Backpack
 class LabelsPerformanceViewController: UIViewController {
     @IBOutlet weak var verticalStackView: UIStackView!
 
-    static let styles: [(BPKFontStyle, BPKFontStyle)] = [
-        (BPKFontStyle.textXs, BPKFontStyle.textXsEmphasized),
-        (BPKFontStyle.textSm, BPKFontStyle.textSmEmphasized),
-        (BPKFontStyle.textBase, BPKFontStyle.textBaseEmphasized),
-        (BPKFontStyle.textLg, BPKFontStyle.textLgEmphasized),
-        (BPKFontStyle.textXl, BPKFontStyle.textXlEmphasized)
+    let styles: [(BPKFontStyle, String)] = [
+        (.textHero1, "Hero1"),
+        (.textHero2, "Hero2"),
+        (.textHero3, "Hero3"),
+        (.textHero5, "Hero5"),
+        (.textHero4, "Hero4"),
+        (.textHeading1, "Heading1"),
+        (.textHeading2, "Heading2"),
+        (.textHeading3, "Heading3"),
+        (.textHeading4, "Heading4"),
+        (.textHeading5, "Heading5"),
+        (.textSubheading, "Subheading"),
+        (.textBodyLongform, "BodyLongform"),
+        (.textHeading4, "Heading4"),
+        (.textBodyDefault, "BodyDefault"),
+        (.textFootnote, "Footnote"),
+        (.textCaption, "Caption")
     ]
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        for index in 0..<100 {
-            let emphasized = index % 2 == 0
-            let view = LabelsPerformanceViewController.buildHorizontalStackView(emphasized: emphasized)
-            verticalStackView.addArrangedSubview(view)
+        for _ in 0..<60 {
+            styles.map {
+                let label = BPKLabel(fontStyle: $0.0)
+                label.text = $0.1
+                return label
+            }.forEach(verticalStackView.addArrangedSubview)
         }
-    }
-
-    static func buildHorizontalStackView(emphasized: Bool) -> UIStackView {
-        let horizontalStackView = UIStackView(frame: CGRect.zero)
-        horizontalStackView.axis = .horizontal
-        horizontalStackView.spacing = BPKSpacingSm
-        horizontalStackView.distribution = .equalSpacing
-
-        for style in styles {
-            let fontStyle = emphasized ? style.1 : style.0
-
-            let label = BPKLabel(fontStyle: fontStyle)
-            label.text = "Lorem ipsum"
-            horizontalStackView.addArrangedSubview(label)
-        }
-
-        return horizontalStackView
     }
 }

--- a/Example/Backpack/ViewControllers/LabelsViewController.swift
+++ b/Example/Backpack/ViewControllers/LabelsViewController.swift
@@ -41,7 +41,6 @@ class LabelsViewController: UIViewController {
         (.textHeading5, "Heading5"),
         (.textSubheading, "Subheading"),
         (.textBodyLongform, "BodyLongform"),
-        (.textHeading4, "Heading4"),
         (.textBodyDefault, "BodyDefault"),
         (.textFootnote, "Footnote"),
         (.textCaption, "Caption")

--- a/Example/Backpack/ViewControllers/LabelsViewController.swift
+++ b/Example/Backpack/ViewControllers/LabelsViewController.swift
@@ -1,7 +1,7 @@
 /*
  * Backpack - Skyscanner's Design System
  *
- * Copyright 2018-2021 Skyscanner Ltd
+ * Copyright 2018-2022 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,63 +26,34 @@ enum LabelsDisplayType {
 }
 
 class LabelsViewController: UIViewController {
-    @IBOutlet var labels: [BPKLabel]!
-    var type: LabelsDisplayType = .normal
+    @IBOutlet var stack: UIStackView!
 
-    static let normalStyles: [BPKFontStyle] = [
-        .textXxxl,
-        .textXxl,
-        .textXl,
-        .textLg,
-        .textBase,
-        .textSm,
-        .textXs,
-        .textCaps
+    let styles: [(BPKFontStyle, String)] = [
+        (.textHero1, "Hero1"),
+        (.textHero2, "Hero2"),
+        (.textHero3, "Hero3"),
+        (.textHero5, "Hero5"),
+        (.textHero4, "Hero4"),
+        (.textHeading1, "Heading1"),
+        (.textHeading2, "Heading2"),
+        (.textHeading3, "Heading3"),
+        (.textHeading4, "Heading4"),
+        (.textHeading5, "Heading5"),
+        (.textSubheading, "Subheading"),
+        (.textBodyLongform, "BodyLongform"),
+        (.textHeading4, "Heading4"),
+        (.textBodyDefault, "BodyDefault"),
+        (.textFootnote, "Footnote"),
+        (.textCaption, "Caption")
     ]
-    static let emphasizedStyles: [BPKFontStyle] = [
-        .textXxxlEmphasized,
-        .textXxlEmphasized,
-        .textXlEmphasized,
-        .textLgEmphasized,
-        .textBaseEmphasized,
-        .textSmEmphasized,
-        .textXsEmphasized,
-        .textCapsEmphasized
-    ]
-    static let heavyStyles: [BPKFontStyle] = [
-        .textXxxlHeavy,
-        .textXxlHeavy,
-        .textXlHeavy
-        ]
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        var styles: [BPKFontStyle]! = nil
-        switch type {
-        case .normal:
-            styles = LabelsViewController.normalStyles
-        case .emphasized:
-            styles = LabelsViewController.emphasizedStyles
-        case .heavy:
-            styles = LabelsViewController.heavyStyles
-        }
-        assert(styles.count <= labels.count, "Number of styles must be less than or equal to the number of labels")
-
-        labels[0..<(labels.count - styles.count)].forEach {
-            $0.isHidden = true
-        }
-        zip(labels[(labels.count - styles.count)..<labels.count], styles).forEach { (tuple) in
-            let (label, style) = tuple
-
-            label.isHidden = false
-            label.fontStyle = style
-
-            if style != .textCaps && style != .textCapsEmphasized {
-                label.text = "Lorem ipsum"
-            } else {
-                label.text = "LOREM IPSUM"
-            }
-        }
+        styles.map {
+            let label = BPKLabel(fontStyle: $0.0)
+            label.text = $0.1
+            label.numberOfLines = 0
+            return label
+        }.forEach(stack.addArrangedSubview)
     }
 }


### PR DESCRIPTION
The api on the Labels was already correct for supporting the new styles. This pr updates the examples of usage of the label to reflect what the new styles are and how they look like.
![Simulator Screen Shot - iPhone 8 - 2022-02-07 at 16 39 28](https://user-images.githubusercontent.com/13455159/152832561-aee87079-762b-4db2-a7cf-3c82b56cc27b.png) ![Simulator Screen Shot - iPhone 8 - 2022-02-07 at 16 39 31](https://user-images.githubusercontent.com/13455159/152832555-0895235d-e64b-4287-ae34-fcdd0107fa72.png)

