### PR TITLE
KOA-5976 Make all SwiftUI components not scale

### DIFF
--- a/Backpack-SwiftUI.podspec
+++ b/Backpack-SwiftUI.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.dependency 'SnapshotTesting', '~> 1.9.0'
-    test_spec.source_files = 'Backpack-SwiftUI/Tests/**/*.{swift,png}'
+    test_spec.source_files = 'Backpack-SwiftUI/Tests/**/*.{swift}'
     test_spec.ios.resource_bundle = {
       'UnitTestsImages' => 'Backpack-SwiftUI/Tests/Images*'
     }

--- a/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
+++ b/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
@@ -43,6 +43,7 @@ public struct BPKBadge: View {
             .outline(style.borderColor, cornerRadius: .xs)
             .accessibilityElement()
             .accessibilityLabel(title)
+            .sizeCategory(.large)
     }
     
     /// Sets the style of the badge

--- a/Backpack-SwiftUI/Button/Classes/BPKButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/BPKButton.swift
@@ -176,6 +176,7 @@ private struct ButtonContentView: View {
         Text(title)
             .font(style: fontStyle)
             .lineLimit(1)
+            .sizeCategory(.large)
     }
     
     private var iconSize: BPKIcon.Size {

--- a/Backpack-SwiftUI/Button/Classes/BPKButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/BPKButton.swift
@@ -174,7 +174,7 @@ private struct ButtonContentView: View {
     
     private func content(withTitle title: String) -> some View {
         Text(title)
-            .font(style: fontStyle, fixed: true)
+            .font(style: fontStyle)
             .lineLimit(1)
     }
     

--- a/Backpack-SwiftUI/Chip/Classes/BPKChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKChip.swift
@@ -61,6 +61,7 @@ public struct BPKChip: View {
         )
         .accessibilityAddTraits(selected ? [.isSelected] : [])
         .disabled(disabled)
+        .sizeCategory(.large)
     }
     
     public func disabled(_ disabled: Bool) -> BPKChip {

--- a/Backpack-SwiftUI/Chip/Classes/BPKChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKChip.swift
@@ -48,7 +48,7 @@ public struct BPKChip: View {
                     BPKIconView(icon)
                 }
                 Text(text)
-                    .font(style: .footnote, fixed: true)
+                    .font(style: .footnote)
             }
             .padding(.horizontal, .base)
         }

--- a/Backpack-SwiftUI/Chip/Classes/BPKDismissableChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKDismissableChip.swift
@@ -44,7 +44,7 @@ public struct BPKDismissableChip: View {
                 BPKIconView(icon)
             }
             Text(text)
-                .font(style: .footnote, fixed: true)
+                .font(style: .footnote)
             BPKIconView(.closeCircle)
                 .foregroundColor(accessoryViewColor)
         }

--- a/Backpack-SwiftUI/Chip/Classes/BPKDismissableChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKDismissableChip.swift
@@ -67,6 +67,7 @@ public struct BPKDismissableChip: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(text)
         .accessibilityAddTraits(.isButton)
+        .sizeCategory(.large)
     }
     
     private var accessoryViewColor: BPKColor {

--- a/Backpack-SwiftUI/Chip/Classes/BPKDropdownChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKDropdownChip.swift
@@ -63,6 +63,7 @@ public struct BPKDropdownChip: View {
         )
         .accessibilityAddTraits(selected ? [.isSelected] : [])
         .disabled(disabled)
+        .sizeCategory(.large)
     }
     
     public func disabled(_ disabled: Bool) -> BPKDropdownChip {

--- a/Backpack-SwiftUI/Chip/Classes/BPKDropdownChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKDropdownChip.swift
@@ -48,7 +48,7 @@ public struct BPKDropdownChip: View {
                     BPKIconView(icon)
                 }
                 Text(text)
-                    .font(style: .footnote, fixed: true)
+                    .font(style: .footnote)
                 BPKIconView(.chevronDown)
             }
             .padding(.trailing, .md)

--- a/Backpack-SwiftUI/Chip/Classes/ChipButtonStyle.swift
+++ b/Backpack-SwiftUI/Chip/Classes/ChipButtonStyle.swift
@@ -32,6 +32,7 @@ struct ChipButtonStyle: ButtonStyle {
             .clipShape(RoundedRectangle(cornerRadius: .sm))
             .outline(outlineColor(configuration.isPressed), cornerRadius: .sm)
             .if(style == .onImage) { $0.shadow(.sm) }
+            .sizeCategory(.large)
     }
     
     private func outlineColor(_ isPressed: Bool) -> BPKColor {

--- a/Backpack-SwiftUI/Nudger/Classes/BPKNudger.swift
+++ b/Backpack-SwiftUI/Nudger/Classes/BPKNudger.swift
@@ -71,6 +71,7 @@ public struct BPKNudger: View {
             }
             updateButtonStates()
         }
+        .sizeCategory(.large)
     }
     
     private func updateButtonStates() {

--- a/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
+++ b/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
@@ -40,7 +40,6 @@ private struct VerticalPriceStack: View {
                     .foregroundColor(.textSecondaryColor)
             }
         }
-        .sizeCategory(.large)
     }
 }
 
@@ -121,6 +120,7 @@ public struct BPKPrice: View {
                                      accessoryFontStyle: accessoryFontStyle())
             }
         }
+        .sizeCategory(.large)
     }
     
     private func accessoryText(_ text: String) -> BPKText {

--- a/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
+++ b/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
@@ -40,6 +40,7 @@ private struct VerticalPriceStack: View {
                     .foregroundColor(.textSecondaryColor)
             }
         }
+        .sizeCategory(.large)
     }
 }
 

--- a/Backpack-SwiftUI/Rating/Classes/BPKRating.swift
+++ b/Backpack-SwiftUI/Rating/Classes/BPKRating.swift
@@ -60,6 +60,7 @@ public struct BPKRating<Content: View>: View {
             }
         }
         .accessibilityElement()
+        .sizeCategory(.large)
     }
 
     public init(

--- a/Backpack-SwiftUI/Switch/Classes/BPKSwitch.swift
+++ b/Backpack-SwiftUI/Switch/Classes/BPKSwitch.swift
@@ -56,6 +56,7 @@ public struct BPKSwitch<Content: View>: View {
     public var body: some View {
         Toggle(isOn: $isOn) {
             content
+                .sizeCategory(.large)
         }
         .toggleStyle(SwitchToggleStyle(tint: Color(.coreAccentColor)))
     }

--- a/Backpack-SwiftUI/Utils/Classes/ScaledFont.swift
+++ b/Backpack-SwiftUI/Utils/Classes/ScaledFont.swift
@@ -27,24 +27,10 @@ fileprivate struct ScaledFont: ViewModifier {
     }
 }
 
-fileprivate struct FixedFont: ViewModifier {
-    var style: BPKFontStyle
-    
-    func body(content: Content) -> some View {
-        return content.font(style.fontFixed)
-            .lineSpacing(style.lineHeight - style.lineHeight)
-    }
-}
-
 extension Text {
-    func font(style: BPKFontStyle, fixed: Bool = false) -> some View {
+    func font(style: BPKFontStyle) -> some View {
         return self
             .tracking(style.letterSpacing)
-            .if(fixed, transform: { item in
-                item.modifier(FixedFont(style: style))
-            })
-            .if(!fixed, transform: { item in
-                item.modifier(ScaledFont(style: style))
-            })
+            .modifier(ScaledFont(style: style))
     }
 }

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -24,6 +24,10 @@ post_install do |installer|
 
   puts 'Removing static analyzer support'
   installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
+      end
+      
       if target.name == "FSCalendar"
           target.build_configurations.each do |config|
               config.build_settings['OTHER_CFLAGS'] = "$(inherited) -Qunused-arguments -Xanalyzer -analyzer-disable-all-checks"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -84,7 +84,7 @@ SPEC CHECKSUMS:
   Backpack: e5f5dca8cef64bd1626b21fee94e06a3dbef60ee
   Backpack-Common: cd375986447ca5f60fda52609fd6e1eccecfdc45
   Backpack-Fonts: 89f9d18aeeb0f6fb026e301261d3af3ee6a8ec6d
-  Backpack-SwiftUI: afea012165673e5449d63b15adbf024aa58b8204
+  Backpack-SwiftUI: f3a7d7bce777f1bfaf70dbfd9d6b7d101d0263ec
   FloatingPanel: 3cee815e9ded75b632543fa73ab655a1ef941452
   FSCalendar: 2d1d0d9398f12d439f55c1fe0f01525b151b8260
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
@@ -93,6 +93,6 @@ SPEC CHECKSUMS:
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
 
-PODFILE CHECKSUM: 3114be19f5e43c4b883feedb83baa4431fa9217b
+PODFILE CHECKSUM: 2bf9f0ac06a0705cb6f41d0ac9f14da7a4f5abce
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
# Dynamic Type

To make the process smoother, we limit all components to scale, as before. We will then unlock components case-by-case

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
