### PR TITLE
KOA-5534 Update BPKNavigationBar

### DIFF
--- a/Backpack/NavigationBar/Classes/BPKNavigationBar.m
+++ b/Backpack/NavigationBar/Classes/BPKNavigationBar.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, readonly) BPKNavigationBarTitleView *titleView;
 
 // Background
-@property(nonatomic, strong, readonly) UIVisualEffectView *backgroundView;
+@property(nonatomic, strong, readonly) UIView *backgroundView;
 @property(nonatomic, strong, readonly) UIView *borderView;
 @property(nonatomic, strong, readonly) UIBlurEffect *backgroundEffect;
 @property(nonatomic, strong, readonly) UIColor *borderViewBackgroundColor;
@@ -170,9 +170,8 @@ NS_ASSUME_NONNULL_BEGIN
             scrollView.scrollIndicatorInsets = scrollView.contentInset;
             self.titleView.showsContent = YES;
             self.borderView.alpha = 1.0;
-            self.backgroundView.backgroundColor = BPKColor.clear;
+            self.backgroundView.backgroundColor = BPKColor.canvasColor;
             self.collapsed = YES;
-            self.backgroundView.effect = self.backgroundEffect;
         }
     } else {
         // Expanded state
@@ -191,7 +190,6 @@ NS_ASSUME_NONNULL_BEGIN
             self.titleView.showsContent = NO;
             self.borderView.alpha = 0.0;
             self.backgroundView.backgroundColor = nil;
-            self.backgroundView.effect = nil;
 
             self.collapsed = NO;
         }
@@ -226,20 +224,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return _largeTitleView;
-}
-
-- (UIBlurEffect *)backgroundEffect {
-    if (!_backgroundEffect) {
-#if __BPK_DARK_MODE_SUPPORTED
-        if (@available(iOS 13.0, *)) {
-            _backgroundEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemThickMaterial];
-            return _backgroundEffect;
-        }
-#endif
-        _backgroundEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
-    }
-
-    return _backgroundEffect;
 }
 
 - (BPKNavigationBarTitleView *)titleView {
@@ -363,7 +347,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (UIColor *)borderViewBackgroundColor {
-    return [BPKColor dynamicColorWithLightVariant:BPKColor.skyGrayTint06 darkVariant:BPKColor.blackTint01];
+    return [BPKColor dynamicColorWithLightVariant:BPKColor.surfaceHighlightColor darkVariant:BPKColor.textSecondaryColor];
 }
 
 @end


### PR DESCRIPTION
# BPKNavigationBar
Update the component with new semantic tokens. Remove visualEffectView in favor of a static colour.

| Light | Dark | 
| --- | --- |
| ![simulator_screenshot_C99D2CC9-B4CF-4396-B999-22EEFB9673AE](https://user-images.githubusercontent.com/728889/187136938-27a8abc9-cb26-49ad-a59b-8d1f22df22fb.png) | ![simulator_screenshot_6B622212-563B-4A4E-87D4-820926A27776](https://user-images.githubusercontent.com/728889/187137071-bc01bb10-ce58-442a-8bde-17f3af3169fc.png) |
| ![simulator_screenshot_0CAD73CD-6035-49E6-8F07-5E5B26937037](https://user-images.githubusercontent.com/728889/187136972-df1da537-d17d-4c5f-9414-d2495ab98b4f.png) |  ![simulator_screenshot_555A7249-062B-4233-B8C7-DDF52860EDAF](https://user-images.githubusercontent.com/728889/187136995-973688b5-ca2a-493d-90f4-6c7b47fa4daf.png) |



+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_