### PR TITLE
SwiftUI BPKIconView improved API

### DIFF
--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -20,24 +20,12 @@ import SwiftUI
 import Backpack_Common
 
 public struct BPKIconView: View {
-    @Binding var icon: BPKIcon
-    @Binding var size: BPKIcon.Size
-    
-    public init(_ icon: Binding<BPKIcon>, size: Binding<BPKIcon.Size> = .constant(.small)) {
-        self._icon = icon
-        self._size = size
-    }
-    
+    let icon: BPKIcon
+    let size: BPKIcon.Size
+
     public init(_ icon: BPKIcon, size: BPKIcon.Size = .small) {
-        self.init(.constant(icon), size: .constant(size))
-    }
-    
-    public init(_ icon: Binding<BPKIcon>, size: BPKIcon.Size = .small) {
-        self.init(icon, size: .constant(size))
-    }
-    
-    public init(_ icon: BPKIcon, size: Binding<BPKIcon.Size> = .constant(.small)) {
-        self.init(.constant(icon), size: size)
+        self.icon = icon
+        self.size = size
     }
 
     public var body: some View {
@@ -84,6 +72,6 @@ private extension Image {
 
 struct BPKIconView_Previews: PreviewProvider {
     static var previews: some View {
-        BPKIconView(.constant(.account), size: .constant(.large))
+        BPKIconView(.account, size: .large)
     }
 }

--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -20,12 +20,27 @@ import SwiftUI
 import Backpack_Common
 
 public struct BPKIconView: View {
-    @State var icon: BPKIcon
-    @State var size: BPKIcon.Size
+    @Binding var icon: BPKIcon
+    @Binding var size: BPKIcon.Size
     
     public init(_ icon: BPKIcon, size: BPKIcon.Size = .small) {
-        self.icon = icon
-        self.size = size
+        self._icon = .constant(icon)
+        self._size = .constant(size)
+    }
+    
+    public init(_ icon: Binding<BPKIcon>, size: Binding<BPKIcon.Size> = .constant(.small)) {
+        self._icon = icon
+        self._size = size
+    }
+    
+    public init(_ icon: Binding<BPKIcon>, size: BPKIcon.Size = .small) {
+        self._icon = icon
+        self._size = .constant(size)
+    }
+    
+    public init(_ icon: BPKIcon, size: Binding<BPKIcon.Size> = .constant(.small)) {
+        self._icon = .constant(icon)
+        self._size = size
     }
 
     public var body: some View {
@@ -72,6 +87,6 @@ private extension Image {
 
 struct BPKIconView_Previews: PreviewProvider {
     static var previews: some View {
-        BPKIconView(.account, size: .large)
+        BPKIconView(.constant(.account), size: .constant(.large))
     }
 }

--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -23,24 +23,21 @@ public struct BPKIconView: View {
     @Binding var icon: BPKIcon
     @Binding var size: BPKIcon.Size
     
-    public init(_ icon: BPKIcon, size: BPKIcon.Size = .small) {
-        self._icon = .constant(icon)
-        self._size = .constant(size)
-    }
-    
     public init(_ icon: Binding<BPKIcon>, size: Binding<BPKIcon.Size> = .constant(.small)) {
         self._icon = icon
         self._size = size
     }
     
+    public init(_ icon: BPKIcon, size: BPKIcon.Size = .small) {
+        self.init(.constant(icon), size: .constant(size))
+    }
+    
     public init(_ icon: Binding<BPKIcon>, size: BPKIcon.Size = .small) {
-        self._icon = icon
-        self._size = .constant(size)
+        self.init(icon, size: .constant(size))
     }
     
     public init(_ icon: BPKIcon, size: Binding<BPKIcon.Size> = .constant(.small)) {
-        self._icon = .constant(icon)
-        self._size = size
+        self.init(.constant(icon), size: size)
     }
 
     public var body: some View {


### PR DESCRIPTION
# SwiftUI BPKIconView
The current iconview did not allow for the icon to be changed after the view was created. In order to facilitate this, we changed from from var to let.

This allows for size and icon changes when the binding changes. 

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_