### PR TITLE
BPKPrice fix

### DIFF
--- a/Backpack/Price/Classes/BPKPrice.swift
+++ b/Backpack/Price/Classes/BPKPrice.swift
@@ -136,7 +136,14 @@ public final class BPKPrice: UIView {
         
         previousPriceLabel.isHidden = previousPrice == nil
         leadingTextLabel.isHidden = leadingText == nil
-        trailingTextLabel.isHidden = trailingText == nil
+        
+        if trailingText == nil {
+            priceStackView.removeArrangedSubview(trailingTextLabel)
+            trailingTextLabel.removeFromSuperview()
+        } else {
+            priceStackView.addArrangedSubview(trailingTextLabel)
+        }
+        
         separatorLabel.isHidden = previousPriceLabel.isHidden || leadingTextLabel.isHidden
         
         updateAlignmentPositioning()


### PR DESCRIPTION
# BPKPrice

Alignment of label would fail when trailing label was set to nil / receiving content.
We now remove the view instead of hiding when the label becomes nil to prevent ambiguos layouts

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
