### PR TITLE
[DON-385] Set line limit in `SearchAppModalContentView` cell's subtitle

### DIFF
--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -63,7 +63,13 @@ struct AppSearchModalContentView: View {
     }
     
     struct ItemCell: View {
+
         let item: BPKAppSearchModalContent.Item
+        
+        private func subtitleLineLimit() -> Int? {
+            let isDefaultSizeOrSmaller = sizeCategory <= .large
+            return isDefaultSizeOrSmaller ? 2 : nil
+        }
         
         var body: some View {
             HStack(spacing: .base) {
@@ -74,7 +80,7 @@ struct AppSearchModalContentView: View {
                         .multilineTextAlignment(.leading)
                     if let subtitle = item.subtitle {
                         BPKText(subtitle, style: .footnote)
-                            .lineLimit(nil)
+                            .lineLimit(subtitleLineLimit())
                             .multilineTextAlignment(.leading)
                     }
                 }

--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -63,6 +63,7 @@ struct AppSearchModalContentView: View {
     }
     
     struct ItemCell: View {
+        @Environment(\.sizeCategory) var sizeCategory
 
         let item: BPKAppSearchModalContent.Item
         

--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -67,11 +67,6 @@ struct AppSearchModalContentView: View {
 
         let item: BPKAppSearchModalContent.Item
         
-        private func subtitleLineLimit() -> Int? {
-            let isDefaultSizeOrSmaller = sizeCategory <= .large
-            return isDefaultSizeOrSmaller ? 2 : nil
-        }
-        
         var body: some View {
             HStack(spacing: .base) {
                 BPKIconView(item.icon, size: .large)
@@ -95,6 +90,11 @@ struct AppSearchModalContentView: View {
             .contentShape(Rectangle())
             .onTapGesture(perform: item.onItemSelected)
             .accessibilityElement(children: .combine)
+        }
+        
+        private func subtitleLineLimit() -> Int? {
+            let isDefaultSizeOrSmaller = sizeCategory <= .large
+            return isDefaultSizeOrSmaller ? 2 : nil
         }
     }
 }


### PR DESCRIPTION
# AppSearchModalContentView
This PR sets a line limit for the subtitle cell in `SearchAppModalContentView` when the dynamic size does not exceed Apple's default size, `Large`.

|    Small      |     Large (Default)    |     Extra Large    |     Accessibility Medium    | 
|---------------------|------------------|------------------|------------------|
| 2 lines  | 2 lines | unlimited lines | unlimited lines  |
|      <img src="https://github.com/Skyscanner/backpack-ios/assets/159815080/fcdfb96b-cc55-4b35-88ab-e5c65294e764" alt="screen-shot" width=“100”/>      |     <img src="https://github.com/Skyscanner/backpack-ios/assets/159815080/c4cc3b7b-1e16-463f-ab0e-93c7570342ca" alt="screen-shot" width=“100”/>    |     <img src="https://github.com/Skyscanner/backpack-ios/assets/159815080/e85dc69c-d476-445e-be6f-334defa94ae7" alt="screen-shot"   width=“100” />    |     <img src="https://github.com/Skyscanner/backpack-ios/assets/159815080/2613f9f9-9bdc-4ac5-8f75-58fdab783c4d" alt="screen-shot" width=“100”/>     | 

## Additional Information
The users in iOS platform can change the default font-size size as described [here](https://support.apple.com/en-gb/102453).

|      Font Size Options      |     Font  Size Options (Larger Accessibility)    |
|---------------------|------------------|
|        <img src="https://github.com/Skyscanner/backpack-ios/assets/159815080/5c4414b8-f815-4602-b143-bc4bf71c76d8" alt="screen-shot" width="250"/>          |     <img src="https://github.com/Skyscanner/backpack-ios/assets/159815080/fc9738d9-1827-41ef-9cab-6d898b2d33e5" alt="screen-shot" width="250"/>          |


The [large](https://developer.apple.com/documentation/uikit/uicontentsizecategory/1622934-large) is the **default option** as stated on the [Apple documentation](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically/#).
> Call scaledFont(for:), passing in a reference to the custom font that's at a point size suitable for use with large. This is the default value for the Dynamic Type setting.
