### PR TITLE
Update swiftUI button documentation

### DIFF
--- a/Backpack-SwiftUI/Button/README.md
+++ b/Backpack-SwiftUI/Button/README.md
@@ -60,7 +60,7 @@ BPKButton("Button title") {
 
 ### Styled .secondary Button.
 
-```swift 
+```swift
 BPKButton("Button title") {
     print("Button tap closure")
 }


### PR DESCRIPTION
# Button docs
The readme for swiftuI buttons had an extra space after the code block first line (` ```swift[SPACE]`).
Removing this should fix parsing on Supernova

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
