### PR TITLE
BPKCarousel: Disabling scrolling when setting one image

### DIFF
--- a/Backpack/Carousel/Classes/CarouselPageViewController.swift
+++ b/Backpack/Carousel/Classes/CarouselPageViewController.swift
@@ -45,11 +45,11 @@ final class CarouselPageViewController: UIPageViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        dataSource = self
         delegate = self
     }
     
     func set(images: [UIView], animated: Bool = true) {
+        dataSource = images.count > 1 ? self : nil
         pages.removeAll()
         images.forEach { pages.append(CarouselContentViewController(view: $0)) }
         setCurrentImage(index: 0, animated: animated)


### PR DESCRIPTION
As discussed and agreed here: https://skyscanner.slack.com/archives/C04NDB73D8S/p1676459363098889?thread_ts=1676046304.364759&cid=C04NDB73D8S 
