### PR TITLE
KOA-5168 add environment to build step when releasing

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -20,7 +20,6 @@ jobs:
   CI:
     name: Build and Test
     runs-on: macos-11
-    environment: Publishing
     permissions:
       statuses: write
       pull-requests: write

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -20,6 +20,7 @@ jobs:
   CI:
     name: Build and Test
     runs-on: macos-11
+    environment: Publishing
     permissions:
       statuses: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ defaults:
 jobs:
   Build:
       name: Build
-      environment: Publishing
       permissions:
         statuses: write
         pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ defaults:
 jobs:
   Build:
       name: Build
+      environment: Publishing
       permissions:
         statuses: write
         pull-requests: write


### PR DESCRIPTION
We need to add the Publishing environment when releasing the build step

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_