### PR TITLE
KOA-5155 fix how we open modal

### DIFF
--- a/Backpack/Dialog/Classes/BPKDialogController.m
+++ b/Backpack/Dialog/Classes/BPKDialogController.m
@@ -74,7 +74,9 @@ NS_ASSUME_NONNULL_BEGIN
         self.iconDefinition = iconDefinition;
         self.flareView = flareView;
         self.scrimActions = [NSMutableArray new];
-        self.transitioningDelegate = self;  
+        self.transitioningDelegate = self;
+        
+        [self setupViews];
     }
 
     return self;
@@ -82,8 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
-    [self setupViews];
+   
     [self addViews];
     [self setupConstraints];
 }

--- a/Backpack/Dialog/Classes/BPKDialogController.m
+++ b/Backpack/Dialog/Classes/BPKDialogController.m
@@ -74,14 +74,18 @@ NS_ASSUME_NONNULL_BEGIN
         self.iconDefinition = iconDefinition;
         self.flareView = flareView;
         self.scrimActions = [NSMutableArray new];
-        self.transitioningDelegate = self;
-
-        [self setupViews];
-        [self addViews];
-        [self setupConstraints];
+        self.transitioningDelegate = self;  
     }
 
     return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    [self setupViews];
+    [self addViews];
+    [self setupConstraints];
 }
 
 + (instancetype)dialogControllerWithTitle:(NSString *_Nullable)title


### PR DESCRIPTION
We setup the views when init'ing the modal controller. This is not the correct time to have access to the view.

The setup functions have been moved, so we call them in viewDidLoad, this will result in the correct behaviour when the iPad is in 'splitscreen' mode.

| Before | After |
| --- | --- |
| ![simulator_screenshot_FB99323B-82B7-4AC8-AAEB-2A18CCBA2DEF](https://user-images.githubusercontent.com/728889/176619719-9304fd9e-5512-4ea2-ae0e-f29cf909bde3.png) | ![simulator_screenshot_6B342C5D-4556-4C16-BC7C-7FE4055742AD](https://user-images.githubusercontent.com/728889/176621836-e4d45a40-cc4a-435c-8959-4da49913fae5.png) |
| ![simulator_screenshot_5BF4AB04-65AB-4A4B-87A3-3D694AA0BB48](https://user-images.githubusercontent.com/728889/176619789-ec7089ef-818e-4edb-accf-2159e8ba64a7.png) | ![simulator_screenshot_98065F20-D83A-42BF-8086-1CD55A8DD8F2](https://user-images.githubusercontent.com/728889/176621916-b16fdb37-0cef-4628-94b4-218fa59efaad.png) |



+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_