### PR TITLE
LMN-774 Exposed BPKTextField.State to be used in BPKAppSearchModal

### DIFF
--- a/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
@@ -25,6 +25,7 @@ public struct BPKAppSearchModal: View {
     let results: BPKAppSearchModalResults
     let closeAccessibilityLabel: String
     let onClose: () -> Void
+    private var textFieldState: BPKTextField.State = .default
     
     public init(
         title: String,
@@ -49,6 +50,7 @@ public struct BPKAppSearchModal: View {
             
             if results.showTextField {
                 BPKTextField(placeholder: inputHint, $inputText)
+                    .inputState(textFieldState)
             }
         
             switch results {
@@ -88,6 +90,12 @@ public struct BPKAppSearchModal: View {
                 .accessibilityAddTraits(.isHeader)
         }
         .padding(.vertical, .md)
+    }
+    
+    public func inputState(_ state: BPKTextField.State) -> BPKAppSearchModal {
+        var result = self
+        result.textFieldState = state
+        return result
     }
 }
 

--- a/Example/Backpack/SwiftUI/Components/AppSearchModal/AppSearchModalExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/AppSearchModal/AppSearchModalExampleView.swift
@@ -38,6 +38,9 @@ struct AppSearchModalExampleView: View {
                     print("Tapped close button")
                 }
             )
+            .inputState(.clear(accessibilityLabel: "clear text", action: {
+                inputText = ""
+            }))
             .onChange(of: inputText, perform: { _ in
                 self.viewModel.loadContentFrom(inputText)
             })


### PR DESCRIPTION
Enables setting the state of the BPKTextField that is part of the BPKAppSearchModal

<img width="316" alt="Screenshot 2024-02-07 at 19 11 31" src="https://github.com/Skyscanner/backpack-ios/assets/391610/73c097e1-527e-41dd-a4b5-27d1592ac569">


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
