### PR TITLE
fix: spacings preview

### DIFF
--- a/Example/Backpack/ViewControllers/Tokens/SpacingTokensView.swift
+++ b/Example/Backpack/ViewControllers/Tokens/SpacingTokensView.swift
@@ -35,10 +35,9 @@ struct SpacingTokensView: View {
             ForEach(spacingTokens, id: \.0) { token in
                 HStack {
                     Color(.primaryColor)
-                        .frame(width: .lg, height: .base)
                         .frame(
                             maxWidth: token.1,
-                            maxHeight: .lg)
+                            maxHeight: .base)
                     Spacer()
                     Text("\(token.0) = \(token.1.value, specifier: "%.0f")")
                 }


### PR DESCRIPTION
The demo for the BPKSpacing was broken after introducing the new tokens

| Before | After | 
| --- | --- |
| ![simulator_screenshot_242146AC-1F4E-41EE-B3A6-D9A6F96ADD1C](https://user-images.githubusercontent.com/728889/167247236-87681957-08dd-4538-8a3d-c22cf9776f52.png) | ![simulator_screenshot_80DC7783-A772-48CD-83A4-FAE140020948](https://user-images.githubusercontent.com/728889/167247257-088e6f3f-b73d-4bc8-b030-2b57fda96e66.png) |

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_