### PR TITLE
Allow the carrierLogo to be set at a later stage

### DIFF
--- a/Backpack/FlightLeg/Classes/BPKFlightLeg.swift
+++ b/Backpack/FlightLeg/Classes/BPKFlightLeg.swift
@@ -30,7 +30,11 @@ public final class BPKFlightLeg: UIView {
     private let duration: String
     private let operatedBy: String?
     private let warning: String?
-    private let carrierLogo: UIImage?
+    public var carrierLogo: UIImage? {
+        didSet {
+            carrierLogoIcon.image = carrierLogo
+        }
+    }
     
     private let departureArrivalTimeLabel: BPKLabel = {
         let departureArrtvalTimeLabel = BPKLabel()


### PR DESCRIPTION
BPKFlightLeg used to accept a carrierLogo of type UIImage?, but it requires an async call to be made to pull an image. To avoid creating another FlightLeg the change will allow the image to be set later once it's available. 
No new snapshots as there is no visual change.