### PR TITLE
[TEMPURA-1242] Remove references to UIApplication.shared

### DIFF
--- a/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheet.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheet.swift
@@ -41,6 +41,7 @@ public extension View {
         closeButtonAccessibilityLabel: String? = nil,
         title: String? = nil,
         action: BPKBottomSheetAction? = nil,
+        rootViewController: UIViewController?,
         @ViewBuilder bottomSheetContent: @escaping () -> BottomSheetContent
     ) -> some View {
         if #available(iOS 16.0, *) {
@@ -64,7 +65,8 @@ public extension View {
                     closeButtonAccessibilityLabel: closeButtonAccessibilityLabel,
                     title: title,
                     action: action,
-                    bottomSheetContent: bottomSheetContent
+                    bottomSheetContent: bottomSheetContent,
+                    rootViewController: rootViewController
                 )
             )
         }
@@ -80,8 +82,9 @@ struct BPKBottomSheet_Previews: PreviewProvider {
                     contentMode: .fitContent, closeButtonAccessibilityLabel: "asd", title: "Hello",
                     action: BPKBottomSheetAction(
                         title: "Action",
-                        action: {})) {
-                            BPKText("Bottom sheet content")
+                        action: {}),
+                    rootViewController: nil) {
+                    BPKText("Bottom sheet content")
                 }
         }
     }

--- a/Backpack-SwiftUI/BottomSheet/Classes/Legacy/LegacyBottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/Legacy/LegacyBottomSheetContainerViewModifier.swift
@@ -29,6 +29,7 @@ struct LegacyBottomSheetContainerViewModifier<BottomSheetContent: View>: ViewMod
     let title: String?
     let action: BPKBottomSheetAction?
     let bottomSheetContent: () -> BottomSheetContent
+    let rootViewController: UIViewController?
     
     init(
         isPresented: Binding<Bool>,
@@ -37,7 +38,8 @@ struct LegacyBottomSheetContainerViewModifier<BottomSheetContent: View>: ViewMod
         closeButtonAccessibilityLabel: String? = nil,
         title: String? = nil,
         action: BPKBottomSheetAction? = nil,
-        @ViewBuilder bottomSheetContent: @escaping () -> BottomSheetContent
+        @ViewBuilder bottomSheetContent: @escaping () -> BottomSheetContent,
+        rootViewController: UIViewController?
     ) {
         self._isPresented = isPresented
         self.contentMode = contentMode
@@ -46,6 +48,7 @@ struct LegacyBottomSheetContainerViewModifier<BottomSheetContent: View>: ViewMod
         self.title = title
         self.action = action
         self.bottomSheetContent = bottomSheetContent
+        self.rootViewController = rootViewController
     }
     
     func body(content: Content) -> some View {
@@ -136,19 +139,10 @@ struct LegacyBottomSheetContainerViewModifier<BottomSheetContent: View>: ViewMod
         rootViewController?.present(controller, animated: true)
         self.controller = controller
     }
-    
-    private var rootViewController: UIViewController? {
-        UIApplication.shared
-            .windows
-            .filter { $0.isKeyWindow }
-            .first?
-            .rootViewController
-    }
 }
 
 struct LegacyBottomSheetContainerViewModifier_Previews: PreviewProvider {
     static var previews: some View {
-        
         BPKButton("Show bottom sheet", action: {})
             .modifier(
                 LegacyBottomSheetContainerViewModifier(
@@ -168,7 +162,8 @@ struct LegacyBottomSheetContainerViewModifier_Previews: PreviewProvider {
                             BPKButton("Make Payment") {}
                                 .padding()
                         }
-                    })
+                    },
+                    rootViewController: nil)
             )
         
     }

--- a/Backpack-SwiftUI/Dialog/Classes/BPKDialog.swift
+++ b/Backpack-SwiftUI/Dialog/Classes/BPKDialog.swift
@@ -27,6 +27,7 @@ public extension View {
         text: String,
         confirmButton: BPKDialogButton,
         secondaryActions: BPKDialogSecondaryActions? = nil,
+        rootViewController: UIViewController? = nil,
         onTouchOutside: (() -> Void)? = nil
     ) -> some View {
         var buttons = [BPKDialogButton(button: confirmButton, style: .featured)]
@@ -36,14 +37,18 @@ public extension View {
                 buttons.append(BPKDialogButton(button: linkButton, style: .link))
             }
         }
-        return self.modifier(UIKitDialogContainerViewModifier(isPresented: presented, dialogContent: {
-            DialogWithIconContent(
-                icon: icon,
-                iconColor: .coreAccentColor,
-                textContent: DialogTextContent(title: title, text: text, contentAlignment: .center),
-                actions: DialogActionsView(buttons: buttons)
-            )
-        }, onTouchOutside: onTouchOutside))
+        return self.modifier(UIKitDialogContainerViewModifier(
+            isPresented: presented,
+            dialogContent: {
+                DialogWithIconContent(
+                    icon: icon,
+                    iconColor: .coreAccentColor,
+                    textContent: DialogTextContent(title: title, text: text, contentAlignment: .center),
+                    actions: DialogActionsView(buttons: buttons)
+                )
+            },
+            onTouchOutside: onTouchOutside,
+            rootViewController: rootViewController))
     }
     
     /// Displays a warning dialog with a title, text and a list of buttons.
@@ -54,6 +59,7 @@ public extension View {
         text: String,
         confirmButton: BPKDialogButton,
         secondaryActions: BPKDialogSecondaryActions? = nil,
+        rootViewController: UIViewController? = nil,
         onTouchOutside: (() -> Void)? = nil
     ) -> some View {
         var buttons = [BPKDialogButton(button: confirmButton, style: .featured)]
@@ -70,7 +76,7 @@ public extension View {
                 textContent: DialogTextContent(title: title, text: text, contentAlignment: .center),
                 actions: DialogActionsView(buttons: buttons)
             )
-        }, onTouchOutside: onTouchOutside))
+        }, onTouchOutside: onTouchOutside, rootViewController: rootViewController))
     }
     
     /// Displays a destructive dialog with a title, text and a list of buttons.
@@ -81,6 +87,7 @@ public extension View {
         text: String,
         confirmButton: BPKDialogButton,
         linkButton: BPKDialogButton? = nil,
+        rootViewController: UIViewController? = nil,
         onTouchOutside: (() -> Void)? = nil
     ) -> some View {
         var buttons = [BPKDialogButton(button: confirmButton, style: .destructive)]
@@ -94,7 +101,7 @@ public extension View {
                 textContent: DialogTextContent(title: title, text: text, contentAlignment: .center),
                 actions: DialogActionsView(buttons: buttons)
             )
-        }, onTouchOutside: onTouchOutside))
+        }, onTouchOutside: onTouchOutside, rootViewController: rootViewController))
     }
     
     /// Displays a dialog with an image, title, text and a list of buttons.
@@ -105,6 +112,7 @@ public extension View {
         text: String,
         confirmButton: BPKDialogButton,
         secondaryActions: BPKDialogSecondaryActions? = nil,
+        rootViewController: UIViewController? = nil,
         onTouchOutside: (() -> Void)? = nil
     ) -> some View {
         var buttons = [BPKDialogButton(button: confirmButton, style: .featured)]
@@ -120,7 +128,7 @@ public extension View {
                     .spacing(.md),
                 actions: DialogActionsView(buttons: buttons)
             ) { DialogImageView(image: image) }
-        }, onTouchOutside: onTouchOutside))
+        }, onTouchOutside: onTouchOutside, rootViewController: rootViewController))
     }
     
     /// Displays a dialog with an image with a flare, title, text and a list of buttons.
@@ -131,6 +139,7 @@ public extension View {
         text: String,
         confirmButton: BPKDialogButton,
         secondaryActions: BPKDialogSecondaryActions? = nil,
+        rootViewController: UIViewController? = nil,
         onTouchOutside: (() -> Void)? = nil
     ) -> some View {
         var buttons = [BPKDialogButton(button: confirmButton, style: .featured)]
@@ -149,7 +158,7 @@ public extension View {
                     DialogImageView(image: image)
                 }
             }
-        }, onTouchOutside: onTouchOutside))
+        }, onTouchOutside: onTouchOutside, rootViewController: rootViewController))
     }
 }
 
@@ -161,7 +170,8 @@ struct BPKDialog_Previews: PreviewProvider {
                 icon: .tick,
                 title: "Title in here",
                 text: "Description that goes two lines ideally, but sometimes it can go longer",
-                confirmButton: .init("Delete", action: {})
+                confirmButton: .init("Delete", action: {}),
+                rootViewController: nil
             )
     }
 }

--- a/Backpack-SwiftUI/Dialog/Classes/UIKitDialogContainerViewModifier.swift
+++ b/Backpack-SwiftUI/Dialog/Classes/UIKitDialogContainerViewModifier.swift
@@ -30,7 +30,7 @@ struct UIKitDialogContainerViewModifier<DialogContent: View>: ViewModifier {
     @Binding var isPresented: Bool
     @ViewBuilder let dialogContent: DialogContent
     let onTouchOutside: (() -> Void)?
-    
+    let rootViewController: UIViewController?
     @State private var controller: UIViewController?
     
     func body(content: Content) -> some View {
@@ -65,14 +65,6 @@ struct UIKitDialogContainerViewModifier<DialogContent: View>: ViewModifier {
         rootViewController?.present(controller, animated: true)
         self.controller = controller
     }
-    
-    private var rootViewController: UIViewController? {
-        UIApplication.shared
-            .windows
-            .filter { $0.isKeyWindow }
-            .first?
-            .rootViewController
-    }
 }
 
 struct UIKitDialogContainerViewModifier_Previews: PreviewProvider {
@@ -84,7 +76,8 @@ struct UIKitDialogContainerViewModifier_Previews: PreviewProvider {
                     BPKText("This is the content of a dialog!")
                         .background(.surfaceDefaultColor)
                 },
-                onTouchOutside: {}
+                onTouchOutside: {},
+                rootViewController: nil
             ))
     }
 }

--- a/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
@@ -58,6 +58,7 @@ struct BottomSheetExampleView: View {
                 title: "Action",
                 action: { closableBottomSheetShown.toggle() }
             ),
+            rootViewController: rootViewController,
             bottomSheetContent: { content }
         )
         .bpkBottomSheet(
@@ -68,6 +69,7 @@ struct BottomSheetExampleView: View {
                 title: "Action",
                 action: { largeBottomSheetShown.toggle() }
             ),
+            rootViewController: rootViewController,
             bottomSheetContent: { content }
         )
         .bpkBottomSheet(
@@ -78,6 +80,7 @@ struct BottomSheetExampleView: View {
                 title: "Action",
                 action: { mediumBottomSheetShown.toggle() }
             ),
+            rootViewController: rootViewController,
             bottomSheetContent: { content }
         )
         .bpkBottomSheet(
@@ -88,6 +91,7 @@ struct BottomSheetExampleView: View {
                 title: "Action",
                 action: { fitContentBottomSheetShown.toggle() }
             ),
+            rootViewController: rootViewController,
             bottomSheetContent: {
                 VStack {
                     BPKText("Bottom sheet content")
@@ -98,6 +102,14 @@ struct BottomSheetExampleView: View {
                 .padding()
             }
         )
+    }
+    
+    private var rootViewController: UIViewController? {
+        UIApplication.shared
+            .windows
+            .filter { $0.isKeyWindow }
+            .first?
+            .rootViewController
     }
 }
 

--- a/Example/Backpack/SwiftUI/Components/Dialog/DialogExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/Dialog/DialogExampleView.swift
@@ -152,6 +152,7 @@ struct DialogExampleView: View {
                 secondaryButton: secondaryButton,
                 linkButton: linkButton
             ),
+            rootViewController: self.rootViewController,
             onTouchOutside: dismissDialogs
         )
         .bpkWarningDialog(
@@ -164,6 +165,7 @@ struct DialogExampleView: View {
                 secondaryButton: secondaryButton,
                 linkButton: linkButton
             ),
+            rootViewController: self.rootViewController,
             onTouchOutside: dismissDialogs
         )
         .bpkDestructiveDialog(
@@ -173,6 +175,7 @@ struct DialogExampleView: View {
             text: "Description that goes two lines ideally, but sometimes it can go longer",
             confirmButton: BPKDialogButton("Delete", action: dismissDialogs),
             linkButton: BPKDialogButton("Cancel", action: dismissDialogs),
+            rootViewController: self.rootViewController,
             onTouchOutside: dismissDialogs
         )
         .bpkImageDialog(
@@ -185,6 +188,7 @@ struct DialogExampleView: View {
                 secondaryButton: secondaryButton,
                 linkButton: linkButton
             ),
+            rootViewController: self.rootViewController,
             onTouchOutside: dismissDialogs
         )
         .bpkFlareDialog(
@@ -197,6 +201,7 @@ struct DialogExampleView: View {
                 secondaryButton: secondaryButton,
                 linkButton: linkButton
             ),
+            rootViewController: self.rootViewController,
             onTouchOutside: dismissDialogs
         )
     }
@@ -220,6 +225,14 @@ struct DialogExampleView: View {
                 presentingFlareDialogView.toggle()
             }
         }
+    }
+    
+    private var rootViewController: UIViewController? {
+        UIApplication.shared
+            .windows
+            .filter { $0.isKeyWindow }
+            .first?
+            .rootViewController
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

# UIApplication References
As we want to use Backpack on application extensions, it is required that references to the `shared` property of `UIApplication` are removed, otherwise Backpack fails to compile.

Changes introduced: 
- `UIKitDialogContainerViewModifier` now has an optional `rootViewController` argument
- `LegacyBottomSheetContainerViewModifier` now has an optional `rootViewController` argument
- Both example views pass the same `rootViewController` previously declared inside each of those modifiers.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
