### PR TITLE
OGM-1926: Disable month selection for last month

### DIFF
--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -170,7 +170,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, strong) BPKCalendarSelectionConfiguration *selectionConfiguration;
 
-
 @property(nonatomic, strong) BPKCalendarWholeMonthConfiguration *_Nullable wholeMonthSelectionConfiguration;
 
 /**

--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -20,6 +20,7 @@
 @class BPKSimpleDate;
 @class BPKCalendarConfiguration;
 @class BPKCalendarSelectionConfiguration;
+@class BPKCalendarWholeMonthConfiguration;
 
 @protocol BPKMonthDateProvider;
 
@@ -169,6 +170,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, strong) BPKCalendarSelectionConfiguration *selectionConfiguration;
 
+
+@property(nonatomic, strong) BPKCalendarWholeMonthConfiguration *_Nullable wholeMonthSelectionConfiguration;
+
 /**
  * List of selected dates
  */
@@ -215,21 +219,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(readonly) BOOL isDragging;
 
 /**
- * Whether selecting a whole month is allowed or not
- */
-@property(readonly) BOOL allowsWholeMonthSelection;
-
-/**
- * The title for the whole month button
- */
-@property(readonly, nonatomic, strong) NSString *_Nullable wholeMonthTitle;
-
-/**
- * Enable select whole month button only for limited of month
- */
-@property(nonatomic) NSInteger selectWholeMonthRange;
-
-/**
  * The calendar's delegate
  */
 @property(nonatomic, nullable, weak) id<BPKCalendarDelegate> delegate;
@@ -255,13 +244,5 @@ NS_ASSUME_NONNULL_BEGIN
  * @param month The month to be selected.
  */
 - (void)selectWholeMonth:(BPKSimpleDate *)month;
-
-/**
- * Wheteher the whole month button is enabled for a given month.
- * @param month A date representing the month.
- * * @return `FALSE` if the month is previous to the `minDate`, `TRUE` otherwise.
- */
-- (BOOL)isWholeMonthButtonEnabledForMonth:(BPKSimpleDate *)month;
-
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKCalendar.h
+++ b/Backpack/Calendar/Classes/BPKCalendar.h
@@ -225,6 +225,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(readonly, nonatomic, strong) NSString *_Nullable wholeMonthTitle;
 
 /**
+ * Enable select whole month button only for limited of month
+ */
+@property(nonatomic) NSInteger selectWholeMonthRange;
+
+/**
  * The calendar's delegate
  */
 @property(nonatomic, nullable, weak) id<BPKCalendarDelegate> delegate;

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -455,7 +455,7 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     NSDate *minDate = [self.minDate dateForCalendar:self.gregorian];
 
     NSDateComponents *comps = [self.gregorian components:NSCalendarUnitMonth fromDate:minDate toDate:monthDate options:0];
-    return comps.month >= 0;
+    return comps.month >= 0 && comps.month < 11;
 }
 
 #pragma mark - <FSCalendarDataSource>

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -44,6 +44,8 @@
 #import "BPKCalendarTrafficLightConfiguration.h"
 #import "BPKCalendarYearPill.h"
 
+#import "Backpack/Backpack-Swift.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 // This is kept around only to support the React Native calendar implementation
@@ -141,7 +143,6 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
         // `minDate` and `maxDate` is `nonnull` so we need to ensure **it is not** `nil`.
         self.minDate = [[BPKSimpleDate alloc] initWithYear:1970 month:1 day:1];
         self.maxDate = [[BPKSimpleDate alloc] initWithYear:2099 month:12 day:31];
-        self.selectWholeMonthRange = NSIntegerMax;
         _gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
         _dateProvider = [[BPKCalendarMonthDateProvider alloc] initWithCalendar:_gregorian];
         [self setup];
@@ -341,6 +342,13 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     }
 }
 
+- (void)setWholeMonthSelectionConfiguration:(BPKCalendarWholeMonthConfiguration *_Nullable)wholeMonthSelectionConfiguration {
+    BPKAssertMainThread();
+    if(_wholeMonthSelectionConfiguration != wholeMonthSelectionConfiguration) {
+        _wholeMonthSelectionConfiguration = wholeMonthSelectionConfiguration;
+    }
+}
+
 - (void)setContentOffset:(CGPoint)contentOffset {
     self.calendarView.collectionView.contentOffset = contentOffset;
 }
@@ -391,14 +399,6 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     }
 
     self.sameDayRange = selectedDates.count == 2 && [selectedDates.firstObject isEqual:selectedDates.lastObject];
-}
-
-- (BOOL)allowsWholeMonthSelection {
-    return self.wholeMonthTitle != nil && self.wholeMonthTitle.length > 0;
-}
-
-- (NSString *_Nullable)wholeMonthTitle {
-    return self.selectionConfiguration.wholeMonthTitle;
 }
 
 #pragma mark - public methods
@@ -453,10 +453,21 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
 
 - (BOOL)isWholeMonthButtonEnabledForMonth:(BPKSimpleDate *)month {
     NSDate *monthDate = [month dateForCalendar:self.gregorian];
+    
+    // If month is before calendar minimum date
     NSDate *minDate = [self.minDate dateForCalendar:self.gregorian];
-
     NSDateComponents *minComps = [self.gregorian components:NSCalendarUnitMonth fromDate:minDate toDate:monthDate options:0];
-    return minComps.month >= 0 && minComps.month < self.selectWholeMonthRange;
+    if (minComps.month < 0) {
+        return false;
+    }
+    
+    // If month is not in the selectableWholeMonthRange
+    NSDate *minSelectableMonth = NSDate.now;
+    NSDate *maxSelectableMonth = [NSDate.now dateByAddingTimeInterval:50000];
+    
+    
+    
+    return true;
 }
 
 #pragma mark - <FSCalendarDataSource>

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -141,6 +141,7 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
         // `minDate` and `maxDate` is `nonnull` so we need to ensure **it is not** `nil`.
         self.minDate = [[BPKSimpleDate alloc] initWithYear:1970 month:1 day:1];
         self.maxDate = [[BPKSimpleDate alloc] initWithYear:2099 month:12 day:31];
+        self.selectWholeMonthRange = NSIntegerMax;
         _gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
         _dateProvider = [[BPKCalendarMonthDateProvider alloc] initWithCalendar:_gregorian];
         [self setup];
@@ -453,11 +454,9 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
 - (BOOL)isWholeMonthButtonEnabledForMonth:(BPKSimpleDate *)month {
     NSDate *monthDate = [month dateForCalendar:self.gregorian];
     NSDate *minDate = [self.minDate dateForCalendar:self.gregorian];
-    NSDate *maxDate = [self.maxDate dateForCalendar:self.gregorian];
 
     NSDateComponents *minComps = [self.gregorian components:NSCalendarUnitMonth fromDate:minDate toDate:monthDate options:0];
-    NSDateComponents *maxComps = [self.gregorian components:NSCalendarUnitMonth fromDate:maxDate toDate:monthDate options:0];
-    return minComps.month >= 0 && maxComps.month < 0;
+    return minComps.month >= 0 && minComps.month < self.selectWholeMonthRange;
 }
 
 #pragma mark - <FSCalendarDataSource>

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -344,7 +344,7 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
 
 - (void)setWholeMonthSelectionConfiguration:(BPKCalendarWholeMonthConfiguration *_Nullable)wholeMonthSelectionConfiguration {
     BPKAssertMainThread();
-    if(_wholeMonthSelectionConfiguration != wholeMonthSelectionConfiguration) {
+    if (_wholeMonthSelectionConfiguration != wholeMonthSelectionConfiguration) {
         _wholeMonthSelectionConfiguration = wholeMonthSelectionConfiguration;
     }
 }

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -451,25 +451,6 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
     self.calendarView.allowsMultipleSelection = previousMultiSelectionConfiguration;
 }
 
-- (BOOL)isWholeMonthButtonEnabledForMonth:(BPKSimpleDate *)month {
-    NSDate *monthDate = [month dateForCalendar:self.gregorian];
-    
-    // If month is before calendar minimum date
-    NSDate *minDate = [self.minDate dateForCalendar:self.gregorian];
-    NSDateComponents *minComps = [self.gregorian components:NSCalendarUnitMonth fromDate:minDate toDate:monthDate options:0];
-    if (minComps.month < 0) {
-        return false;
-    }
-    
-    // If month is not in the selectableWholeMonthRange
-    NSDate *minSelectableMonth = NSDate.now;
-    NSDate *maxSelectableMonth = [NSDate.now dateByAddingTimeInterval:50000];
-    
-    
-    
-    return true;
-}
-
 #pragma mark - <FSCalendarDataSource>
 
 - (FSCalendarCell *)calendar:(FSCalendar *)calendar cellForDate:(NSDate *)date atMonthPosition:(FSCalendarMonthPosition)monthPosition {

--- a/Backpack/Calendar/Classes/BPKCalendar.m
+++ b/Backpack/Calendar/Classes/BPKCalendar.m
@@ -453,9 +453,11 @@ CGFloat const BPKCalendarDefaultCellHeight = 44;
 - (BOOL)isWholeMonthButtonEnabledForMonth:(BPKSimpleDate *)month {
     NSDate *monthDate = [month dateForCalendar:self.gregorian];
     NSDate *minDate = [self.minDate dateForCalendar:self.gregorian];
+    NSDate *maxDate = [self.maxDate dateForCalendar:self.gregorian];
 
-    NSDateComponents *comps = [self.gregorian components:NSCalendarUnitMonth fromDate:minDate toDate:monthDate options:0];
-    return comps.month >= 0 && comps.month < 11;
+    NSDateComponents *minComps = [self.gregorian components:NSCalendarUnitMonth fromDate:minDate toDate:monthDate options:0];
+    NSDateComponents *maxComps = [self.gregorian components:NSCalendarUnitMonth fromDate:maxDate toDate:monthDate options:0];
+    return minComps.month >= 0 && maxComps.month < 0;
 }
 
 #pragma mark - <FSCalendarDataSource>

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfiguration.h
@@ -44,15 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface BPKCalendarSelectionConfiguration : NSObject
 
 /**
- * Creates a `BPKCalendarSelectionConfiguration` with the specific classes.
- *
- * @param selectionStyle The selection style of the config.
- * @param wholeMonthTitle The title of the whole month button, if it's `nil` or empty then the button won't be visible.
- * @return `BPKCalendarSelectionConfiguration` instance.
- */
-- (instancetype)initWithSelectionStyle:(BPKCalendarSelectionStyle)selectionStyle andWholeMonthTitle:(NSString *_Nullable)wholeMonthTitle;
-
-/**
  * Creates a `BPKCalendarSelectionConfiguration` with the specific classes. Internally it calls to initWithSelectionStyle:andWholeMonthTitle: but
  * passing `nil` as `wholeMonthTitle`
  *

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.h
@@ -53,19 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A selection configuration.
  */
 - (instancetype)initWithSelectionHint:(NSString *)selectionHint deselectionHint:(NSString *)deselectionHint;
-
-/**
- * Create a multi-selection configuration with given accessibility strings.
- *
- * @param selectionHint The hint provided to assistive technologies informing a user how to select a date.
- * @param deselectionHint The hint provided to assistive technologies informing a user how to deselect a date.
- *  @param wholeMonthTitle The title of the whole month button, if it's `nil` or empty then the button won't be visible.
- * @return A selection configuration.
- */
-- (instancetype)initWithSelectionHint:(NSString *)selectionHint
-                      deselectionHint:(NSString *)deselectionHint
-                   andWholeMonthTitle:(NSString *_Nullable)wholeMonthTitle;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
@@ -20,8 +20,7 @@
 
 @implementation BPKCalendarSelectionConfigurationMultiple
 
-- (instancetype)initWithSelectionHint:(NSString *)selectionHint
-                      deselectionHint:(NSString *)deselectionHint {
+- (instancetype)initWithSelectionHint:(NSString *)selectionHint deselectionHint:(NSString *)deselectionHint {
     self = [super initWithSelectionStyle:BPKCalendarSelectionStyleMultiple];
 
     if (self) {

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationMultiple.m
@@ -20,14 +20,9 @@
 
 @implementation BPKCalendarSelectionConfigurationMultiple
 
-- (instancetype)initWithSelectionHint:(NSString *)selectionHint deselectionHint:(NSString *)deselectionHint {
-    return [self initWithSelectionHint:selectionHint deselectionHint:deselectionHint andWholeMonthTitle:nil];
-}
-
 - (instancetype)initWithSelectionHint:(NSString *)selectionHint
-                      deselectionHint:(NSString *)deselectionHint
-                   andWholeMonthTitle:(NSString *_Nullable)wholeMonthTitle {
-    self = [super initWithSelectionStyle:BPKCalendarSelectionStyleMultiple andWholeMonthTitle:wholeMonthTitle];
+                      deselectionHint:(NSString *)deselectionHint {
+    self = [super initWithSelectionStyle:BPKCalendarSelectionStyleMultiple];
 
     if (self) {
         _selectionHint = [selectionHint copy];

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.h
@@ -92,31 +92,6 @@ NS_ASSUME_NONNULL_BEGIN
                      betweenSelectionState:(NSString *)betweenSelectionState
                  startAndEndSelectionState:(NSString *)startAndEndSelectionState
                           returnDatePrompt:(NSString *)returnDatePrompt;
-
-/**
- * Create a multi-selection configuration with given accessibility strings.
- *
- * @param startSelectionHint The hint provided to assistive technologies informing a user how to select the first date in the range.
- * @param endSelectionHint The hint provided to assistive technologies informing a user how to select the second date in the range.
- * @param startSelectionState The label provided to assistive technologies informing a user that a date is selected as the first date in the range.
- * @param endSelectionState The label provided to assistive technologies informing a user that a date is selected as the second date in the range.
- * @param betweenSelectionState The label provided to assistive technologies informing a user that a date lies between the first and second selected
- * dates.
- * @param startAndEndSelectionState The label provided to assistive technologies informing a user that a date is selected as both the first and second
- * date in the range.
- * @param returnDatePrompt The prompt provided to assistive technologies informing a user that they should now select a second date.
- * * @param wholeMonthTitle The title of the whole month button, if it's `nil` or empty then the button won't be visible.
- * @return A selection configuration.
- */
-- (instancetype)initWithStartSelectionHint:(NSString *)startSelectionHint
-                          endSelectionHint:(NSString *)endSelectionHint
-                       startSelectionState:(NSString *)startSelectionState
-                         endSelectionState:(NSString *)endSelectionState
-                     betweenSelectionState:(NSString *)betweenSelectionState
-                 startAndEndSelectionState:(NSString *)startAndEndSelectionState
-                          returnDatePrompt:(NSString *)returnDatePrompt
-                        andWholeMonthTitle:(NSString *_Nullable)wholeMonthTitle;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationRange.m
@@ -27,25 +27,7 @@
                      betweenSelectionState:(NSString *)betweenSelectionState
                  startAndEndSelectionState:(NSString *)startAndEndSelectionState
                           returnDatePrompt:(NSString *)returnDatePrompt {
-    return [self initWithStartSelectionHint:startSelectionHint
-                           endSelectionHint:endSelectionHint
-                        startSelectionState:startSelectionState
-                          endSelectionState:endSelectionState
-                      betweenSelectionState:betweenSelectionState
-                  startAndEndSelectionState:startAndEndSelectionState
-                           returnDatePrompt:returnDatePrompt
-                         andWholeMonthTitle:nil];
-}
-
-- (instancetype)initWithStartSelectionHint:(NSString *)startSelectionHint
-                          endSelectionHint:(NSString *)endSelectionHint
-                       startSelectionState:(NSString *)startSelectionState
-                         endSelectionState:(NSString *)endSelectionState
-                     betweenSelectionState:(NSString *)betweenSelectionState
-                 startAndEndSelectionState:(NSString *)startAndEndSelectionState
-                          returnDatePrompt:(NSString *)returnDatePrompt
-                        andWholeMonthTitle:(NSString *_Nullable)wholeMonthTitle {
-    self = [super initWithSelectionStyle:BPKCalendarSelectionStyleRange andWholeMonthTitle:wholeMonthTitle];
+    self = [super initWithSelectionStyle:BPKCalendarSelectionStyleRange];
 
     if (self) {
         _startSelectionHint = [startSelectionHint copy];

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param selectionHint The hint provided to assistive technologies informing a user how to select a date.
  * @return A selection configuration.
- */ 
+ */
 - (instancetype)initWithSelectionHint:(NSString *)selectionHint;
 
 @end

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.h
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.h
@@ -43,17 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param selectionHint The hint provided to assistive technologies informing a user how to select a date.
  * @return A selection configuration.
- */
+ */ 
 - (instancetype)initWithSelectionHint:(NSString *)selectionHint;
-
-/**
- * Create a single selection configuration with given accessibility strings.
- *
- * @param selectionHint The hint provided to assistive technologies informing a user how to select a date.
- * @param wholeMonthTitle The title of the whole month button, if it's `nil` or empty then the button won't be visible.
- * @return A selection configuration.
- */
-- (instancetype)initWithSelectionHint:(NSString *)selectionHint andWholeMonthTitle:(NSString *_Nullable)wholeMonthTitle;
 
 @end
 

--- a/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
+++ b/Backpack/Calendar/Classes/BPKCalendarSelectionConfigurationSingle.m
@@ -21,11 +21,7 @@
 @implementation BPKCalendarSelectionConfigurationSingle
 
 - (instancetype)initWithSelectionHint:(NSString *)selectionHint {
-    return [self initWithSelectionHint:selectionHint andWholeMonthTitle:nil];
-}
-
-- (instancetype)initWithSelectionHint:(NSString *)selectionHint andWholeMonthTitle:(NSString *_Nullable)wholeMonthTitle {
-    self = [super initWithSelectionStyle:BPKCalendarSelectionStyleSingle andWholeMonthTitle:wholeMonthTitle];
+    self = [super initWithSelectionStyle:BPKCalendarSelectionStyleSingle];
 
     if (self) {
         _selectionHint = [selectionHint copy];

--- a/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
+++ b/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
@@ -25,6 +25,7 @@
 #import <Backpack/Spacing.h>
 
 #import "BPKCalendarAppearance.h"
+#import "Backpack/Backpack-Swift.h"
 
 @interface FSCalendarStickyHeader (Private)
 
@@ -110,11 +111,13 @@ CGFloat const BPKBaselineOffset = 2.0;
     if (!calendar) {
         return;
     }
-
-    self.selectMonthButton.hidden = !calendar.allowsWholeMonthSelection;
+    
+    BPKCalendarWholeMonthConfiguration *configuration = calendar.wholeMonthSelectionConfiguration;
+    self.selectMonthButton.hidden = configuration == nil;
+    
     BPKSimpleDate *simpleMonth = [BPKSimpleDate simpleDatesFromDates:@[month] forCalendar:calendar.gregorian].firstObject;
-    self.selectMonthButton.enabled = [calendar isWholeMonthButtonEnabledForMonth:simpleMonth];
-    [self.selectMonthButton setTitle:calendar.wholeMonthTitle];
+    self.selectMonthButton.enabled = [configuration isWholeMonthSelectionEnabledWithMonth:simpleMonth];
+    [self.selectMonthButton setTitle:configuration.title];
 }
 
 #pragma mark - Actions

--- a/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
+++ b/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
@@ -111,10 +111,10 @@ CGFloat const BPKBaselineOffset = 2.0;
     if (!calendar) {
         return;
     }
-    
+
     BPKCalendarWholeMonthConfiguration *configuration = calendar.wholeMonthSelectionConfiguration;
     self.selectMonthButton.hidden = configuration == nil;
-    
+
     BPKSimpleDate *simpleMonth = [BPKSimpleDate simpleDatesFromDates:@[month] forCalendar:calendar.gregorian].firstObject;
     self.selectMonthButton.enabled = [configuration isWholeMonthSelectionEnabledWithMonth:simpleMonth];
     [self.selectMonthButton setTitle:configuration.title];

--- a/Backpack/Calendar/Classes/BPKCalendarWholeMonthSelectionConfiguration.swift
+++ b/Backpack/Calendar/Classes/BPKCalendarWholeMonthSelectionConfiguration.swift
@@ -19,14 +19,24 @@
 @objcMembers
 public class BPKCalendarWholeMonthConfiguration: NSObject {
     public let title: String
-    private let selectableMonthRange: ClosedRange<BPKYearMonth>
+    private let selectableMonthRange: ClosedRange<BPKYearMonth>?
     
-    public init(title: String, selectableMonthRange: ClosedRange<BPKYearMonth>) {
+    public init(title: String, selectableMonthRange: ClosedRange<BPKYearMonth>? = nil) {
         self.title = title
         self.selectableMonthRange = selectableMonthRange
     }
     
+    /**
+     * Check if the passed month is included in the selectable months
+     *
+     * @param month The mont to check
+     * @return True when the month is in the selectable range, or when the selectable ragne is nil
+     */
     public func isWholeMonthSelectionEnabled(month: BPKSimpleDate) -> Bool {
+        guard let selectableMonthRange else {
+            return true
+        }
+        
         let currentMonth = BPKYearMonth(year: month.year, month: month.month)
         return selectableMonthRange.contains(currentMonth)
     }

--- a/Backpack/Calendar/Classes/BPKCalendarWholeMonthSelectionConfiguration.swift
+++ b/Backpack/Calendar/Classes/BPKCalendarWholeMonthSelectionConfiguration.swift
@@ -1,0 +1,33 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@objc
+@objcMembers
+public class BPKCalendarWholeMonthConfiguration: NSObject {
+    public let title: String
+    private let selectableMonthRange: ClosedRange<BPKYearMonth>
+    
+    public init(title: String, selectableMonthRange: ClosedRange<BPKYearMonth>) {
+        self.title = title
+        self.selectableMonthRange = selectableMonthRange
+    }
+    
+    public func isWholeMonthSelectionEnabled(month: BPKSimpleDate) -> Bool {
+        let currentMonth = BPKYearMonth(year: month.year, month: month.month)
+        return selectableMonthRange.contains(currentMonth)
+    }
+}

--- a/Backpack/Calendar/Classes/BPKYearMonth.swift
+++ b/Backpack/Calendar/Classes/BPKYearMonth.swift
@@ -28,7 +28,11 @@ public struct BPKYearMonth {
 
 extension BPKYearMonth: Comparable {
     public static func < (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
-        if lhs.year < rhs.year && lhs.month < rhs.month {
+        if lhs.year < rhs.year {
+            return true
+        }
+        
+        if lhs.year == rhs.year && lhs.month < rhs.month {
             return true
         }
         
@@ -36,7 +40,11 @@ extension BPKYearMonth: Comparable {
     }
     
     public static func > (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
-        if lhs.year > rhs.year && lhs.month > rhs.month {
+        if lhs.year > rhs.year {
+            return true
+        }
+        
+        if lhs.year == rhs.year && lhs.month > rhs.month {
             return true
         }
         
@@ -52,7 +60,11 @@ extension BPKYearMonth: Comparable {
     }
     
     public static func <= (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
-        if lhs.year <= rhs.year && lhs.month <= rhs.month {
+        if lhs.year <= rhs.year {
+            return true
+        }
+        
+        if lhs.year == rhs.year && lhs.month <= rhs.month {
             return true
         }
         
@@ -60,7 +72,11 @@ extension BPKYearMonth: Comparable {
     }
     
     public static func >= (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
-        if lhs.year >= rhs.year && lhs.month >= rhs.month {
+        if lhs.year >= rhs.year {
+            return true
+        }
+        
+        if lhs.year == rhs.year && lhs.month >= rhs.month {
             return true
         }
         

--- a/Backpack/Calendar/Classes/BPKYearMonth.swift
+++ b/Backpack/Calendar/Classes/BPKYearMonth.swift
@@ -1,0 +1,69 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public struct BPKYearMonth {
+    public let year: UInt
+    public let month: UInt
+    
+    public init(year: UInt, month: UInt) {
+        self.year = year
+        self.month = month
+    }
+}
+
+extension BPKYearMonth: Comparable {
+    public static func < (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
+        if lhs.year < rhs.year && lhs.month < rhs.month {
+            return true
+        }
+        
+        return false
+    }
+    
+    public static func > (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
+        if lhs.year > rhs.year && lhs.month > rhs.month {
+            return true
+        }
+        
+        return false
+    }
+    
+    public static func == (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
+        if lhs.year == rhs.year && lhs.month == rhs.month {
+            return true
+        }
+        
+        return false
+    }
+    
+    public static func <= (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
+        if lhs.year <= rhs.year && lhs.month <= rhs.month {
+            return true
+        }
+        
+        return false
+    }
+    
+    public static func >= (lhs: BPKYearMonth, rhs: BPKYearMonth) -> Bool {
+        if lhs.year >= rhs.year && lhs.month >= rhs.month {
+            return true
+        }
+        
+        return false
+    }
+}

--- a/Backpack/Calendar/README.md
+++ b/Backpack/Calendar/README.md
@@ -279,6 +279,23 @@ extension MyClass: BPKCalendarDelegate {
 }
 ```
 
+### Whole month selection
+You can enable the selection of an entire month by setting the `wholeMonthSelectionConfiguration` on the BPKCalendar.
+The `selectableMonthRange` can be `nil`, which will not disable any selection options.
+
+> Keep in mind that when you set a min and max date on the calendar, 
+> you want to match this in your whole month configuration.
+>
+> There are no safeguards in place to disable whole month for months that are fully disabled.
+
+```swift
+let calendar = BPKCalendar()
+/* code omitted */
+calendar.wholeMonthSelectionConfiguration = BPKCalendarWholeMonthConfiguration(
+    title: "Select whole month",
+    selectableMonthRange: BPKYearMonth(year: 2020, month: 1)...BPKYearMonth(year: 2020, month: 12)
+)
+```
 ### Appearance attributes
 
 - `(UIColor)dateSelectedContentColor`

--- a/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
+++ b/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
@@ -239,8 +239,7 @@ final class BPKCalendarSnapshotTest: XCTestCase, BPKCalendarDelegate {
         )
         
         sut.wholeMonthSelectionConfiguration = .init(
-            title: "Select whole month",
-            selectableMonthRange: BPKYearMonth(year: 2020, month: 1)...BPKYearMonth(year: 2020, month: 12)
+            title: "Select whole month"
         )
         
         // When

--- a/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
+++ b/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
@@ -235,8 +235,12 @@ final class BPKCalendarSnapshotTest: XCTestCase, BPKCalendarDelegate {
             endSelectionState: "",
             betweenSelectionState: "",
             startAndEndSelectionState: "",
-            returnDatePrompt: "",
-            andWholeMonthTitle: "Select whole month"
+            returnDatePrompt: ""
+        )
+        
+        sut.wholeMonthSelectionConfiguration = .init(
+            title: "Select whole month",
+            selectableMonthRange: BPKYearMonth(year: 2020, month: 1)...BPKYearMonth(year: 2020, month: 12)
         )
         
         // When

--- a/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
+++ b/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
@@ -247,6 +247,21 @@ final class BPKCalendarSnapshotTest: XCTestCase, BPKCalendarDelegate {
         assertSnapshot(snapshotView)
     }
     
+    func testCalendarWithWholeMonthButtonxxxxx() {
+        // Given
+        sut.selectionConfiguration = BPKCalendarSelectionConfigurationSingle(selectionHint: "")
+        sut.selectedDates = [BPKSimpleDate(date: date1, for: sut.gregorian)]
+        sut.selectWholeMonthRange = 1
+        sut.reloadData()
+        
+        // When
+        sut.selectedDates = []
+        sut.reloadData()
+        
+        // Then
+        assertSnapshot(snapshotView)
+    }
+    
     // MARK: Helpers
     private func setupViews(calendar: BPKCalendar) -> UIView {
         let snapshotView = UIView()

--- a/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
+++ b/Backpack/Tests/SnapshotTests/BPKCalendarSnapshotTest.swift
@@ -247,21 +247,6 @@ final class BPKCalendarSnapshotTest: XCTestCase, BPKCalendarDelegate {
         assertSnapshot(snapshotView)
     }
     
-    func testCalendarWithWholeMonthButtonxxxxx() {
-        // Given
-        sut.selectionConfiguration = BPKCalendarSelectionConfigurationSingle(selectionHint: "")
-        sut.selectedDates = [BPKSimpleDate(date: date1, for: sut.gregorian)]
-        sut.selectWholeMonthRange = 1
-        sut.reloadData()
-        
-        // When
-        sut.selectedDates = []
-        sut.reloadData()
-        
-        // Then
-        assertSnapshot(snapshotView)
-    }
-    
     // MARK: Helpers
     private func setupViews(calendar: BPKCalendar) -> UIView {
         let snapshotView = UIView()

--- a/Backpack/Tests/UnitTests/BPKCalendarWholeMonthConfigurationTests.swift
+++ b/Backpack/Tests/UnitTests/BPKCalendarWholeMonthConfigurationTests.swift
@@ -1,0 +1,70 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import Backpack
+
+final class BPKCalendarWholeMonthConfigurationTests: XCTestCase {
+    func test_monthInRange_whenRangeIsNotSet() {
+        // Given
+        let sut = BPKCalendarWholeMonthConfiguration(
+            title: "SelectWholeMonth",
+            selectableMonthRange: nil
+        )
+        
+        let month = BPKSimpleDate(year: 2020, month: 1, day: 1)
+        
+        // When
+        let result = sut.isWholeMonthSelectionEnabled(month: month)
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+    func test_monthInRange_whenRangeIsSet() {
+        // Given
+        let sut = BPKCalendarWholeMonthConfiguration(
+            title: "SelectWholeMonth",
+            selectableMonthRange: BPKYearMonth(year: 2020, month: 1)...BPKYearMonth(year: 2020, month: 12)
+        )
+        
+        let month = BPKSimpleDate(year: 2020, month: 1, day: 1)
+        
+        // When
+        let result = sut.isWholeMonthSelectionEnabled(month: month)
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+    func test_monthOutOfRange_whenRangeIsSet() {
+        // Given
+        let sut = BPKCalendarWholeMonthConfiguration(
+            title: "SelectWholeMonth",
+            selectableMonthRange: BPKYearMonth(year: 2020, month: 1)...BPKYearMonth(year: 2020, month: 12)
+        )
+        
+        let month = BPKSimpleDate(year: 2021, month: 1, day: 1)
+        
+        // When
+        let result = sut.isWholeMonthSelectionEnabled(month: month)
+        
+        // Then
+        XCTAssertFalse(result)
+    }
+}

--- a/Backpack/Tests/UnitTests/BPKYearMonthTests.swift
+++ b/Backpack/Tests/UnitTests/BPKYearMonthTests.swift
@@ -1,0 +1,79 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import Backpack
+
+final class BPKYearMonthTests: XCTestCase {
+    func test_isEqual() {
+        // Given
+        let sut1 = BPKYearMonth(year: 2023, month: 1)
+        let sut2 = BPKYearMonth(year: 2023, month: 1)
+        
+        // Then
+        XCTAssertTrue(sut1 == sut2)
+    }
+    
+    func test_isBefore() {
+        // Given
+        let sut1 = BPKYearMonth(year: 2022, month: 1)
+        let sut2 = BPKYearMonth(year: 2023, month: 1)
+        let sut3 = BPKYearMonth(year: 2023, month: 2)
+        
+        // Then
+        XCTAssertTrue(sut1 < sut2)
+        XCTAssertTrue(sut2 < sut3)
+    }
+    
+    func test_isBeforeOrEqual() {
+        // Given
+        let sut1 = BPKYearMonth(year: 2022, month: 1)
+        let sut2 = BPKYearMonth(year: 2023, month: 1)
+        let sut3 = BPKYearMonth(year: 2023, month: 2)
+        let sut4 = BPKYearMonth(year: 2023, month: 1)
+        
+        // Then
+        XCTAssertTrue(sut1 <= sut2)
+        XCTAssertTrue(sut2 <= sut3)
+        XCTAssertTrue(sut2 <= sut4)
+    }
+    
+    func test_isAfter() {
+        // Given
+        let sut1 = BPKYearMonth(year: 2022, month: 1)
+        let sut2 = BPKYearMonth(year: 2023, month: 1)
+        let sut3 = BPKYearMonth(year: 2023, month: 2)
+        
+        // Then
+        XCTAssertTrue(sut2 > sut1)
+        XCTAssertTrue(sut3 > sut2)
+    }
+    
+    func test_isAfterOrEqual() {
+        // Given
+        let sut1 = BPKYearMonth(year: 2022, month: 1)
+        let sut2 = BPKYearMonth(year: 2023, month: 1)
+        let sut3 = BPKYearMonth(year: 2023, month: 2)
+        let sut4 = BPKYearMonth(year: 2023, month: 1)
+        
+        // Then
+        XCTAssertTrue(sut2 >= sut1)
+        XCTAssertTrue(sut3 >= sut2)
+        XCTAssertTrue(sut4 >= sut2)
+    }
+}

--- a/Example/Backpack/UIKit/Components/Calendar/CalendarViewController.swift
+++ b/Example/Backpack/UIKit/Components/Calendar/CalendarViewController.swift
@@ -191,7 +191,6 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
     }
     
     func calendar(_ calendar: BPKCalendar, didSelectWholeMonth dateList: [BPKSimpleDate]) {
-        print("Did select whole month")
-        print(dateList)
+        print("calendar:", calendar, "didSelectWholeMonth:", dateList)
     }
 }

--- a/Example/Backpack/UIKit/Components/Calendar/CalendarViewController.swift
+++ b/Example/Backpack/UIKit/Components/Calendar/CalendarViewController.swift
@@ -42,16 +42,14 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
 
     var singleSelectionConfiguration: BPKCalendarSelectionConfiguration {
         return BPKCalendarSelectionConfigurationSingle(
-            selectionHint: "Double tap to select date",
-            andWholeMonthTitle: wholeMonthTitle
+            selectionHint: "Double tap to select date"
         )
     }
     
     var multipleSelectionConfiguration: BPKCalendarSelectionConfiguration {
         return BPKCalendarSelectionConfigurationMultiple(
             selectionHint: "Double tap to select date",
-            deselectionHint: "Double tap to deselect date",
-            andWholeMonthTitle: wholeMonthTitle
+            deselectionHint: "Double tap to deselect date"
         )
     }
     
@@ -63,14 +61,20 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
             endSelectionState: "Selected as return date",
             betweenSelectionState: "Between departure and return date",
             startAndEndSelectionState: "Selected as both departure and return date",
-            returnDatePrompt: "Now please select a return date",
-            andWholeMonthTitle: wholeMonthTitle
+            returnDatePrompt: "Now please select a return date"
         )
     }
 
     override func viewDidLoad() {
         // I guess it shouldn't be possible to create a calendar without a selection config 🤔
         calendar.selectionConfiguration = singleSelectionConfiguration
+        
+        if let wholeMonthTitle {
+            calendar.wholeMonthSelectionConfiguration = BPKCalendarWholeMonthConfiguration(
+                title: wholeMonthTitle,
+                selectableMonthRange: BPKYearMonth(year: 2020, month: 1)...BPKYearMonth(year: 2020, month: 12)
+            )
+        }
 
         if showPrices {
             calendar = BPKCalendar(
@@ -184,5 +188,10 @@ class CalendarViewController: UIViewController, BPKCalendarDelegate {
         }
 
         return showPrices ? noPrice : BPKCalendarTrafficLightCellData.noData
+    }
+    
+    func calendar(_ calendar: BPKCalendar, didSelectWholeMonth dateList: [BPKSimpleDate]) {
+        print("Did select whole month")
+        print(dateList)
     }
 }


### PR DESCRIPTION
OGM-1926

We want to disable the last month button as it select the actual month instead. 
To fix this issue we decided to disable it for now.

![Simulator Screen Shot - iPhone 8 - 2023-11-07 at 10 00 59](https://github.com/Skyscanner/backpack-ios/assets/17477905/1fceaaf7-476b-422a-b551-6056a3c5612d)


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
