### PR TITLE
Setting BPKFlightLeg imageView contentMode to aspectFit

### DIFF
--- a/Backpack/FlightLeg/Classes/BPKFlightLeg.swift
+++ b/Backpack/FlightLeg/Classes/BPKFlightLeg.swift
@@ -81,6 +81,7 @@ public final class BPKFlightLeg: UIView {
     }()
     private let carrierLogoIcon: UIImageView = {
         let carrierLogoIcon = UIImageView()
+        carrierLogoIcon.contentMode = .scaleAspectFit
         carrierLogoIcon.tintColor = BPKColor.textOnLightColor
         return carrierLogoIcon
     }()


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Currently when displaying the FlightLeg component in S2L the content mode of the carrier logo is stretched. 
![IMG_A2F19B074B87-1](https://github.com/Skyscanner/backpack-ios/assets/19799348/ac6d38c0-d792-4418-9aff-68660ec38d7d)



+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
