### PR TITLE
failing to release if clang is not installed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,6 +106,7 @@ end
 desc "Runs clang-format on all h and m files to ensure formatting is correct"
 task :lint do
   abort red "The following generated files have changed during setup:\n#{get_changed_files}" unless check_pristine
+  sh "brew list clang-format@1" # Fail if clang-format is not installed
   `find ./Backpack -name "*.[hm]" -exec clang-format -i {} \+`
   abort red "clang-format has changed the following files:\n#{get_changed_files}" unless check_pristine
   sh "bundle exec pod lib lint --allow-warnings"


### PR DESCRIPTION
Clang is used for linting and it wasn't being run if it's not installed on the releaser's computer.
the release script will now fail if this is not installed.

This will not be a problem later on when we move to automated releases on CI, since installing this library will be part of the process