### PR TITLE
[Patch] BPKButton accessibility label

### DIFF
--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -336,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTitle:(NSString *_Nullable)title {
     BPKAssertMainThread();
 
-    if (self.accessibilityLabel == _title) {
+    if ([self.accessibilityLabel isEqualToString:_title]) {
         self.accessibilityLabel = title;
     }
 

--- a/Backpack/Tests/UnitTests/BPKButtonTest.swift
+++ b/Backpack/Tests/UnitTests/BPKButtonTest.swift
@@ -89,4 +89,16 @@ final class BPKButtonTest: XCTestCase {
         // Then
         XCTAssertEqual(sut.accessibilityLabel, expectedLabel)
     }
+    
+    func test_regularButton_setTitle_nil() {
+        // Given
+        let sut = BPKButton(size: .default, style: .primary)
+        
+        // When
+        sut.title = "Other test button"
+        sut.title = nil
+        
+        // Then
+        XCTAssertNil(sut.accessibilityLabel)
+    }
 }


### PR DESCRIPTION
# BPKButton

We introduced a check, but failed to use the correct string compare in objective-c

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
