### PR TITLE
[KOA-5645] Fix iOS docs site

### DIFF
--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -40,6 +40,7 @@ function buildDocsHtmlFiles() {
   mkdir -p "$outputDir/versions/latest"
 
   buildRedirectHTML "$outputDir/404.html"
+  buildRedirectHTML "$outputDir/index.html"
   buildLatestIndex $version
 }
 

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -40,7 +40,6 @@ function buildDocsHtmlFiles() {
   mkdir -p "$outputDir/versions/latest"
 
   buildRedirectHTML "$outputDir/404.html"
-  buildRedirectHTML "$outputDir/index.html"
   buildLatestIndex $version
 }
 

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -3,12 +3,12 @@
 EXAMPLE_WORKSPACE='Example/Backpack.xcworkspace'
 
 function documentUIKit() {
-  sourcekitten doc -- -workspace $EXAMPLE_WORKSPACE -scheme "Backpack Native" >swiftDoc.json
+  sourcekitten doc -- -workspace $EXAMPLE_WORKSPACE -scheme Backpack >swiftDoc.json
 
   $(dirname "$0")/create-docs-header
 
   sourcekitten doc --objc $(pwd)/Backpack/BackpackDocHeaders.h -- -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator) -I $(pwd) -fmodules >objcDocs.json
-  jazzy --sourcekitten-sourcefile objcDocs.json,swiftDoc.json -o $outputDir/uikit
+  jazzy --sourcekitten-sourcefile objcDocs.json,swiftDoc.json -o "$outputDir/versions/$version/uikit"
 
   rm Backpack/BackpackDocHeaders.h
   rm objcDocs.json
@@ -16,22 +16,22 @@ function documentUIKit() {
 }
 
 function documentSwiftUI() {
-  sourcekitten doc -- -workspace $EXAMPLE_WORKSPACE -scheme "Backpack SwiftUI" >swiftDoc-swiftui.json
-  jazzy --sourcekitten-sourcefile swiftDoc-swiftui.json -o $outputDir/swiftui
+  sourcekitten doc -- -workspace $EXAMPLE_WORKSPACE -scheme "Backpack-SwiftUI" >swiftDoc-swiftui.json
+  jazzy --sourcekitten-sourcefile swiftDoc-swiftui.json -o "$outputDir/versions/$version/swiftui"
   rm swiftDoc-swiftui.json
 }
 
 function buildRedirectHTML() {
   echo '<!DOCTYPE html>
   <html>
-    <meta http-equiv="refresh" content="0;url=/ios/versions/latest" />
+    <meta http-equiv="refresh" content="0;url=/ios/versions/latest/index.html" />
   </html>' >$1
 }
 
 function buildLatestIndex() {
   echo "<!DOCTYPE html>
   <html>
-    <meta http-equiv=\"refresh\" content=\"0;url=/ios/versions/$1/swiftui\" />
+    <meta http-equiv=\"refresh\" content=\"0;url=/ios/versions/$1/swiftui/index.html\" />
   </html>" >"docs/versions/latest/index.html"
 }
 


### PR DESCRIPTION
KOA-5645
Docs were not being generated in the right folder, nor with the right parameters. It's fixed now!

The tool is not picking up the """""enums""""" that we do in obj-c, like `BPKSPacing.h` because they're not really enums.. we should migrate those over to proper objc enums or just move them to swift enums!! but that's a different change to this