### PR TITLE
fix: LMN-806 use timezone for month formatter

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
@@ -52,6 +52,7 @@ public struct BPKCalendar: View {
         self.selectionType = selectionType
 
         monthHeaderDateFormatter = DateFormatter()
+        monthHeaderDateFormatter.timeZone = calendar.timeZone
         monthHeaderDateFormatter.dateFormat = "MMMM yyyy"
     }
     

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
@@ -38,6 +38,7 @@ struct CalendarExampleRangeView: View {
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.locale = calendar.locale
+        formatter.timeZone = calendar.timeZone
         self.formatter = formatter
         
         let selectionStart = calendar.date(from: .init(year: 2023, month: 11, day: 23))!

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleSingleView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleSingleView.swift
@@ -38,6 +38,7 @@ struct CalendarExampleSingleView: View {
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.locale = calendar.locale
+        formatter.timeZone = calendar.timeZone
         self.formatter = formatter
         
         _selectedDate = State(initialValue: calendar.date(from: .init(year: 2023, month: 11, day: 15))!)


### PR DESCRIPTION
### Summary - BPKCalendar FIx

This is a fix for Calendar Header Formatting that can be reproduced in a particular situation (possibly others as well)

* Set the (Swift)Calendar used to create the (Backpack)BPKCalendar to a UTC calendar (In Skyscanner there are situations where we present dates in a UTC timezone).
* Set the device _time_ to 1st day of the month before 11am
* Set the device _timezone_ to Honolulu (you will see your system lock change to the _last day of the month before_

The calendar opens and even though the 1st month being displayed is correct, E.g. in the example below, the 1st month being displayed is December, the _Header_ is incorrect Where it displays "November 2023" this should read "December 2023"

#### Minor Issue - Calendar example Date Format

* Used the same timezone for the date formatter in the example view so these dates are also displayed as expected across timezones

I have also included a fix for the 

### Issue, showing incorrect Month header

![Screenshot 2023-11-30 at 23 24 44](https://github.com/Skyscanner/backpack-ios/assets/391610/52eb36d5-499f-4a32-ac48-9d9d1f4253b2)

### Fix showing correct Month header

![Screenshot 2023-11-30 at 23 25 15](https://github.com/Skyscanner/backpack-ios/assets/391610/e95ea750-fb22-46af-85f6-f9e52f3edb12)

### Issue, showing incorrect Date Selection Format in CalendarExampleRangeView

![Screenshot 2023-12-05 at 01 55 53](https://github.com/Skyscanner/backpack-ios/assets/391610/25162c0c-71ed-4a83-9062-d3bfebb9f332)

### Fix showing correct Date Selection Format in CalendarExampleRangeView

![Screenshot 2023-12-05 at 01 55 26](https://github.com/Skyscanner/backpack-ios/assets/391610/2dcae6c2-5172-4437-9bd0-4041a718645d)


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
