### PR TITLE
Emitting event for slider changes

### DIFF
--- a/Backpack-SwiftUI/Slider/Classes/BPKRangeSlider.swift
+++ b/Backpack-SwiftUI/Slider/Classes/BPKRangeSlider.swift
@@ -37,7 +37,8 @@ public struct BPKRangeSlider: View {
     private let step: Float
     private let minSpacing: Float
     private let thumbnailLabels: ThumbnailLabels?
-    
+    private let onDragEnded: (ClosedRange<Float>) -> Void
+
     private let sliderHeight: CGFloat = 4
     private let thumbSize: CGFloat = 20
     private let flareHeight: CGFloat = 6
@@ -56,18 +57,21 @@ public struct BPKRangeSlider: View {
     ///   - step: The step size of the slider. Defaults to 1.
     ///   - minSpacing: The minimum spacing between the two thumbs. Defaults to 0.
     ///   - thumbnailLabels: The minimum spacing between the two thumbs. Defaults to 0.
+    ///   - onDragEnded: A closure that is called when the user stops dragging the slider.
     public init(
         selectedRange: Binding<ClosedRange<Float>>,
         sliderBounds: ClosedRange<Float>,
         step: Float = 1,
         minSpacing: Float = 0,
-        thumbnailLabels: ThumbnailLabels? = nil
+        thumbnailLabels: ThumbnailLabels? = nil,
+        onDragEnded: @escaping (ClosedRange<Float>) -> Void = { _ in }
     ) {
         self._selectedRange = selectedRange
         self.sliderBounds = sliderBounds
         self.step = step
         self.minSpacing = minSpacing
         self.thumbnailLabels = thumbnailLabels
+        self.onDragEnded = onDragEnded
     }
     
     public var body: some View {
@@ -108,10 +112,13 @@ public struct BPKRangeSlider: View {
                 .padding(.bottom, (thumbSize / 2) - (sliderHeight / 2))
             SliderThumbView(
                 size: thumbSize,
-                offset: trailingThumbOffset(sliderSize: sliderSize)
-            ) { value in
-                handleTrailingThumbDrag(value: value, sliderSize: sliderSize)
-            }
+                offset: trailingThumbOffset(sliderSize: sliderSize),
+                onDrag: { value in
+                    handleTrailingThumbDrag(value: value, sliderSize: sliderSize)
+                },
+                onDragEnded: { onDragEnded(selectedRange) }
+            )
+            
             .accessibilityLabel(trailingAccessibilityLabel)
             .accessibility(value: Text("\(selectedRange.upperBound)"))
             .accessibilityAdjustableAction { direction in
@@ -128,10 +135,12 @@ public struct BPKRangeSlider: View {
             }
             SliderThumbView(
                 size: thumbSize,
-                offset: leadingThumbOffset(sliderSize: sliderSize)
-            ) { value in
-                handleLeadingThumbDrag(value: value, sliderSize: sliderSize)
-            }
+                offset: leadingThumbOffset(sliderSize: sliderSize),
+                onDrag: { value in
+                    handleLeadingThumbDrag(value: value, sliderSize: sliderSize)
+                },
+                onDragEnded: { onDragEnded(selectedRange) }
+            )
             .accessibilityLabel(leadingAccessibilityLabel)
             .accessibility(value: Text("\(selectedRange.lowerBound)"))
             .accessibilityAdjustableAction { direction in

--- a/Backpack-SwiftUI/Slider/Classes/BPKSlider.swift
+++ b/Backpack-SwiftUI/Slider/Classes/BPKSlider.swift
@@ -24,7 +24,8 @@ public struct BPKSlider: View {
     @Binding private var value: Float
     private let sliderBounds: ClosedRange<Float>
     private let step: Float
-    
+    private let onDragEnded: (Float) -> Void
+
     private let sliderHeight: CGFloat = 4
     private let thumbSize: CGFloat = 20
     private var thumbAccessibilityLabel = ""
@@ -37,14 +38,17 @@ public struct BPKSlider: View {
     ///   - value: Binding of the value of the slider.
     ///   - sliderBounds: The bounds of the slider.
     ///   - step: The step size of the slider. Defaults to 1.
+    ///   - onDragEnded: A closure that will be called when the user stops dragging the slider.
     public init(
         value: Binding<Float>,
         sliderBounds: ClosedRange<Float>,
-        step: Float = 1
+        step: Float = 1,
+        onDragEnded: @escaping (Float) -> Void = { _ in }
     ) {
         self._value = value
         self.sliderBounds = sliderBounds
         self.step = step
+        self.onDragEnded = onDragEnded
     }
     
     public var body: some View {
@@ -70,6 +74,8 @@ public struct BPKSlider: View {
                 offset: thumbOffset(sliderSize: sliderSize)
             ) { dragValue in
                 handleThumbDrag(value: dragValue, sliderSize: sliderSize)
+            } onDragEnded: {
+                onDragEnded(value)
             }
             .accessibilityLabel(thumbAccessibilityLabel)
             .accessibility(value: Text("\(value)"))

--- a/Backpack-SwiftUI/Slider/Classes/SliderThumbView.swift
+++ b/Backpack-SwiftUI/Slider/Classes/SliderThumbView.swift
@@ -22,6 +22,7 @@ struct SliderThumbView: View {
     let size: CGFloat
     let offset: CGFloat
     let onDrag: (DragGesture.Value) -> Void
+    let onDragEnded: () -> Void
     
     var body: some View {
         Circle()
@@ -34,12 +35,15 @@ struct SliderThumbView: View {
                     .onChanged { value in
                         onDrag(value)
                     }
+                    .onEnded { _ in
+                        onDragEnded()
+                    }
             )
     }
 }
 
 struct SliderThumbView_Previews: PreviewProvider {
     static var previews: some View {
-        SliderThumbView(size: 20, offset: 0) { _ in }
+        SliderThumbView(size: 20, offset: 0) { _ in } onDragEnded: {}
     }
 }

--- a/Backpack-SwiftUI/Slider/README.md
+++ b/Backpack-SwiftUI/Slider/README.md
@@ -26,6 +26,21 @@ BPKSlider(value: $value, sliderBounds: 0...1)
 BPKRangeSlider(selectedRange: $value, sliderBounds: 0...1)
 ```
 
+### Listening to changes after the user has finished interacting with the slider
+```swift
+BPKSlider(
+    value: $value,
+    sliderBounds: 0...1,
+    onDragEnded: { newValue in print("Slider value changed to \(newValue)") }
+)
+
+BPKRangeSlider(
+    selectedRange: $value,
+    sliderBounds: 0...1,
+    onDragEnded: { newRange in print("Slider range changed to \(newRange)") }
+)
+```
+
 ### Changing the step size
 ```swift
 @State var value: Float = 50


### PR DESCRIPTION
Emitting an event when the user stops dragging the slider or range slider. This is useful for applications that need to react to the slider value changes

The changes are:

* Added a parameter onDragEnded to BPKSlider and BPKRangeSlider that takes a closure that will be called with the new value or range when the user stops dragging.
* Added a call to onDragEnded in the SliderThumbView when the drag gesture ends.
* Updated the README.md file with examples of how to use the onDragEnded parameter.