### PR TITLE
fixing bug when attributed text is empty

### DIFF
--- a/Backpack/Font/Classes/Generated/BPKFont.m
+++ b/Backpack/Font/Classes/Generated/BPKFont.m
@@ -101,7 +101,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSParagraphStyle *)paragraphStyleOnAttributedString:(NSAttributedString *)attributedText forStyle:(BPKFontStyle)style {
-    NSParagraphStyle *existingStyle = [attributedText attribute:NSParagraphStyleAttributeName atIndex: 0 longestEffectiveRange:NULL inRange:NSMakeRange(0, attributedText.length)];
+    NSParagraphStyle *existingStyle = nil;
+    if (attributedText.length > 0) {
+        existingStyle = [attributedText attribute:NSParagraphStyleAttributeName atIndex: 0 longestEffectiveRange:NULL inRange:NSMakeRange(0, attributedText.length)];
+    } else {
+        existingStyle = [NSParagraphStyle defaultParagraphStyle];
+    }
     if (existingStyle == nil) { return nil; }
     NSMutableParagraphStyle *paragraphStyle = [existingStyle mutableCopy];
     UIFont *font = [self fontForFontStyle:style];

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,11 @@
 # Unreleased
 > Place your changes below this line.
 
+**Fixed:**
+
+- Backpack/Font:
+  - Fixing bug when attributed text is empty.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -101,7 +101,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSParagraphStyle *)paragraphStyleOnAttributedString:(NSAttributedString *)attributedText forStyle:(BPKFontStyle)style {
-    NSParagraphStyle *existingStyle = [attributedText attribute:NSParagraphStyleAttributeName atIndex: 0 longestEffectiveRange:NULL inRange:NSMakeRange(0, attributedText.length)];
+    NSParagraphStyle *existingStyle = nil;
+    if (attributedText.length > 0) {
+        existingStyle = [attributedText attribute:NSParagraphStyleAttributeName atIndex: 0 longestEffectiveRange:NULL inRange:NSMakeRange(0, attributedText.length)];
+    } else {
+        existingStyle = [NSParagraphStyle defaultParagraphStyle];
+    }
     if (existingStyle == nil) { return nil; }
     NSMutableParagraphStyle *paragraphStyle = [existingStyle mutableCopy];
     UIFont *font = [self fontForFontStyle:style];


### PR DESCRIPTION
fixing bug when attributed text is empty

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`