### PR TITLE
Adding a swiftui version of the dialog used as a zstack of views

### DIFF
--- a/Backpack-SwiftUI/Dialog/Classes/BPKDialogView.swift
+++ b/Backpack-SwiftUI/Dialog/Classes/BPKDialogView.swift
@@ -18,9 +18,13 @@
 
 import SwiftUI
 
+/// This extension provides a set of convenience methods to display a dialog that works as a view.
+/// It's usage is discouraged in favour of the `BPKDialog` view. Usage of this view should be limited to cases where
+/// presenting a new view controller is not possible. (`BPKDialog` uses a view controller to present the dialog
+/// behind the scenes).
 public extension View {
     /// Displays a success dialog with a title, text and a list of buttons.
-    func bpkSuccessDialog(
+    func bpkSuccessDialogView(
         presented: Binding<Bool>,
         icon: BPKIcon,
         title: String,
@@ -36,7 +40,7 @@ public extension View {
                 buttons.append(BPKDialogButton(button: linkButton, style: .link))
             }
         }
-        return self.modifier(UIKitDialogContainerViewModifier(isPresented: presented, dialogContent: {
+        return self.modifier(DialogContainerViewModifier(isPresented: presented, dialogContent: {
             DialogWithIconContent(
                 icon: icon,
                 iconColor: .coreAccentColor,
@@ -47,7 +51,7 @@ public extension View {
     }
     
     /// Displays a warning dialog with a title, text and a list of buttons.
-    func bpkWarningDialog(
+    func bpkWarningDialogView(
         presented: Binding<Bool>,
         icon: BPKIcon,
         title: String,
@@ -63,7 +67,7 @@ public extension View {
                 buttons.append(BPKDialogButton(button: linkButton, style: .link))
             }
         }
-        return self.modifier(UIKitDialogContainerViewModifier(isPresented: presented, dialogContent: {
+        return self.modifier(DialogContainerViewModifier(isPresented: presented, dialogContent: {
             DialogWithIconContent(
                 icon: icon,
                 iconColor: .statusWarningSpotColor,
@@ -74,7 +78,7 @@ public extension View {
     }
     
     /// Displays a destructive dialog with a title, text and a list of buttons.
-    func bpkDestructiveDialog(
+    func bpkDestructiveDialogView(
         presented: Binding<Bool>,
         icon: BPKIcon,
         title: String,
@@ -87,7 +91,7 @@ public extension View {
         if let linkButton {
             buttons.append(BPKDialogButton(button: linkButton, style: .link))
         }
-        return self.modifier(UIKitDialogContainerViewModifier(isPresented: presented, dialogContent: {
+        return self.modifier(DialogContainerViewModifier(isPresented: presented, dialogContent: {
             DialogWithIconContent(
                 icon: icon,
                 iconColor: .statusDangerSpotColor,
@@ -98,7 +102,7 @@ public extension View {
     }
     
     /// Displays a dialog with an image, title, text and a list of buttons.
-    func bpkImageDialog(
+    func bpkImageDialogView(
         presented: Binding<Bool>,
         image: Image,
         title: String,
@@ -114,7 +118,7 @@ public extension View {
                 buttons.append(BPKDialogButton(button: linkButton, style: .link))
             }
         }
-        return self.modifier(UIKitDialogContainerViewModifier(isPresented: presented, dialogContent: {
+        return self.modifier(DialogContainerViewModifier(isPresented: presented, dialogContent: {
             DialogWithHeaderContent(
                 textContent: DialogTextContent(title: title, text: text, contentAlignment: .leading)
                     .spacing(.md),
@@ -124,7 +128,7 @@ public extension View {
     }
     
     /// Displays a dialog with an image with a flare, title, text and a list of buttons.
-    func bpkFlareDialog(
+    func bpkFlareDialogView(
         presented: Binding<Bool>,
         image: Image,
         title: String,
@@ -140,7 +144,7 @@ public extension View {
                 buttons.append(BPKDialogButton(button: linkButton, style: .link))
             }
         }
-        return self.modifier(UIKitDialogContainerViewModifier(isPresented: presented, dialogContent: {
+        return self.modifier(DialogContainerViewModifier(isPresented: presented, dialogContent: {
             DialogWithHeaderContent(
                 textContent: DialogTextContent(title: title, text: text, contentAlignment: .center),
                 actions: DialogActionsView(buttons: buttons)
@@ -153,10 +157,10 @@ public extension View {
     }
 }
 
-struct BPKDialog_Previews: PreviewProvider {
+struct BPKDialogView_Previews: PreviewProvider {
     static var previews: some View {
         Color(.canvasColor)
-            .bpkSuccessDialog(
+            .bpkSuccessDialogView(
                 presented: .constant(true),
                 icon: .tick,
                 title: "Title in here",

--- a/Backpack-SwiftUI/Dialog/Classes/DialogContainerViewModifier.swift
+++ b/Backpack-SwiftUI/Dialog/Classes/DialogContainerViewModifier.swift
@@ -44,6 +44,7 @@ struct DialogContainerViewModifier<DialogContent: View>: ViewModifier {
                             .frame(maxWidth: 400)
                         Spacer(minLength: .lg)
                     }
+                    .accessibilityAddTraits(.isModal)
                 }
                 // This keeps the dialog on top of everything while animating out.
                 .zIndex(.infinity)

--- a/Backpack-SwiftUI/Dialog/Classes/DialogContainerViewModifier.swift
+++ b/Backpack-SwiftUI/Dialog/Classes/DialogContainerViewModifier.swift
@@ -30,57 +30,40 @@ struct DialogContainerViewModifier<DialogContent: View>: ViewModifier {
     @ViewBuilder let dialogContent: DialogContent
     let onTouchOutside: (() -> Void)?
     
-    @State private var controller: UIViewController?
-    
     func body(content: Content) -> some View {
-        content
-            .onChange(of: isPresented) { _ in
-                if isPresented {
-                    showDialogWithContent {
-                        ZStack {
-                            Color(.scrimColor)
-                                .ignoresSafeArea()
-                                .onTapGesture { onTouchOutside?() }
-                            HStack {
-                                Spacer(minLength: .lg)
-                                dialogContent
-                                    .frame(maxWidth: 400)
-                                Spacer(minLength: .lg)
-                            }
-                        }
+        ZStack {
+            content
+            if isPresented {
+                ZStack {
+                    Color(.scrimColor)
+                        .ignoresSafeArea()
+                        .onTapGesture { onTouchOutside?() }
+                    HStack {
+                        Spacer(minLength: .lg)
+                        dialogContent
+                            .frame(maxWidth: 400)
+                        Spacer(minLength: .lg)
                     }
-                } else {
-                    controller?.dismiss(animated: true)
                 }
-            }
-    }
-    
-    private func showDialogWithContent<Content: View>(_ content: () -> Content) {
-        let controller = UIHostingController(rootView: content())
-        controller.view.backgroundColor = .clear
-        controller.modalTransitionStyle = .crossDissolve
-        controller.modalPresentationStyle = .overFullScreen
-
-        rootViewController?.present(controller, animated: true)
-        self.controller = controller
-    }
-    
-    private var rootViewController: UIViewController? {
-        UIApplication.shared
-            .windows
-            .filter { $0.isKeyWindow }
-            .first?
-            .rootViewController
+                // This keeps the dialog on top of everything while animating out.
+                .zIndex(.infinity)
+                .transition(.opacity)
+            }            
+        }
+        .animation(.easeIn, value: isPresented)
     }
 }
 
 struct DialogContainerViewModifier_Previews: PreviewProvider {
     static var previews: some View {
         Color(.canvasColor)
-            .modifier(DialogContainerViewModifier(isPresented: .constant(true)) {
-                BPKText("This is the content of a dialog!")
-                    .background(.surfaceDefaultColor)
-        } onTouchOutside: {
-            })
+            .modifier(DialogContainerViewModifier(
+                isPresented: .constant(true),
+                dialogContent: {
+                    BPKText("This is the content of a dialog!")
+                        .background(.surfaceDefaultColor)
+                },
+                onTouchOutside: {}
+            ))
     }
 }

--- a/Backpack-SwiftUI/Dialog/Classes/DialogContainerViewModifier.swift
+++ b/Backpack-SwiftUI/Dialog/Classes/DialogContainerViewModifier.swift
@@ -48,7 +48,7 @@ struct DialogContainerViewModifier<DialogContent: View>: ViewModifier {
                 // This keeps the dialog on top of everything while animating out.
                 .zIndex(.infinity)
                 .transition(.opacity)
-            }            
+            }
         }
         .animation(.easeIn, value: isPresented)
     }

--- a/Backpack-SwiftUI/Dialog/Classes/UIKitDialogContainerViewModifier.swift
+++ b/Backpack-SwiftUI/Dialog/Classes/UIKitDialogContainerViewModifier.swift
@@ -1,0 +1,90 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+
+/// View modifier that adds a dialog to the view hierarchy. It uses UIKit's UIViewController presentations
+/// behind the scenes.
+///
+/// - Parameters:
+///   - isPresented: A binding to a boolean value that determines whether the dialog is presented.
+///   - dialogContent: The content of the dialog.
+///   - onTouchOutside: A callback that is called when the scrim is tapped.
+/// - Returns: A view with the dialog added.
+struct UIKitDialogContainerViewModifier<DialogContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    @ViewBuilder let dialogContent: DialogContent
+    let onTouchOutside: (() -> Void)?
+    
+    @State private var controller: UIViewController?
+    
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isPresented) { _ in
+                if isPresented {
+                    showDialogWithContent {
+                        ZStack {
+                            Color(.scrimColor)
+                                .ignoresSafeArea()
+                                .onTapGesture { onTouchOutside?() }
+                            HStack {
+                                Spacer(minLength: .lg)
+                                dialogContent
+                                    .frame(maxWidth: 400)
+                                Spacer(minLength: .lg)
+                            }
+                        }
+                    }
+                } else {
+                    controller?.dismiss(animated: true)
+                }
+            }
+    }
+    
+    private func showDialogWithContent<Content: View>(_ content: () -> Content) {
+        let controller = UIHostingController(rootView: content())
+        controller.view.backgroundColor = .clear
+        controller.modalTransitionStyle = .crossDissolve
+        controller.modalPresentationStyle = .overFullScreen
+
+        rootViewController?.present(controller, animated: true)
+        self.controller = controller
+    }
+    
+    private var rootViewController: UIViewController? {
+        UIApplication.shared
+            .windows
+            .filter { $0.isKeyWindow }
+            .first?
+            .rootViewController
+    }
+}
+
+struct UIKitDialogContainerViewModifier_Previews: PreviewProvider {
+    static var previews: some View {
+        Color(.canvasColor)
+            .modifier(UIKitDialogContainerViewModifier(
+                isPresented: .constant(true),
+                dialogContent: {
+                    BPKText("This is the content of a dialog!")
+                        .background(.surfaceDefaultColor)
+                },
+                onTouchOutside: {}
+            ))
+    }
+}

--- a/Example/Backpack Screenshot/SwiftUIScreenshots.swift
+++ b/Example/Backpack Screenshot/SwiftUIScreenshots.swift
@@ -231,30 +231,30 @@ tapBackButton()
         
         navigate(title: "Dialogs") {
             switchTab(title: "SwiftUI")
-            app.buttons["Open Success"].tap()
+            app.buttons["Modal Success"].tap()
             saveScreenshot(component: "dialog", scenario: "success", userInterfaceStyle: userInterfaceStyle)
             app.buttons["Confirmation"].tap()
             
-            _ = app.buttons["Open Warning"].waitForExistence(timeout: 1)
-            app.buttons["Open Warning"].tap()
+            _ = app.buttons["Modal Warning"].waitForExistence(timeout: 1)
+            app.buttons["Modal Warning"].tap()
             saveScreenshot(component: "dialog", scenario: "warning", userInterfaceStyle: userInterfaceStyle)
             app.buttons["Confirmation"].tap()
             
-            _ = app.buttons["Open Destructive"].waitForExistence(timeout: 1)
-            app.buttons["Open Destructive"].tap()
+            _ = app.buttons["Modal Destructive"].waitForExistence(timeout: 1)
+            app.buttons["Modal Destructive"].tap()
             saveScreenshot(component: "dialog", scenario: "destructive", userInterfaceStyle: userInterfaceStyle)
             app.buttons["Delete"].tap()
             
-            _ = app.buttons["Open Flare"].waitForExistence(timeout: 1)
-            app.buttons["Open Flare"].tap()
+            _ = app.buttons["Modal Flare"].waitForExistence(timeout: 1)
+            app.buttons["Modal Flare"].tap()
             saveScreenshot(component: "dialog", scenario: "flare", userInterfaceStyle: userInterfaceStyle)
             app.buttons["Confirmation"].tap()
             
-            _ = app.buttons["Open Image"].waitForExistence(timeout: 1)
-            app.buttons["Open Image"].tap()
+            _ = app.buttons["Modal Image"].waitForExistence(timeout: 1)
+            app.buttons["Modal Image"].tap()
             saveScreenshot(component: "dialog", scenario: "image", userInterfaceStyle: userInterfaceStyle)
             app.buttons["Confirmation"].tap()
-            _ = app.buttons["Open Image"].waitForExistence(timeout: 1)
+            _ = app.buttons["Modal Image"].waitForExistence(timeout: 1)
         }
         
         navigate(title: "Flare views") {

--- a/Example/Backpack/SwiftUI/Components/Dialog/DialogExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/Dialog/DialogExampleView.swift
@@ -27,21 +27,118 @@ struct DialogExampleView: View {
     @State var presentingImageDialog = false
     @State var presentingFlareDialog = false
     
+    @State var presentingSuccessDialogView = false
+    @State var presentingWarningDialogView = false
+    @State var presentingDestructiveDialogView = false
+    @State var presentingImageDialogView = false
+    @State var presentingFlareDialogView = false
+    
     var body: some View {
+        HStack {
+            viewDialogs
+            modalDialogs
+        }
+        .bpkSuccessDialogView(
+            presented: $presentingSuccessDialogView,
+            icon: .tick,
+            title: "Title in here",
+            text: "Desription that goes two lines ideally, but sometimes it can go longer",
+            confirmButton: confirmButton,
+            secondaryActions: BPKDialogSecondaryActions(
+                secondaryButton: secondaryButton,
+                linkButton: linkButton
+            ),
+            onTouchOutside: dismissDialogs
+        )
+        .bpkWarningDialogView(
+            presented: $presentingWarningDialogView,
+            icon: .alertAdd,
+            title: "Title in here",
+            text: "Description that goes two lines ideally, but sometimes it can go longer",
+            confirmButton: confirmButton,
+            secondaryActions: BPKDialogSecondaryActions(
+                secondaryButton: secondaryButton,
+                linkButton: linkButton
+            ),
+            onTouchOutside: dismissDialogs
+        )
+        .bpkDestructiveDialogView(
+            presented: $presentingDestructiveDialogView,
+            icon: .trash,
+            title: "Title in here",
+            text: "Description that goes two lines ideally, but sometimes it can go longer",
+            confirmButton: BPKDialogButton("Delete", action: dismissDialogs),
+            linkButton: BPKDialogButton("Cancel", action: dismissDialogs),
+            onTouchOutside: dismissDialogs
+        )
+        .bpkImageDialogView(
+            presented: $presentingImageDialogView,
+            image: Image("dialog_image"),
+            title: "Image Dialog!",
+            text: "You're about to delete this item. This action cannot be undone.",
+            confirmButton: confirmButton,
+            secondaryActions: BPKDialogSecondaryActions(
+                secondaryButton: secondaryButton,
+                linkButton: linkButton
+            ),
+            onTouchOutside: dismissDialogs
+        )
+        .bpkFlareDialogView(
+            presented: $presentingFlareDialogView,
+            image: Image("dialog_flare"),
+            title: "Flare Dialog!",
+            text: "You're about to delete this item. This action cannot be undone.",
+            confirmButton: confirmButton,
+            secondaryActions: BPKDialogSecondaryActions(
+                secondaryButton: secondaryButton,
+                linkButton: linkButton
+            ),
+            onTouchOutside: dismissDialogs
+        )
+    }
+    
+    private var confirmButton: BPKDialogButton {
+        BPKDialogButton("Confirmation", action: dismissDialogs)
+    }
+    
+    private var secondaryButton: BPKDialogButton {
+        BPKDialogButton("Skip", action: dismissDialogs)
+    }
+    
+    private var linkButton: BPKDialogButton {
+        BPKDialogButton("Link opitonal", action: dismissDialogs)
+    }
+    
+    private func dismissDialogs() {
+        presentingSuccessDialog = false
+        presentingWarningDialog = false
+        presentingDestructiveDialog = false
+        presentingImageDialog = false
+        presentingFlareDialog = false
+        
+        presentingSuccessDialogView = false
+        presentingWarningDialogView = false
+        presentingDestructiveDialogView = false
+        presentingImageDialogView = false
+        presentingFlareDialogView = false
+    }
+    
+    var modalDialogs: some View {
         VStack {
-            BPKButton("Open Success") {
+            BPKText("As Modal")
+            BPKButton("Modal Success") {
                 presentingSuccessDialog.toggle()
             }
-            BPKButton("Open Warning") {
+            BPKButton("Modal Warning") {
                 presentingWarningDialog.toggle()
             }
-            BPKButton("Open Destructive") {
+            BPKButton("Modal Destructive") {
                 presentingDestructiveDialog.toggle()
             }
-            BPKButton("Open Image") {
+            BPKButton("Modal Image") {
                 presentingImageDialog.toggle()
             }
-            BPKButton("Open Flare") {
+            BPKButton("Modal Flare") {
                 presentingFlareDialog.toggle()
             }
         }
@@ -104,24 +201,25 @@ struct DialogExampleView: View {
         )
     }
     
-    private var confirmButton: BPKDialogButton {
-        BPKDialogButton("Confirmation", action: dismissDialogs)
-    }
-    
-    private var secondaryButton: BPKDialogButton {
-        BPKDialogButton("Skip", action: dismissDialogs)
-    }
-    
-    private var linkButton: BPKDialogButton {
-        BPKDialogButton("Link opitonal", action: dismissDialogs)
-    }
-    
-    private func dismissDialogs() {
-        presentingSuccessDialog = false
-        presentingWarningDialog = false
-        presentingDestructiveDialog = false
-        presentingImageDialog = false
-        presentingFlareDialog = false
+    var viewDialogs: some View {
+        VStack {
+            BPKText("As View")
+            BPKButton("View Success") {
+                presentingSuccessDialogView.toggle()
+            }
+            BPKButton("View Warning") {
+                presentingWarningDialogView.toggle()
+            }
+            BPKButton("View Destructive") {
+                presentingDestructiveDialogView.toggle()
+            }
+            BPKButton("View Image") {
+                presentingImageDialogView.toggle()
+            }
+            BPKButton("View Flare") {
+                presentingFlareDialogView.toggle()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adding a SwiftUI version of the dialog component, which can be used as a ZStack of views instead of a view controller. The SwiftUI dialog uses the same content and actions views as the UIKit dialog, but wraps them in a custom modifier that handles the presentation logic.

This is meant to be used in cases where presenting a view controller is not an option. The example use case for Hotels is that we need to show a dialog on a screen that's currently presenting a screen, making a new presentation impossible.

This, being just a view, has a couple of drawbacks, like presentation events for accessibility, which needs to now be done manually from the client or the scrim not being able to be drown on top of a tab bar controller or a nav bar.
So, the usage of this component is not encouraged, but there are some cases where this a different option is not possible, like the above mentioned case.