### PR TITLE
[NO-JIRA] Fix BPKPanel initializer

### DIFF
--- a/Backpack/Panel/Classes/BPKPanel.h
+++ b/Backpack/Panel/Classes/BPKPanel.h
@@ -46,9 +46,29 @@ IB_DESIGNABLE @interface BPKPanel : UIView
  */
 @property(nonatomic) BPKPanelStyle style;
 
+/**
+ * Create a `BPKPanel` with padded initially set.
+ *
+ * @param padded Whether the panel should have padding or not.
+ */
 - (instancetype)initWithPadded:(BOOL)padded NS_DESIGNATED_INITIALIZER;
-- (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
-- (instancetype)new NS_UNAVAILABLE;
+
+/**
+ * Create a `BPKPanel` with a given frame.
+ *
+ * @param frame The initial frame of the card.
+ * @return `BPKPanel` instance.
+ */
+- (instancetype)initWithFrame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Creates a `BPKPanel` with a decoder (typically when creating from Storyboards)
+ *
+ * @param aDecoder Decoder object to extract parameters from
+ * @return `BPKPanel` instance.
+ */
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)new NS_UNAVAILABLE;
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Panel/Classes/BPKPanel.m
+++ b/Backpack/Panel/Classes/BPKPanel.m
@@ -45,6 +45,17 @@ const BOOL BPKPanelDefaultPaddedValue = YES;
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame {
+    BPKAssertMainThread();
+    self = [super initWithFrame:frame];
+
+    if (self) {
+        [self setupWithPadded:BPKPanelDefaultPaddedValue];
+    }
+
+    return self;
+}
+
 - (instancetype)initWithPadded:(BOOL)padded {
     BPKAssertMainThread();
     self = [super initWithFrame:CGRectZero];

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,7 +4,7 @@
 **Fixed:**
 
 - Upgraded to the current node LTS - 16
-- Added initialiser to BPKPanel
+- Added initialiser to BpkPanel
 
 ## How to write a good changelog entry
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,7 +4,7 @@
 **Fixed:**
 
 - Upgraded to the current node LTS - 16
-- Added initializer to BPKPanel
+- Added initialiser to BPKPanel
 
 ## How to write a good changelog entry
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,7 +4,7 @@
 **Fixed:**
 
 - Upgraded to the current node LTS - 16
-- Added init(frame:) to BPKPanel
+- Added initializer to BPKPanel
 
 ## How to write a good changelog entry
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,7 @@
 **Fixed:**
 
 - Upgraded to the current node LTS - 16
+- Added init(frame:) to BPKPanel
 
 ## How to write a good changelog entry
 


### PR DESCRIPTION
When creating a BPKPanel in code using `BPKPanel()`, it would not apply any styling to the panel. Only when calling `BPKPanel(padded: true/false)` it would apply the styling.

When inspecting the code there was an 'unavailable' marker for the 'with frame' initializer, but this was ignored by Swift, allowing customers to initialize the panel without passing any parameters and falling back to the frame initializer.

This PR adds the with frame and aligns it with how the BPKCard handles this case. We also took the time to align the docs in the header file with the ones found on BPKCard.

| Before | After |
| --------------- | --------------- |
| ![simulator_screenshot_CD5D4001-10B4-4A79-9751-787EAF41E1B5](https://user-images.githubusercontent.com/728889/165008176-95cc3645-806b-44c6-8332-df857f1420a6.png) | ![simulator_screenshot_F4068897-9BC2-4FAC-BA6A-3F2B1C0DAF81](https://user-images.githubusercontent.com/728889/165008149-3f50a5f2-66d4-487f-a72b-70837af4d54e.png) |

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_