### PR TITLE
KOA-5977 BPKBadge dynamic type fixes

### DIFF
--- a/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
+++ b/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
@@ -37,13 +37,15 @@ public struct BPKBadge: View {
         content
             .padding([.leading, .trailing], .md)
             .padding([.top, .bottom], .sm)
-            .frame(height: 24)
+            .frame(minHeight: 24)
             .background(style.backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: .xs))
             .outline(style.borderColor, cornerRadius: .xs)
             .accessibilityElement()
             .accessibilityLabel(title)
-            .sizeCategory(.large)
+            .if(!BPKFont.enableDynamicType, transform: {
+                $0.sizeCategory(.large)
+            })
     }
     
     /// Sets the style of the badge

--- a/Backpack-SwiftUI/Chip/Classes/BPKChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKChip.swift
@@ -61,7 +61,9 @@ public struct BPKChip: View {
         )
         .accessibilityAddTraits(selected ? [.isSelected] : [])
         .disabled(disabled)
-        .sizeCategory(.large)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
     }
     
     public func disabled(_ disabled: Bool) -> BPKChip {

--- a/Backpack-SwiftUI/Chip/Classes/BPKDismissableChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKDismissableChip.swift
@@ -56,7 +56,9 @@ public struct BPKDismissableChip: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(text)
         .accessibilityAddTraits(.isButton)
-        .sizeCategory(.large)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
         .onTapGesture(perform: onClick)
     }
     

--- a/Backpack-SwiftUI/Chip/Classes/BPKDropdownChip.swift
+++ b/Backpack-SwiftUI/Chip/Classes/BPKDropdownChip.swift
@@ -63,7 +63,9 @@ public struct BPKDropdownChip: View {
         )
         .accessibilityAddTraits(selected ? [.isSelected] : [])
         .disabled(disabled)
-        .sizeCategory(.large)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
     }
     
     public func disabled(_ disabled: Bool) -> BPKDropdownChip {

--- a/Backpack-SwiftUI/Chip/Classes/ChipButtonStyle.swift
+++ b/Backpack-SwiftUI/Chip/Classes/ChipButtonStyle.swift
@@ -32,7 +32,9 @@ struct ChipButtonStyle: ButtonStyle {
             .clipShape(RoundedRectangle(cornerRadius: .sm))
             .outline(outlineColor(configuration.isPressed), cornerRadius: .sm)
             .if(style == .onImage) { $0.shadow(.sm) }
-            .sizeCategory(.large)
+            .if(!BPKFont.enableDynamicType, transform: {
+                $0.sizeCategory(.large)
+            })
     }
     
     private func outlineColor(_ isPressed: Bool) -> BPKColor {

--- a/Backpack-SwiftUI/ChipGroup/Classes/BPKStickyChip.swift
+++ b/Backpack-SwiftUI/ChipGroup/Classes/BPKStickyChip.swift
@@ -35,7 +35,9 @@ struct BPKStickyChip: View {
             )
         )
         .accessibilityAddTraits(stickyChip.selected ? [.isSelected] : [])
-        .sizeCategory(.large)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
         .accessibilityLabel(stickyChip.accessibilityLabel)
     }
 }

--- a/Backpack-SwiftUI/Font/Classes/BPKFont.swift
+++ b/Backpack-SwiftUI/Font/Classes/BPKFont.swift
@@ -20,9 +20,14 @@ import SwiftUI
 
 public struct BPKFont {
     static var fontDefinition: BPKFontDefinition?
+    static var enableDynamicType: Bool = false
     
     public static func setFontDefinition(_ fontDefinition: BPKFontDefinition) {
         BPKFont.fontDefinition = fontDefinition
+    }
+    
+    public static func setDynamicType(enabled: Bool) {
+        BPKFont.enableDynamicType = enabled
     }
 }
 

--- a/Backpack-SwiftUI/Nudger/Classes/BPKNudger.swift
+++ b/Backpack-SwiftUI/Nudger/Classes/BPKNudger.swift
@@ -117,7 +117,9 @@ public struct BPKNudger: View {
         .onChange(of: value, perform: { _ in
             updateButtonStates()
         })
-        .sizeCategory(.large)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
     }
     
     private func updateButtonStates() {

--- a/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
+++ b/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
@@ -122,7 +122,9 @@ public struct BPKPrice: View {
                     accessoryFontStyle: accessoryFontStyle())
             }
         }
-        .sizeCategory(.large)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
     }
     
     private func accessoryText(_ text: String) -> BPKText {

--- a/Backpack-SwiftUI/Rating/Classes/BPKRating.swift
+++ b/Backpack-SwiftUI/Rating/Classes/BPKRating.swift
@@ -61,7 +61,9 @@ public struct BPKRating<Content: View>: View {
             }
         }
         .accessibilityElement()
-        .sizeCategory(.large)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
     }
 
     public init(

--- a/Backpack-SwiftUI/Switch/Classes/BPKSwitch.swift
+++ b/Backpack-SwiftUI/Switch/Classes/BPKSwitch.swift
@@ -56,7 +56,9 @@ public struct BPKSwitch<Content: View>: View {
     public var body: some View {
         Toggle(isOn: $isOn) {
             content
-                .sizeCategory(.large)
+                .if(!BPKFont.enableDynamicType, transform: {
+                    $0.sizeCategory(.large)
+                })
         }
         .toggleStyle(SwitchToggleStyle(tint: Color(.coreAccentColor)))
     }


### PR DESCRIPTION
# Dynamic type

- Allow BPKBadge to scale properly
- Introduce BPKFont.setDyamicType(enabled:Bool) to configure dynamic type

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
