### PR TITLE
liberating clang format version

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -89,7 +89,7 @@ jobs:
         working-directory: Example
 
       - name: Install clang-format
-        run: brew install clang-format@14
+        run: brew install clang-format
 
       - name: Check pristine
         run: ./scripts/lint


### PR DESCRIPTION
Clang format 14 was removed from brew, so our installation of it fails, liberating the version as we want to be using the latest all the time anyways