### PR TITLE
BPKHorizontal navigation Accessibility fix

### DIFF
--- a/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.swift
+++ b/Backpack/HorizontalNavigation/Classes/BPKHorizontalNavigation.swift
@@ -289,6 +289,8 @@ public class BPKHorizontalNavigation<Size: BPKHorizontalNavigationSize>: UIContr
             heightAnchor.constraint(equalTo: scrollView.heightAnchor),
             bottomAnchor.constraint(equalTo: barView.bottomAnchor)
         ])
+        
+        self.accessibilityTraits.insert(.tabBar)
 
         repopulateStackView()
         self.selectedItemIndex = selectedItemIndex

--- a/Example/Backpack NativeUITests/HorizontalNavigationUITest.swift
+++ b/Example/Backpack NativeUITests/HorizontalNavigationUITest.swift
@@ -20,11 +20,11 @@ import XCTest
 
 class HorizontalNavigationUITest: BackpackUITestCase {
     lazy var flightsOption: XCUIElement = {
-        return app.buttons["Flights"]
+        return app.buttons["Flights"].firstMatch
     }()
 
     lazy var hotelsOption: XCUIElement = {
-        return app.buttons["Hotels"]
+        return app.buttons["Hotels"].firstMatch
     }()
 
     func navigateAndShow() {


### PR DESCRIPTION
# BPKHorizontal navigation

Added the `.tabBar` trait, so people are informed the navigation behaves like a tabbar. 
This will announce "tab x of y" which makes it easier to understand the layour of the page. 

| Before | After |
| --- | --- |
| ![IMG_F9EC8D7FAAE6-1](https://user-images.githubusercontent.com/728889/230325925-95d4f493-8a17-4291-a884-44be31d22ecc.jpeg) | ![IMG_2C0DB6F84FAF-1](https://user-images.githubusercontent.com/728889/230325601-5d2aae12-a3e0-45ce-b93c-d87a1face58f.jpeg) |

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
