### PR TITLE
SONIC-2126: BPKCarousel page indicator should update when delegate = nil

### DIFF
--- a/Backpack/Carousel/Classes/BPKCarousel.swift
+++ b/Backpack/Carousel/Classes/BPKCarousel.swift
@@ -26,11 +26,7 @@ public protocol BPKCarouselDelegate: AnyObject {
 public final class BPKCarousel: UIView {
     private let internalCarousel: BPKInternalCarousel
     
-    public weak var delegate: BPKCarouselDelegate? {
-        didSet {
-            internalCarousel.delegate = self
-        }
-    }
+    public weak var delegate: BPKCarouselDelegate?
     
     public var currentImage: Int { internalCarousel.currentImage }
     
@@ -44,6 +40,7 @@ public final class BPKCarousel: UIView {
         internalCarousel = BPKInternalCarousel(pageIndicator: pageIndicator)
         super.init(frame: .zero)
         
+        internalCarousel.delegate = self
         internalCarousel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(internalCarousel)
         NSLayoutConstraint.activate([

--- a/Backpack/Carousel/Classes/BPKCarousel.swift
+++ b/Backpack/Carousel/Classes/BPKCarousel.swift
@@ -26,7 +26,11 @@ public protocol BPKCarouselDelegate: AnyObject {
 public final class BPKCarousel: UIView {
     private let internalCarousel: BPKInternalCarousel
     
-    public weak var delegate: BPKCarouselDelegate?
+    public weak var delegate: BPKCarouselDelegate? {
+        didSet {
+            internalCarousel.delegate = self
+        }
+    }
     
     public var currentImage: Int { internalCarousel.currentImage }
     


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

# Changes
- Fix the issue which swiping BPKCarousel doesn't update the pageIndicator when its delegate is nil

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
