### PR TITLE
[KOA-5736] Deprecating dynamicColor

### DIFF
--- a/Backpack-SwiftUI/Color/Classes/Generated/BPKDynamicColors.swift
+++ b/Backpack-SwiftUI/Color/Classes/Generated/BPKDynamicColors.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 
+@available(*, deprecated, message: "Please use only available BPKColors")
 public func dynamicColor(lightVariant: UIColor, darkVariant: UIColor) -> UIColor {
     UIColor { $0.userInterfaceStyle == .dark ? darkVariant : lightVariant }
 }

--- a/Backpack/Color/Classes/Generated/BPKColor.h
+++ b/Backpack/Color/Classes/Generated/BPKColor.h
@@ -826,8 +826,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param lightVariant The color used in light mode, or on systems that don't support dark-mode.
  * @param darkVariant The color used in dark mode.
+ * @deprecated Please use only available BPKColors.
  */
-+ (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant;
++ (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant __deprecated_msg("Please use only available BPKColors");
 
 @end
 NS_ASSUME_NONNULL_END

--- a/templates/BPKColor.h.njk
+++ b/templates/BPKColor.h.njk
@@ -70,8 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param lightVariant The color used in light mode, or on systems that don't support dark-mode.
  * @param darkVariant The color used in dark mode.
+ * @deprecated Please use only available BPKColors.
  */
-+ (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant;
++ (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant __deprecated_msg("Please use only available BPKColors");
 
 @end
 NS_ASSUME_NONNULL_END

--- a/templates/swiftui/DynamicColors.njk
+++ b/templates/swiftui/DynamicColors.njk
@@ -18,6 +18,7 @@
 
 import UIKit
 
+@available(*, deprecated, message: "Please use only available BPKColors")
 public func dynamicColor(lightVariant: UIColor, darkVariant: UIColor) -> UIColor {
     UIColor { $0.userInterfaceStyle == .dark ? darkVariant : lightVariant }
 }


### PR DESCRIPTION
KOA-5736

Deprecating dynamicColor methods to discourage its usage and enable it's future removal/make internal. 