### PR TITLE
BPKButton, Dynamic Type improvements

### DIFF
--- a/Backpack-SwiftUI/Button/Classes/BPKButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/BPKButton.swift
@@ -176,7 +176,6 @@ private struct ButtonContentView: View {
         Text(title)
             .font(style: fontStyle)
             .lineLimit(1)
-            .sizeCategory(.large)
     }
     
     private var iconSize: BPKIcon.Size {

--- a/Backpack-SwiftUI/Button/Classes/CurrentStateButtonStyle.swift
+++ b/Backpack-SwiftUI/Button/Classes/CurrentStateButtonStyle.swift
@@ -49,7 +49,8 @@ struct CurrentStateButtonStyle: ButtonStyle {
         let foreground = colors(forConfiguration: configuration).foreground
         
         configuration.label
-            .frame(width: width, height: height)
+            .frame(width: width)
+            .frame(minHeight: height)
             .frame(maxWidth: matchesParentWidth ? .infinity : nil)
             .padding([.leading, .trailing], sidesPadding)
             .background(background)

--- a/Backpack/Button/Classes/BPKButton.m
+++ b/Backpack/Button/Classes/BPKButton.m
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:self.spinner];
 
-    self.heightConstraint = [self.heightAnchor constraintEqualToConstant:[self heightForSize:self.size]];
+    self.heightConstraint = [self.heightAnchor constraintGreaterThanOrEqualToConstant:[self heightForSize:self.size]];
     // To use when just icon
     self.widthConstraint = [self.widthAnchor constraintEqualToConstant:[self heightForSize:self.size]];
     self.stackLeadingFallbackConstraint = [self.contentStack.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor


### PR DESCRIPTION
# BPKButton

Allow DynamicType for both SwiftUI and UIKit buttons. Consumers can limit scaling behaviour with the regular UIKit and SwiftUI implements. 

The default behaviour for the buttons is to scale the size of the label.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
