### PR TITLE
[NoJira] Enabling updates of price related values

### DIFF
--- a/Backpack/Price/Classes/BPKPrice.swift
+++ b/Backpack/Price/Classes/BPKPrice.swift
@@ -63,7 +63,7 @@ public final class BPKPrice: UIView {
     public var size: Size {
         didSet { stylePriceLabel() }
     }
-        
+    
     private let priceLabel = BPKLabel()
     private let trailingTextLabel = BPKLabel()
     private let previousPriceLabel = BPKLabel()
@@ -93,18 +93,7 @@ public final class BPKPrice: UIView {
         return stackView
     }()
     
-    public init(
-        price: String? = nil,
-        leadingText: String? = nil,
-        previousPrice: String? = nil,
-        trailingText: String? = nil,
-        alignment: Alignment = .leading,
-        size: Size = .large
-    ) {
-        self.price = price
-        self.leadingText = leadingText
-        self.previousPrice = previousPrice
-        self.trailingText = trailingText
+    public init(alignment: Alignment = .leading, size: Size = .large) {
         self.alignment = alignment
         self.size = size
         
@@ -118,7 +107,7 @@ public final class BPKPrice: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-     
+    
     private func setupView() {
         [priceLabel, trailingTextLabel].forEach {
             priceStackView.addArrangedSubview($0)

--- a/Backpack/Price/Classes/BPKPrice.swift
+++ b/Backpack/Price/Classes/BPKPrice.swift
@@ -29,31 +29,39 @@ public final class BPKPrice: UIView {
     }
     
     public var price: String? {
-        didSet { priceLabel.text = price }
+        didSet {
+            priceLabel.text = price
+            updateViews()
+        }
     }
     
     public var leadingText: String? {
-        didSet { leadingTextLabel.text = leadingText }
+        didSet {
+            leadingTextLabel.text = leadingText
+            updateViews()
+        }
     }
     
     public var previousPrice: String? {
-        didSet { previousPriceLabel.text = previousPrice }
+        didSet {
+            previousPriceLabel.text = previousPrice
+            updateViews()
+        }
     }
     
     public var trailingText: String? {
-        didSet { trailingTextLabel.text = trailingText }
+        didSet {
+            trailingTextLabel.text = trailingText
+            updateViews()
+        }
     }
     
     public var alignment: Alignment {
-        didSet {
-            updateAlignmentPositioning()
-        }
+        didSet { updateAlignmentPositioning() }
     }
     
     public var size: Size {
-        didSet {
-            updateAlignmentPositioning()
-        }
+        didSet { stylePriceLabel() }
     }
         
     private let priceLabel = BPKLabel()
@@ -74,12 +82,14 @@ public final class BPKPrice: UIView {
         stackView.axis = .horizontal
         stackView.spacing = BPKSpacingSm
         stackView.alignment = .firstBaseline
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
     
     private let containerStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
     
@@ -108,7 +118,7 @@ public final class BPKPrice: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+     
     private func setupView() {
         [priceLabel, trailingTextLabel].forEach {
             priceStackView.addArrangedSubview($0)
@@ -118,6 +128,12 @@ public final class BPKPrice: UIView {
             containerStackView.addArrangedSubview($0)
         }
         
+        updateViews()
+        containerStackView.addSubview(priceStackView)
+        addSubview(containerStackView)
+    }
+    
+    private func updateViews() {
         stylePriceLabel()
         styleAccessoryLabels()
         
@@ -129,22 +145,12 @@ public final class BPKPrice: UIView {
         previousPriceLabel.text = previousPrice
         applyLineThroughStyling()
         
-        [
-            priceStackView,
-            containerStackView
-        ].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        }
-        
         previousPriceLabel.isHidden = previousPrice == nil
         leadingTextLabel.isHidden = leadingText == nil
         trailingTextLabel.isHidden = trailingText == nil
         separatorLabel.isHidden = previousPriceLabel.isHidden || leadingTextLabel.isHidden
         
         updateAlignmentPositioning()
-        
-        containerStackView.addSubview(priceStackView)
-        addSubview(containerStackView)
     }
     
     private func setupConstraints() {

--- a/Backpack/Rating/Classes/BPKRating.swift
+++ b/Backpack/Rating/Classes/BPKRating.swift
@@ -111,12 +111,9 @@ public class BPKRating: UIView {
 
     // MARK: - Init
     public init(
-        accessibilityLabel: String = "",
-        title: String? = nil,
         value: Float = 0.0,
         ratingScale: BPKRatingScale = .zeroToFive,
         size: BPKRatingSize = .default,
-        subtitle: String? = nil,
         showScale: Bool = true
     ) {
         self.value = value
@@ -126,11 +123,7 @@ public class BPKRating: UIView {
         self.titleView = titleLabel
         super.init(frame: .zero)
 
-        self.title = title
-        self.subtitle = subtitle
-
         self.isAccessibilityElement = true
-        self.accessibilityLabel = accessibilityLabel
 
         setup()
         updateLookAndFeel()

--- a/Backpack/Rating/Classes/BPKRating.swift
+++ b/Backpack/Rating/Classes/BPKRating.swift
@@ -111,9 +111,9 @@ public class BPKRating: UIView {
 
     // MARK: - Init
     public init(
-        accessibilityLabel: String,
-        title: String?,
-        value: Float,
+        accessibilityLabel: String = "",
+        title: String? = nil,
+        value: Float = 0.0,
         ratingScale: BPKRatingScale = .zeroToFive,
         size: BPKRatingSize = .default,
         subtitle: String? = nil,

--- a/Backpack/Tests/SnapshotTests/BPKPriceSnapshotTest.swift
+++ b/Backpack/Tests/SnapshotTests/BPKPriceSnapshotTest.swift
@@ -40,23 +40,20 @@ class BPKPriceSnapshotTest: XCTestCase {
         parentView.backgroundColor = BPKColor.surfaceDefaultColor
         parentView.translatesAutoresizingMaskIntoConstraints = false
         
-        let price = BPKPrice(
-            price: price,
-            leadingText: leadingText,
-            previousPrice: previousPrice,
-            trailingText: trailingText,
-            alignment: alignment,
-            size: size
-        )
+        let priceView = BPKPrice(alignment: alignment, size: size)
+        priceView.price = price
+        priceView.leadingText = leadingText
+        priceView.previousPrice = previousPrice
+        priceView.trailingText = trailingText
         
-        price.translatesAutoresizingMaskIntoConstraints = false
-        parentView.addSubview(price)
+        priceView.translatesAutoresizingMaskIntoConstraints = false
+        parentView.addSubview(priceView)
         
         NSLayoutConstraint.activate([
-            price.topAnchor.constraint(equalTo: parentView.topAnchor),
-            price.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
-            price.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
-            price.bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
+            priceView.topAnchor.constraint(equalTo: parentView.topAnchor),
+            priceView.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
+            priceView.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
+            priceView.bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
         ])
         
         return parentView

--- a/Backpack/Tests/SnapshotTests/BPKRatingSnapshotTest.swift
+++ b/Backpack/Tests/SnapshotTests/BPKRatingSnapshotTest.swift
@@ -83,15 +83,15 @@ class BPKRatingSnapshotTest: XCTestCase {
                 titleView: starRating
             )
         } else {
-            return BPKRating(
-                accessibilityLabel: "",
-                title: "Excellent",
+            let view = BPKRating(
                 value: 4.5,
                 ratingScale: parameter.scale,
                 size: parameter.size,
-                subtitle: parameter.subtitle,
                 showScale: parameter.showScale
             )
+            view.title = "Excellent"
+            view.subtitle = parameter.subtitle
+            return view
         }
     }
 
@@ -102,12 +102,8 @@ class BPKRatingSnapshotTest: XCTestCase {
 
     func testBPKRatingTitleViewConstraintUpdateAfterSetTitleView() {
         // Given
-        let rating = BPKRating(
-            accessibilityLabel: "",
-            title: "Excellent",
-            value: 3.99,
-            size: .large
-        )
+        let rating = BPKRating(value: 3.99, size: .large)
+        rating.title = "Excellent"
         rating.translatesAutoresizingMaskIntoConstraints = false
         rating.backgroundColor = BPKColor.canvasColor
 

--- a/Example/Backpack/UIKit/Components/Price/PriceExampleViewController.swift
+++ b/Example/Backpack/UIKit/Components/Price/PriceExampleViewController.swift
@@ -76,14 +76,11 @@ final class PriceExampleViewController: UIViewController {
             stackView.translatesAutoresizingMaskIntoConstraints = false
         
             [BPKPrice.Alignment.leading, BPKPrice.Alignment.trailing].forEach { alignment in
-                let priceView = BPKPrice(
-                    price: "£1830",
-                    leadingText: leadingText,
-                    previousPrice: previousPrice,
-                    trailingText: trailingText,
-                    alignment: alignment,
-                    size: size
-                )
+                let priceView = BPKPrice(alignment: alignment, size: size)
+                priceView.price = "£1830"
+                priceView.leadingText = leadingText
+                priceView.previousPrice = previousPrice
+                priceView.trailingText = trailingText
                 priceView.translatesAutoresizingMaskIntoConstraints = false
                 stackView.addArrangedSubview(priceView)
             }

--- a/Example/Backpack/UIKit/Components/Rating/RatingsViewController.swift
+++ b/Example/Backpack/UIKit/Components/Rating/RatingsViewController.swift
@@ -108,15 +108,19 @@ final class RatingsViewController: UIViewController {
 
         switch titleType {
         case .stringLabel:
-            return BPKRating(
-                accessibilityLabel: accessibilityLabel,
-                title: title ?? "",
+            let view = BPKRating(
                 value: value,
                 ratingScale: scale,
                 size: size,
-                subtitle: subtitle,
                 showScale: showScale
             )
+            if let title {
+                view.title = title
+            }
+            if let subtitle {
+                view.subtitle = subtitle
+            }
+            return view
         case .starRating:
             let starRating = BPKStarRating()
             starRating.rating = 4.5


### PR DESCRIPTION
Came across some unexpected behaviour and requirements when using BPKPrice and BPKRating components for the hotels itinerary card (S2L):

Changes are:

BPKPrice:
- Update view state when setting a new value to properties

BPKRating: 
- Allow init of component without having to add values for properties. Often, such as in my case now I don't have the data required to pass in yet. 

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
