### PR TITLE
[KOA-4887] Forwarding compression resistance and hugging priority

### DIFF
--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -340,6 +340,18 @@ NS_ASSUME_NONNULL_BEGIN
     [super setSelected:selected];
 }
 
+- (void)setContentHuggingPriority:(UILayoutPriority)priority forAxis:(UILayoutConstraintAxis)axis {
+    [super setContentHuggingPriority:priority forAxis:axis];
+    [self.titleLabel setContentHuggingPriority:priority forAxis:axis];
+    [self.imageView setContentHuggingPriority:priority forAxis:axis];
+}
+
+- (void)setContentCompressionResistancePriority:(UILayoutPriority)priority forAxis:(UILayoutConstraintAxis)axis {
+    [super setContentCompressionResistancePriority:priority forAxis:axis];
+    [self.titleLabel setContentCompressionResistancePriority:priority forAxis:axis];
+    [self.imageView setContentCompressionResistancePriority:priority forAxis:axis];
+}
+
 - (void)setHighlighted:(BOOL)highlighted {
     BPKAssertMainThread();
     [super setHighlighted:highlighted];

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -3,6 +3,9 @@
 
 **Added:**
 
+- Backpack/Button:
+  - Forwarding Content Compression Resistance and Hugging Priority to inner label and icon of the Button.
+
 - Backpack/Calendar:
   - Adding UI Tests for happy paths for calendar
 


### PR DESCRIPTION
Forwarding calls to `setContentCompressionResistancePriority` and `setContentHuggingPriority` to the inner components of the button to allow clients to properly manage those.

Remember to include the following changes:
+ [x] `UNRELEASED.md`