### PR TITLE
SONIC-1959: Change FloatingNotificationView to public 

### DIFF
--- a/Backpack/FloatingNotification/Classes/FloatingNotificationView.swift
+++ b/Backpack/FloatingNotification/Classes/FloatingNotificationView.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-final class FloatingNotificationView: UIView {
+public final class FloatingNotificationView: UIView {
     
     private let shouldAnimateDown: ((FloatingNotificationView) -> Void)
     private let hiddenBottomConstraintConstant: CGFloat


### PR DESCRIPTION
# Change FloatingNotificationView to public for updating the accessibilityElements array 

## The issue I am fixing
- I am showing a BPKFloatingNotifcation from a view where it has a fixed array of `view.accessibilityElements = [navigationHeaderView, tableView]`
- When I call `showNotification`, the button is not selectable by voice-over because the newly added FloatingNotificationView is not an accessibilityElement.
```swift
BPKFloatingNotification.show(
            .titleWithIconAndAction(
                parentView: view, // <- view has fixed accessibilityElements array
                title: title,
                iconName: .tickCircle,
                action: .action(title: actionTitle, action: action)
            ))
```
- So, I added the following function to add the following code to update the accessibilityElements array
  - ```swift
      public override func viewDidLayoutSubviews() {
        super.viewDidLayoutSubviews()

        // ⭐️ the line below requires public FloatingNotificationView
        let accessibilityElementsContainsFloatingNotification = view.accessibilityElements?.contains(where: { $0 is FloatingNotificationView })
        // Set the floating Notification view as accessible
        if view.subviews.count > view.accessibilityElements?.count ?? 0 &&
            accessibilityElementsContainsFloatingNotification == false,
           let floatingNotificationView = view.subviews.filter({ $0 is FloatingNotificationView }).first { // ⭐️ This also requires public FloatingNotificationView
            // Add floatingNotificationView when it is not in the accessibilityElements
            view.accessibilityElements?.append(floatingNotificationView)
        } else if view.subviews.count < view.accessibilityElements?.count ?? 0 &&
                    accessibilityElementsContainsFloatingNotification == true {
            // Remove floatingNotificationView when it is removed from the view hierarchy
            view.accessibilityElements?.removeAll { $0 is FloatingNotificationView } // ⭐️ This also requires public FloatingNotificationView
        }
    }
     ```
- As a result, I would like to change FloatingNotificationView's access level to `public`

----
## Other Consideration 
An alternative solution is to move the accessibilityElements update logic in backpack-ios. 

For example:
 - update parentView's  accessibilityElements after `addSubView()` 
   - `viewModel.parentView.accessibilityElements?.append(self)`
 - update parentView's  accessibilityElements before `removeFromSuperView()`
   - `superview.accessibilityElements?.removeAll { $0 == self }`

Let me know if you prefer the current solution "setting a view class to public" OR adding the `accessibilityElements` append & remove logic in Backpack-ios.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `README.md`
+ [x] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
