### PR TITLE
KOA-6275 Add dynamic font config for Backpack (UIKit)

### DIFF
--- a/Backpack/Font/Classes/BPKFontManager.h
+++ b/Backpack/Font/Classes/BPKFontManager.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface BPKFontManager : NSObject
 
 @property(nullable, nonatomic) id<BPKFontDefinitionProtocol> fontDefinition;
+@property(nonatomic) BOOL dynamicTypeEnabled;
 
 + (instancetype)sharedInstance;
 

--- a/Backpack/Font/Classes/BPKFontManager.h
+++ b/Backpack/Font/Classes/BPKFontManager.h
@@ -11,9 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
-- (UIFont *)regularFontWithSize:(CGFloat)size;
-- (UIFont *)semiboldFontWithSize:(CGFloat)size;
-- (UIFont *)heavyFontWithSize:(CGFloat)size;
+- (UIFont *)regularFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style;
+- (UIFont *)semiboldFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style;
+- (UIFont *)heavyFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style;
 
 @end
 

--- a/Backpack/Font/Classes/BPKFontManager.m
+++ b/Backpack/Font/Classes/BPKFontManager.m
@@ -50,4 +50,10 @@
     }
 }
 
+- (void)setDynamicTypeEnabled:(BOOL)enabled {
+    if (_dynamicTypeEnabled != enabled) {
+        _dynamicTypeEnabled = enabled;
+    }
+}
+
 @end

--- a/Backpack/Font/Classes/BPKFontManager.m
+++ b/Backpack/Font/Classes/BPKFontManager.m
@@ -29,19 +29,19 @@
     return [UIFont systemFontOfSize:size weight:weight];
 }
 
-- (UIFont *)regularFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style{
+- (UIFont *)regularFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style {
     NSString *fontName = self.fontDefinition ? self.fontDefinition.regularFontFace : nil;
-    return [[UIFontMetrics metricsForTextStyle: style] scaledFontForFont: [self fontWithName:fontName size:size weight:UIFontWeightRegular]];
+    return [[UIFontMetrics metricsForTextStyle:style] scaledFontForFont:[self fontWithName:fontName size:size weight:UIFontWeightRegular]];
 }
 
-- (UIFont *)semiboldFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style{
+- (UIFont *)semiboldFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style {
     NSString *fontName = self.fontDefinition ? self.fontDefinition.semiboldFontFace : nil;
-    return [[UIFontMetrics metricsForTextStyle: style] scaledFontForFont: [self fontWithName:fontName size:size weight:UIFontWeightSemibold]];
+    return [[UIFontMetrics metricsForTextStyle:style] scaledFontForFont:[self fontWithName:fontName size:size weight:UIFontWeightSemibold]];
 }
 
-- (UIFont *)heavyFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style{
+- (UIFont *)heavyFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style {
     NSString *fontName = self.fontDefinition ? self.fontDefinition.heavyFontFace : nil;
-    return [[UIFontMetrics metricsForTextStyle: style] scaledFontForFont: [self fontWithName:fontName size:size weight:UIFontWeightHeavy]];
+    return [[UIFontMetrics metricsForTextStyle:style] scaledFontForFont:[self fontWithName:fontName size:size weight:UIFontWeightHeavy]];
 }
 
 - (void)setFontDefinition:(id<BPKFontDefinitionProtocol>)fontDefinition {

--- a/Backpack/Font/Classes/BPKFontManager.m
+++ b/Backpack/Font/Classes/BPKFontManager.m
@@ -29,19 +29,19 @@
     return [UIFont systemFontOfSize:size weight:weight];
 }
 
-- (UIFont *)regularFontWithSize:(CGFloat)size {
+- (UIFont *)regularFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style{
     NSString *fontName = self.fontDefinition ? self.fontDefinition.regularFontFace : nil;
-    return [self fontWithName:fontName size:size weight:UIFontWeightRegular];
+    return [[UIFontMetrics metricsForTextStyle: style] scaledFontForFont: [self fontWithName:fontName size:size weight:UIFontWeightRegular]];
 }
 
-- (UIFont *)semiboldFontWithSize:(CGFloat)size {
+- (UIFont *)semiboldFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style{
     NSString *fontName = self.fontDefinition ? self.fontDefinition.semiboldFontFace : nil;
-    return [self fontWithName:fontName size:size weight:UIFontWeightSemibold];
+    return [[UIFontMetrics metricsForTextStyle: style] scaledFontForFont: [self fontWithName:fontName size:size weight:UIFontWeightSemibold]];
 }
 
-- (UIFont *)heavyFontWithSize:(CGFloat)size {
+- (UIFont *)heavyFontWithSize:(CGFloat)size textStyle:(UIFontTextStyle)style{
     NSString *fontName = self.fontDefinition ? self.fontDefinition.heavyFontFace : nil;
-    return [self fontWithName:fontName size:size weight:UIFontWeightHeavy];
+    return [[UIFontMetrics metricsForTextStyle: style] scaledFontForFont: [self fontWithName:fontName size:size weight:UIFontWeightHeavy]];
 }
 
 - (void)setFontDefinition:(id<BPKFontDefinitionProtocol>)fontDefinition {

--- a/Backpack/Font/Classes/Generated/BPKFont.h
+++ b/Backpack/Font/Classes/Generated/BPKFont.h
@@ -207,6 +207,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setFontDefinition:(id<BPKFontDefinitionProtocol>_Nullable)fontDefinition;
 
 /**
+ *  Enable/disable dynamic type for UIKit components
+ *
+ * @param enabled When true, all text will scale to user preference
+*/
++ (void)setDyanmicTypeEnabled:(BOOL)enabled;
+
+/**
  * Create a `UIFont` instance for a specific text style.
  *
  *

--- a/Backpack/Font/Classes/Generated/BPKFont.m
+++ b/Backpack/Font/Classes/Generated/BPKFont.m
@@ -121,58 +121,58 @@ NS_ASSUME_NONNULL_BEGIN
     switch (style) {
        
            case BPKFontStyleTextBodyDefault:
-             return [fontManager regularFontWithSize:16];
+             return [fontManager regularFontWithSize:16 textStyle:UIFontTextStyleBody];
              
            case BPKFontStyleTextBodyLongform:
-             return [fontManager regularFontWithSize:20];
+             return [fontManager regularFontWithSize:20 textStyle:UIFontTextStyleBody];
              
            case BPKFontStyleTextCaption:
-             return [fontManager regularFontWithSize:12];
+             return [fontManager regularFontWithSize:12 textStyle:UIFontTextStyleCaption1];
              
            case BPKFontStyleTextFootnote:
-             return [fontManager regularFontWithSize:14];
+             return [fontManager regularFontWithSize:14 textStyle:UIFontTextStyleFootnote];
              
            case BPKFontStyleTextHeading1:
-             return [fontManager semiboldFontWithSize:40];
+             return [fontManager semiboldFontWithSize:40 textStyle:UIFontTextStyleTitle1];
              
            case BPKFontStyleTextHeading2:
-             return [fontManager semiboldFontWithSize:32];
+             return [fontManager semiboldFontWithSize:32 textStyle:UIFontTextStyleTitle2];
              
            case BPKFontStyleTextHeading3:
-             return [fontManager semiboldFontWithSize:24];
+             return [fontManager semiboldFontWithSize:24 textStyle:UIFontTextStyleTitle3];
              
            case BPKFontStyleTextHeading4:
-             return [fontManager semiboldFontWithSize:20];
+             return [fontManager semiboldFontWithSize:20 textStyle:UIFontTextStyleTitle3];
              
            case BPKFontStyleTextHeading5:
-             return [fontManager semiboldFontWithSize:16];
+             return [fontManager semiboldFontWithSize:16 textStyle:UIFontTextStyleTitle3];
              
            case BPKFontStyleTextHero1:
-             return [fontManager semiboldFontWithSize:120];
+             return [fontManager semiboldFontWithSize:120 textStyle:UIFontTextStyleLargeTitle];
              
            case BPKFontStyleTextHero2:
-             return [fontManager semiboldFontWithSize:96];
+             return [fontManager semiboldFontWithSize:96 textStyle:UIFontTextStyleLargeTitle];
              
            case BPKFontStyleTextHero3:
-             return [fontManager semiboldFontWithSize:76];
+             return [fontManager semiboldFontWithSize:76 textStyle:UIFontTextStyleLargeTitle];
              
            case BPKFontStyleTextHero4:
-             return [fontManager semiboldFontWithSize:64];
+             return [fontManager semiboldFontWithSize:64 textStyle:UIFontTextStyleLargeTitle];
              
            case BPKFontStyleTextHero5:
-             return [fontManager semiboldFontWithSize:48];
+             return [fontManager semiboldFontWithSize:48 textStyle:UIFontTextStyleLargeTitle];
              
            case BPKFontStyleTextLabel1:
-             return [fontManager semiboldFontWithSize:16];
+             return [fontManager semiboldFontWithSize:16 textStyle:UIFontTextStyleBody];
              
            case BPKFontStyleTextLabel2:
-             return [fontManager semiboldFontWithSize:14];
+             return [fontManager semiboldFontWithSize:14 textStyle:UIFontTextStyleBody];
              
            case BPKFontStyleTextLabel3:
-             return [fontManager semiboldFontWithSize:12];
+             return [fontManager semiboldFontWithSize:12 textStyle:UIFontTextStyleBody];
              
            case BPKFontStyleTextSubheading:
-             return [fontManager regularFontWithSize:24];
+             return [fontManager regularFontWithSize:24 textStyle:UIFontTextStyleSubheadline];
              
             default:
               NSAssert(NO, @"Unknown fontStyle %ld", (unsigned long)style);

--- a/Backpack/Font/Classes/Generated/BPKFont.m
+++ b/Backpack/Font/Classes/Generated/BPKFont.m
@@ -36,6 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
     [BPKFontManager sharedInstance].fontDefinition = fontDefinition;
 }
 
++ (void)setDyanmicTypeEnabled:(BOOL)enabled {
+    [BPKFontManager sharedInstance].dynamicTypeEnabled = enabled;
+}
+
 + (NSAttributedString *)attributedStringWithFontStyle:(BPKFontStyle)fontStyle
                                               content:(NSString *)content {
     return [self attributedStringWithFontStyle:fontStyle

--- a/Backpack/Label/Classes/BPKLabel.m
+++ b/Backpack/Label/Classes/BPKLabel.m
@@ -22,6 +22,7 @@
 #import <Backpack/Common.h>
 
 #import "BPKTextDefinition.h"
+#import "BPKFontManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKLabel ()
@@ -126,6 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.persistentStyleRanges = [[NSMutableArray alloc] init];
     self.fontStyle = style;
     self.textColor = BPKColor.textPrimaryColor;
+    self.adjustsFontForContentSizeCategory = [[BPKFontManager sharedInstance] dynamicTypeEnabled];
 }
 
 @end

--- a/Backpack/Label/Classes/BPKLabel.m
+++ b/Backpack/Label/Classes/BPKLabel.m
@@ -21,8 +21,8 @@
 #import <Backpack/Color.h>
 #import <Backpack/Common.h>
 
-#import "BPKTextDefinition.h"
 #import "BPKFontManager.h"
+#import "BPKTextDefinition.h"
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BPKLabel ()

--- a/Backpack/Tests/UnitTests/BPKFontTest.m
+++ b/Backpack/Tests/UnitTests/BPKFontTest.m
@@ -66,8 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testAttributesForFontStyleWithCustomFontDefinitionInjected {
     BPKFontManager *mockFontManager = OCMClassMock(BPKFontManager.class);
     OCMStub([mockFontManager regularFontWithSize:20.0 textStyle:UIFontTextStyleBody]).andReturn([UIFont fontWithName:@"SnellRoundhand" size:16.0]);
-    OCMStub([mockFontManager semiboldFontWithSize:20.0 textStyle:UIFontTextStyleTitle3]).andReturn([UIFont fontWithName:@"SnellRoundhand-Bold" size:20.0]);
-    OCMStub([mockFontManager semiboldFontWithSize:24.0 textStyle:UIFontTextStyleTitle3]).andReturn([UIFont fontWithName:@"SnellRoundhand-Black" size:24.0]);
+    OCMStub([mockFontManager semiboldFontWithSize:20.0 textStyle:UIFontTextStyleTitle3])
+        .andReturn([UIFont fontWithName:@"SnellRoundhand-Bold" size:20.0]);
+    OCMStub([mockFontManager semiboldFontWithSize:24.0 textStyle:UIFontTextStyleTitle3])
+        .andReturn([UIFont fontWithName:@"SnellRoundhand-Black" size:24.0]);
 
     NSDictionary *regularAttributes = [BPKFont attributesForFontStyle:BPKFontStyleTextBodyLongform fontManager:mockFontManager];
     NSDictionary *semiboldAttributes = [BPKFont attributesForFontStyle:BPKFontStyleTextHeading4 fontManager:mockFontManager];

--- a/Backpack/Tests/UnitTests/BPKFontTest.m
+++ b/Backpack/Tests/UnitTests/BPKFontTest.m
@@ -65,9 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testAttributesForFontStyleWithCustomFontDefinitionInjected {
     BPKFontManager *mockFontManager = OCMClassMock(BPKFontManager.class);
-    OCMStub([mockFontManager regularFontWithSize:20.0]).andReturn([UIFont fontWithName:@"SnellRoundhand" size:16.0]);
-    OCMStub([mockFontManager semiboldFontWithSize:20.0]).andReturn([UIFont fontWithName:@"SnellRoundhand-Bold" size:20.0]);
-    OCMStub([mockFontManager semiboldFontWithSize:24.0]).andReturn([UIFont fontWithName:@"SnellRoundhand-Black" size:24.0]);
+    OCMStub([mockFontManager regularFontWithSize:20.0 textStyle:UIFontTextStyleBody]).andReturn([UIFont fontWithName:@"SnellRoundhand" size:16.0]);
+    OCMStub([mockFontManager semiboldFontWithSize:20.0 textStyle:UIFontTextStyleTitle3]).andReturn([UIFont fontWithName:@"SnellRoundhand-Bold" size:20.0]);
+    OCMStub([mockFontManager semiboldFontWithSize:24.0 textStyle:UIFontTextStyleTitle3]).andReturn([UIFont fontWithName:@"SnellRoundhand-Black" size:24.0]);
 
     NSDictionary *regularAttributes = [BPKFont attributesForFontStyle:BPKFontStyleTextBodyLongform fontManager:mockFontManager];
     NSDictionary *semiboldAttributes = [BPKFont attributesForFontStyle:BPKFontStyleTextHeading4 fontManager:mockFontManager];

--- a/Example/Backpack/AppDelegate.swift
+++ b/Example/Backpack/AppDelegate.swift
@@ -41,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             BPKFont.setFontDefinition(relativeFontDefinition)
             BPKFont.setFontDefinition(Backpack_SwiftUI.BPKRelativeFontDefinition())
         }
-        
+        Backpack.BPKFont.setDyanmicTypeEnabled(true)
         Backpack_SwiftUI.BPKFont.setDynamicType(enabled: true)
     }
     

--- a/Example/Backpack/AppDelegate.swift
+++ b/Example/Backpack/AppDelegate.swift
@@ -41,6 +41,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             BPKFont.setFontDefinition(relativeFontDefinition)
             BPKFont.setFontDefinition(Backpack_SwiftUI.BPKRelativeFontDefinition())
         }
+        
+        Backpack_SwiftUI.BPKFont.setDynamicType(enabled: true)
     }
     
     func application(

--- a/scripts/gulp/fonts.js
+++ b/scripts/gulp/fonts.js
@@ -82,6 +82,31 @@ const TEXT_STYLE_MAP_SWIFTUI = {
     BPKFontStyleTextCaption: ".caption",
 }
 
+const TEXT_STYLE_MAP_UIKIT = {
+    BPKFontStyleTextHero1: "UIFontTextStyleLargeTitle",
+    BPKFontStyleTextHero2: "UIFontTextStyleLargeTitle",
+    BPKFontStyleTextHero3: "UIFontTextStyleLargeTitle",
+    BPKFontStyleTextHero4: "UIFontTextStyleLargeTitle",
+    BPKFontStyleTextHero5: "UIFontTextStyleLargeTitle",
+
+    BPKFontStyleTextHeading5: "UIFontTextStyleTitle3",
+    BPKFontStyleTextHeading4: "UIFontTextStyleTitle3",
+    BPKFontStyleTextHeading3: "UIFontTextStyleTitle3",
+    BPKFontStyleTextHeading2: "UIFontTextStyleTitle2",
+    BPKFontStyleTextHeading1: "UIFontTextStyleTitle1",
+
+    BPKFontStyleTextSubheading: "UIFontTextStyleSubheadline",
+    BPKFontStyleTextBodyLongform: "UIFontTextStyleBody",
+    BPKFontStyleTextBodyDefault: "UIFontTextStyleBody",
+
+    BPKFontStyleTextLabel3: "UIFontTextStyleBody",
+    BPKFontStyleTextLabel2: "UIFontTextStyleBody",
+    BPKFontStyleTextLabel1: "UIFontTextStyleBody",
+
+    BPKFontStyleTextFootnote: "UIFontTextStyleFootnote",
+    BPKFontStyleTextCaption: "UIFontTextStyleCaption1",
+}
+
 const convertFontWeight = (weightMap, weightString) => {
     const weight = weightMap[weightString.trim()];
     if (!weight) {
@@ -175,6 +200,17 @@ const uikitFonts = properties => fonts(properties, fontProps => {
             }
             return enumValue;
         };
+
+        const textStyleValueForName = (name) => {
+            const enumValue = TEXT_STYLE_MAP_UIKIT[name];
+            if (typeof enumValue !== 'string') {
+                throw new Error(
+                    `No font enum value found for \`${name}\` in \`TEXT_STYLE_MAP_UIKIT\`. Every font variant MUST have a value in this object`,
+                );
+            }
+            return enumValue;
+        };
+
         const enumName = `BPKFontStyle${_.upperFirst(fontProps.key)}`;
 
         return {
@@ -185,7 +221,8 @@ const uikitFonts = properties => fonts(properties, fontProps => {
             weight: convertFontWeight(WEIGHT_MAP_OBJC, fontProps.weightProp[0].value),
             type: 'font',
             lineHeight: lineHeightFor(fontProps.lineHeightProp[0]),
-            letterSpacing: letterSpacingFor(fontProps.letterSpacingProp[0])
+            letterSpacing: letterSpacingFor(fontProps.letterSpacingProp[0]),
+            textStyle: textStyleValueForName(enumName)
         };
     })
 

--- a/templates/BPKFont.h.njk
+++ b/templates/BPKFont.h.njk
@@ -122,6 +122,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setFontDefinition:(id<BPKFontDefinitionProtocol>_Nullable)fontDefinition;
 
 /**
+ *  Enable/disable dynamic type for UIKit components
+ *
+ * @param enabled When true, all text will scale to user preference
+*/
++ (void)setDyanmicTypeEnabled:(BOOL)enabled;
+
+/**
  * Create a `UIFont` instance for a specific text style.
  *
  *

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -36,6 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
     [BPKFontManager sharedInstance].fontDefinition = fontDefinition;
 }
 
++ (void)setDyanmicTypeEnabled:(BOOL)enabled {
+    [BPKFontManager sharedInstance].dynamicTypeEnabled = enabled;
+}
+
 + (NSAttributedString *)attributedStringWithFontStyle:(BPKFontStyle)fontStyle
                                               content:(NSString *)content {
     return [self attributedStringWithFontStyle:fontStyle

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -122,11 +122,11 @@ NS_ASSUME_NONNULL_BEGIN
        {% for f in font %}
            case {{f.enumName}}:
              {% if f.weight.includes("UIFontWeightBlack") -%}
-               return [fontManager heavyFontWithSize:{{f.size}}];
+               return [fontManager heavyFontWithSize:{{f.size}} textStyle:{{f.textStyle}}];
              {% elif f.weight.includes("UIFontWeightBold") -%}
-               return [fontManager semiboldFontWithSize:{{f.size}}];
+               return [fontManager semiboldFontWithSize:{{f.size}} textStyle:{{f.textStyle}}];
              {% else -%}
-               return [fontManager regularFontWithSize:{{f.size}}];
+               return [fontManager regularFontWithSize:{{f.size}} textStyle:{{f.textStyle}}];
              {% endif %}{% endfor %}
             default:
               NSAssert(NO, @"Unknown fontStyle %ld", (unsigned long)style);


### PR DESCRIPTION
# Dynamic type

Add a config option to allow dynamic type for Backpack (UIKit) components. There have been no change to components (so far). This is just to allow resizing. 

Future commits will deal with appearances

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
