### PR TITLE
[KOA-4720] adding source kitten to generate swift docs with jazzy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
 
       - name: Install clang format
         run: brew install clang-format@14
+      
+      - name: Install sourcekitten
+        run: brew install sourcekitten
 
       - name: nvm install
         run: nvm install

--- a/Rakefile
+++ b/Rakefile
@@ -230,6 +230,12 @@ end
 desc "Build the static API docs"
 task :docs, :outputDir do |t, args|
   args.with_defaults(:outputDir => "docs")
+  sh "sourcekitten doc -- -workspace #{EXAMPLE_WORKSPACE} -scheme Backpack > swiftDoc.json"
+  sh "jazzy --sourcekitten-sourcefile swiftDoc.json"
+  FileUtils.rm('swiftDoc.json')
+  sh "sourcekitten doc -- -workspace #{EXAMPLE_WORKSPACE} -scheme \"#{SWIFTUI_SCHEME}\" > swiftDoc-swiftui.json"
+  sh "jazzy --sourcekitten-sourcefile swiftDoc-swiftui.json"
+  FileUtils.rm('swiftDoc-swiftui.json')
   sh "bundle exec jazzy -o #{args.outputDir} --objc --author Backpack --umbrella-header Backpack/Backpack.h --framework-root Backpack --module Backpack --skip-undocumented --sdk iphonesimulator"
 end
 


### PR DESCRIPTION
Jazzy states in their docs that for combined projects with ObjC and Swift, there's an extra step needed for swift code to be picked up to generate docs. This step is to first create a file that defines how to scan the swift code. SourceKitten plays this role and it's the recommended (by Jazzy) tool for it.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [x] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_