### PR TITLE
Comment out "uitests" module in CI script

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -57,7 +57,7 @@ if [ $# -lt 2 ]; then
     check_modules "uikit" "test"
     check_modules "swiftui" "test"
     check_modules "common" "test"
-    check_modules "uitests" "test"
+    # check_modules "uitests" "test"
 else
     check_modules $1 $2
 fi


### PR DESCRIPTION
This pull request disables the `uitests` ran in PRs. This module is currently causing issues/flakiness and needs to be temporarily disabled. Once the issues/flakiness are resolved, the tests can be re enabled