### PR TITLE
Not running tests while pushing the trunk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 defaults:
   run:
@@ -10,71 +10,70 @@ defaults:
 
 jobs:
   Build:
-      name: Build
-      permissions:
-        statuses: write
-        pull-requests: write
-      uses: ./.github/workflows/_build.yml
+    name: Build
+    permissions:
+      statuses: write
+      pull-requests: write
+    uses: ./.github/workflows/_build.yml
   Deploy:
     name: Release to Cocoapods
     runs-on: macos-11
     environment: Publishing
     needs: [Build]
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          ref: main
 
-    - name: Checkout source code
-      uses: actions/checkout@v3
-      with:
-        ref: main
-    
-    - name: Install sourcekitten
-      run: brew install sourcekitten
+      - name: Install sourcekitten
+        run: brew install sourcekitten
 
-    - name: Set Ruby version
-      uses: ruby/setup-ruby@v1 # Sets ruby version via `.ruby-version`
+      - name: Set Ruby version
+        uses: ruby/setup-ruby@v1 # Sets ruby version via `.ruby-version`
 
-    - name: Bundle Install
-      run: bundle install --jobs 4 --retry 3
-      
-    - name: Pod repo update
-      run: | 
-        bundle exec pod repo update
+      - name: Bundle Install
+        run: bundle install --jobs 4 --retry 3
 
-    - name: Publish Pods - Backpack Common
-      run: |
-        set -eo pipefail
-        bundle exec pod trunk push Backpack-Common.podspec --allow-warnings --synchronous
-        bundle exec pod repo update
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        LIB_VERSION: ${{ github.event.release.tag_name }}
+      - name: Pod repo update
+        run: |
+          bundle exec pod repo update
 
-    - name: Publish Pods - Backpack UIKit
-      run: |
-        set -eo pipefail
-        bundle exec pod trunk push Backpack.podspec --allow-warnings --synchronous
-        bundle exec pod repo update
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        LIB_VERSION: ${{ github.event.release.tag_name }}
+      - name: Publish Pods - Backpack Common
+        run: |
+          set -eo pipefail
+          bundle exec pod trunk push Backpack-Common.podspec --allow-warnings --skip-tests--synchronous 
+          bundle exec pod repo update
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          LIB_VERSION: ${{ github.event.release.tag_name }}
 
-    - name: Publish Pods - Backpack SwiftUI
-      run: |
-        set -eo pipefail
-        bundle exec pod trunk push Backpack-SwiftUI.podspec --allow-warnings --synchronous
-        bundle exec pod repo update
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        LIB_VERSION: ${{ github.event.release.tag_name }}
+      - name: Publish Pods - Backpack UIKit
+        run: |
+          set -eo pipefail
+          bundle exec pod trunk push Backpack.podspec --allow-warnings --skip-tests --synchronous
+          bundle exec pod repo update
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          LIB_VERSION: ${{ github.event.release.tag_name }}
 
-    - name: Build code docs
-      run: ./scripts/build-docs-ci ${{ github.event.release.tag_name }}
+      - name: Publish Pods - Backpack SwiftUI
+        run: |
+          set -eo pipefail
+          bundle exec pod trunk push Backpack-SwiftUI.podspec --allow-warnings --skip-tests --synchronous
+          bundle exec pod repo update
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          LIB_VERSION: ${{ github.event.release.tag_name }}
 
-    - name: Deploy code documentation
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        personal_token: ${{ secrets.DEPLOY_TOKEN }}
-        publish_dir: docs/
-        keep_files: true
-        external_repository: backpack/ios
-        publish_branch: main
+      - name: Build code docs
+        run: ./scripts/build-docs-ci ${{ github.event.release.tag_name }}
+
+      - name: Deploy code documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.DEPLOY_TOKEN }}
+          publish_dir: docs/
+          keep_files: true
+          external_repository: backpack/ios
+          publish_branch: main


### PR DESCRIPTION
When releasing, Cocoapods triggers a Test Run with a simulator that's not the same one that we use for generating the snapshot tests, thus, it fails the release. Now that the tests are not in the example project, but in the actual lib, there's no way to control what the `pod trunk push` uses for running the snapshot tests.

We're running the tests manually anyways before calling `pod trunk push` in the release workflow (releasing depends on the build workflow, which analyzes and run all tests!), so it was redundant anyways!

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_