### PR TITLE
[BugFix] DynamicType and AttributedText

### DIFF
--- a/Backpack/Font/Classes/Generated/BPKFont.m
+++ b/Backpack/Font/Classes/Generated/BPKFont.m
@@ -116,6 +116,11 @@ NS_ASSUME_NONNULL_BEGIN
     UIFont *font = [self fontForFontStyle:style];
     CGFloat lineHeight = [self lineHeightForStyle:style];
     [paragraphStyle setLineSpacing:lineHeight - font.lineHeight];
+
+    if (![[BPKFontManager sharedInstance] dynamicTypeEnabled]) {
+        [paragraphStyle setMinimumLineHeight:font.capHeight];
+        [paragraphStyle setMaximumLineHeight:lineHeight];
+    }
     return paragraphStyle;
 }
 

--- a/Backpack/Font/Classes/Generated/BPKFont.m
+++ b/Backpack/Font/Classes/Generated/BPKFont.m
@@ -116,17 +116,6 @@ NS_ASSUME_NONNULL_BEGIN
     UIFont *font = [self fontForFontStyle:style];
     CGFloat lineHeight = [self lineHeightForStyle:style];
     [paragraphStyle setLineSpacing:lineHeight - font.lineHeight];
-    [paragraphStyle setMinimumLineHeight:font.capHeight];
-    [paragraphStyle setMaximumLineHeight:lineHeight];
-        
-    // When dynamic type is enabled, and the size is different from 'default'
-    // We apply the largest line height, this is to prevent line clipping on larger DynamicType sizess
-    if ([[BPKFontManager sharedInstance] dynamicTypeEnabled]) {
-        UIContentSizeCategory _Nullable currentPreferredContentSize = [UIApplication sharedApplication].preferredContentSizeCategory;
-        if(currentPreferredContentSize > UIContentSizeCategoryLarge) {
-            [paragraphStyle setMaximumLineHeight:fmax(lineHeight, font.lineHeight)];
-        }
-    }
     return paragraphStyle;
 }
 

--- a/Backpack/Label/Classes/BPKLabel.m
+++ b/Backpack/Label/Classes/BPKLabel.m
@@ -133,14 +133,5 @@ NS_ASSUME_NONNULL_BEGIN
     self.textColor = BPKColor.textPrimaryColor;
     self.adjustsFontForContentSizeCategory = [[BPKFontManager sharedInstance] dynamicTypeEnabled];
 }
-
-- (void)traitCollectionDidChange:(UITraitCollection *_Nullable)previousTraitCollection {
-    if (self.traitCollection.preferredContentSizeCategory == previousTraitCollection.preferredContentSizeCategory) {
-        return;
-    }
-
-    [self updateTextStyle];
-}
-
 @end
 NS_ASSUME_NONNULL_END

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -116,6 +116,11 @@ NS_ASSUME_NONNULL_BEGIN
     UIFont *font = [self fontForFontStyle:style];
     CGFloat lineHeight = [self lineHeightForStyle:style];
     [paragraphStyle setLineSpacing:lineHeight - font.lineHeight];
+
+    if (![[BPKFontManager sharedInstance] dynamicTypeEnabled]) {
+        [paragraphStyle setMinimumLineHeight:font.capHeight];
+        [paragraphStyle setMaximumLineHeight:lineHeight];
+    }
     return paragraphStyle;
 }
 

--- a/templates/BPKFont.m.njk
+++ b/templates/BPKFont.m.njk
@@ -116,17 +116,6 @@ NS_ASSUME_NONNULL_BEGIN
     UIFont *font = [self fontForFontStyle:style];
     CGFloat lineHeight = [self lineHeightForStyle:style];
     [paragraphStyle setLineSpacing:lineHeight - font.lineHeight];
-    [paragraphStyle setMinimumLineHeight:font.capHeight];
-    [paragraphStyle setMaximumLineHeight:lineHeight];
-        
-    // When dynamic type is enabled, and the size is different from 'default'
-    // We apply the largest line height, this is to prevent line clipping on larger DynamicType sizess
-    if ([[BPKFontManager sharedInstance] dynamicTypeEnabled]) {
-        UIContentSizeCategory _Nullable currentPreferredContentSize = [UIApplication sharedApplication].preferredContentSizeCategory;
-        if(currentPreferredContentSize > UIContentSizeCategoryLarge) {
-            [paragraphStyle setMaximumLineHeight:fmax(lineHeight, font.lineHeight)];
-        }
-    }
     return paragraphStyle;
 }
 


### PR DESCRIPTION
# DynamicType + AttributedText

The way we handled the scaling would erase custom attributedText. 
For now, we forego the custom lineheights when DynamicType is on, as a test with our custom font. Once we prove it works, we can remove custom lineheights at all times.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
