### PR TITLE
BPKBadge accessibility outline

### DIFF
--- a/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
+++ b/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
@@ -41,6 +41,8 @@ public struct BPKBadge: View {
             .background(style.backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: .xs))
             .outline(style.borderColor, cornerRadius: .xs)
+            .accessibilityElement()
+            .accessibilityLabel(title)
     }
     
     /// Sets the style of the badge

--- a/Backpack/Badge/Classes/Badge.swift
+++ b/Backpack/Badge/Classes/Badge.swift
@@ -99,12 +99,14 @@ public class BPKBadge: UIView {
     private func placeElements() {
         removeStackViewSubviews()
         containerStackView.addArrangedSubview(label)
-        guard let icon = icon else { return }
+        guard let _ = icon else { return }
         containerStackView.insertArrangedSubview(iconView, at: 0)
     }
     
     private func setup() {
         addSubview(containerStackView)
+        
+        isAccessibilityElement = true
         
         layer.cornerRadius = BPKCornerRadiusXs
         layer.masksToBounds = true
@@ -118,8 +120,6 @@ public class BPKBadge: UIView {
         ])
         
         updateLookAndFeel()
-        
-        self.isAccessibilityElement = true
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Backpack/Badge/Classes/Badge.swift
+++ b/Backpack/Badge/Classes/Badge.swift
@@ -23,7 +23,10 @@ import UIKit
 public class BPKBadge: UIView {
     public var message: String? {
         get { label.text }
-        set { label.text = newValue }
+        set {
+            label.text = newValue
+            accessibilityLabel = newValue
+        }
     }
     
     public var type: BPKBadgeType = .success {
@@ -115,6 +118,8 @@ public class BPKBadge: UIView {
         ])
         
         updateLookAndFeel()
+        
+        self.isAccessibilityElement = true
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Backpack/Badge/Classes/Badge.swift
+++ b/Backpack/Badge/Classes/Badge.swift
@@ -99,7 +99,7 @@ public class BPKBadge: UIView {
     private func placeElements() {
         removeStackViewSubviews()
         containerStackView.addArrangedSubview(label)
-        guard let _ = icon else { return }
+        if icon == nil { return }
         containerStackView.insertArrangedSubview(iconView, at: 0)
     }
     


### PR DESCRIPTION
# BPKBadge

The outline of the accessibility marquee for the badge was focusing on the label and not the entire badge. With this PR we fix UIKit and SwiftUI to have the correct behaviour. 

| Before | After | 
| --- | --- |
| ![IMG_C8749D847A68-1](https://user-images.githubusercontent.com/728889/219871377-05cc2e28-63dd-4408-8e98-302479b0640c.jpeg) | ![IMG_6DA9906A31C4-1](https://user-images.githubusercontent.com/728889/219871264-a4aaf6fe-7e4d-4012-8204-aec681760738.jpeg) |





+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
