### PR TITLE
SwiftUI BPKIconView

### DIFF
--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -64,7 +64,7 @@ private extension BPKIcon.Size {
 private extension Image {
     init(icon: BPKIcon, size: BPKIcon.Size = .small) {
         let iconName = "\(icon.name)-\(size.suffix)"
-        self.init(iconName, bundle: BPKCommonBundle.iconsBundle)
+        self.init(decorative: iconName, bundle: BPKCommonBundle.iconsBundle)
     }
 }
 


### PR DESCRIPTION
# BPKIconView

The icon view did not use the `decorative:` initializer, where we want our icons to be decorative by default. 

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
