### PR TITLE
[BugFix] BPKButton accessibility label

### DIFF
--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.isAccessibilityElement = YES;
 
     self.accessibilityTraits = self.isEnabled ? UIAccessibilityTraitButton : (UIAccessibilityTraitNotEnabled | UIAccessibilityTraitButton);
-    self.accessibilityLabel = self.title;
+    
     self.titleLabel.isAccessibilityElement = NO;
     self.imageView.isAccessibilityElement = NO;
     self.spinner.isAccessibilityElement = NO;
@@ -335,6 +335,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setTitle:(NSString *_Nullable)title {
     BPKAssertMainThread();
+    
+    if(self.accessibilityLabel == _title) {
+        self.accessibilityLabel = title;
+    }
 
     self.titleLabel.text = title;
     _title = [title copy];

--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.isAccessibilityElement = YES;
 
     self.accessibilityTraits = self.isEnabled ? UIAccessibilityTraitButton : (UIAccessibilityTraitNotEnabled | UIAccessibilityTraitButton);
-    
+
     self.titleLabel.isAccessibilityElement = NO;
     self.imageView.isAccessibilityElement = NO;
     self.spinner.isAccessibilityElement = NO;
@@ -335,8 +335,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setTitle:(NSString *_Nullable)title {
     BPKAssertMainThread();
-    
-    if(self.accessibilityLabel == _title) {
+
+    if (self.accessibilityLabel == _title) {
         self.accessibilityLabel = title;
     }
 

--- a/Backpack/Tests/UnitTests/BPKButtonTest.swift
+++ b/Backpack/Tests/UnitTests/BPKButtonTest.swift
@@ -1,0 +1,92 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import Backpack
+
+final class BPKButtonTest: XCTestCase {
+    // MARK: - Accessibility tests
+    /// These tests were added after a bug was discovered with the accessibilityLabel being overridden
+    /// as soon as any update was done to the button. The issue happened with enabled/title/color etc.
+    func test_regularButton_usesTitle_asA11yLabel() {
+        // Given
+        let sut = BPKButton(size: .default, style: .primary)
+        let expectedLabel = "Test button"
+        
+        // When
+        sut.title = expectedLabel
+        
+        // Then
+        XCTAssertEqual(sut.accessibilityLabel, expectedLabel)
+    }
+    
+    func test_regularButton_doesntOverrideA11yLabel() {
+        // Given
+        let sut = BPKButton(size: .default, style: .primary)
+        let expectedLabel = "Accessibility Label"
+        
+        // When
+        sut.title = "Test button"
+        sut.accessibilityLabel = expectedLabel
+        sut.isEnabled = true
+        
+        // Then
+        XCTAssertEqual(sut.accessibilityLabel, expectedLabel)
+    }
+    
+    func test_iconButton_doesntOverrideA11yLabel() {
+        // Given
+        let sut = BPKButton(size: .default, style: .primary)
+        let expectedLabel = "Accessibility Label"
+        
+        // When
+        sut.setImage(BPKIcon.makeSmallTemplateIcon(name: .accessibility))
+        sut.accessibilityLabel = expectedLabel
+        sut.isEnabled = true
+        
+        // Then
+        XCTAssertEqual(sut.accessibilityLabel, expectedLabel)
+    }
+    
+    func test_regularButton_updatingTitleWithoutCustomA11yLabel_updatesLabel() {
+        // Given
+        let sut = BPKButton(size: .default, style: .primary)
+        let expectedLabel = "New test button"
+        
+        // When
+        sut.title = "Test button"
+        sut.title = expectedLabel
+        
+        // Then
+        XCTAssertEqual(sut.accessibilityLabel, expectedLabel)
+    }
+    
+    func test_regularButton_updatingTitleWithCustomA11yLabel_doesNotUpdateLabel() {
+        // Given
+        let sut = BPKButton(size: .default, style: .primary)
+        let expectedLabel = "Accessibility Label"
+        
+        // When
+        sut.title = "Test button"
+        sut.accessibilityLabel = expectedLabel
+        sut.title = "Other test button"
+        
+        // Then
+        XCTAssertEqual(sut.accessibilityLabel, expectedLabel)
+    }
+}


### PR DESCRIPTION
# BPKButton
The accessibility label of the BPKButton would be reset when any style change was applied. This is now resolved and tests have been added to prevent regressions

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
