### PR TITLE
LMN-1303 Remove focus when scrolling in BPKAppSearchModal and disable autocorrection

### DIFF
--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -20,8 +20,14 @@ import SwiftUI
 
 struct AppSearchModalContentView: View {
     let state: BPKAppSearchModalContent
+    let onScroll: (_ offset: CGPoint) -> Void
     var body: some View {
-        ScrollView(showsIndicators: false) {
+        
+        ScrollViewWithOffset { point in
+            if point != .zero {
+                onScroll(point)
+            }
+        } content: {
             VStack(spacing: .base) {
                 if let shortcuts = state.shortcuts, !shortcuts.isEmpty {
                     makeShortcuts(shortcuts)
@@ -104,7 +110,7 @@ struct AppSearchModalContentView_Previews: PreviewProvider {
         AppSearchModalContentView(state: .init(
             sections: (0..<3).map(buildSection),
             shortcuts: (0..<4).map(buildShortcut)
-        ))
+        ), onScroll: { _ in })
     }
     
     static func buildSection(with index: Int) -> BPKAppSearchModalContent.Section {

--- a/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
@@ -26,6 +26,7 @@ public struct BPKAppSearchModal: View {
     let closeAccessibilityLabel: String
     let onClose: () -> Void
     private var textFieldState: TextFieldState = .default
+    @FocusState private var inputFieldIsFocussed: Bool
     
     public init(
         title: String,
@@ -51,13 +52,17 @@ public struct BPKAppSearchModal: View {
             if results.showTextField {
                 BPKTextField(placeholder: inputHint, $inputText)
                     .inputState(textFieldState.inputState)
+                    .focused($inputFieldIsFocussed)
+                    .autocorrectionDisabled(true)
             }
         
             switch results {
             case .loading(let loading):
                 AppSearchModalLoadingView(state: loading)
             case .content(let content):
-                AppSearchModalContentView(state: content)
+                AppSearchModalContentView(
+                    state: content,
+                    onScroll: onScroll(_:))
                     .padding(.top, .md)
             case .error(let error):
                 AppSearchModalErrorView(state: error)
@@ -96,6 +101,10 @@ public struct BPKAppSearchModal: View {
         var result = self
         result.textFieldState = state
         return result
+    }
+    
+    private func onScroll(_ offset: CGPoint) {
+        inputFieldIsFocussed = false
     }
 }
 

--- a/Backpack-SwiftUI/NavigationBar/Classes/NavBarScrollViewWithOffset.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/NavBarScrollViewWithOffset.swift
@@ -24,34 +24,15 @@ struct NavBarScrollViewWithOffset<Content: View>: View {
     @ViewBuilder let content: () -> Content
     
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            ZStack(alignment: .top) {
-                GeometryReader { geo in
-                    Color.clear
-                        .preference(
-                            key: ScrollOffsetPreferenceKey.self,
-                            value: geo.frame(in: .named("scrollView")).origin
-                        )
-                }
-                .frame(height: 0)
-                content()
-                    .offset(y: style.verticalOffset)
-            }
+        
+        ScrollViewWithOffset(onScroll: onScroll) {
+            content()
+                .offset(y: style.verticalOffset)
         }
-        .coordinateSpace(name: "scrollView")
-        .onPreferenceChange(
-            ScrollOffsetPreferenceKey.self,
-            perform: onScroll
-        )
         .if(style != .transparent, transform: { view in
             view.safeAreaInset(edge: .bottom) {
                 Color.clear.frame(height: style.verticalOffset - style.largeTitlePadding)
             }
         })
     }
-}
-
-private struct ScrollOffsetPreferenceKey: PreferenceKey {
-    static var defaultValue: CGPoint = .zero
-    static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {}
 }

--- a/Backpack-SwiftUI/Utils/Classes/ScrollViewWithOffset.swift
+++ b/Backpack-SwiftUI/Utils/Classes/ScrollViewWithOffset.swift
@@ -1,0 +1,50 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+
+struct ScrollViewWithOffset<Content: View>: View {
+    let onScroll: (_ offset: CGPoint) -> Void
+    @ViewBuilder let content: () -> Content
+    
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            ZStack(alignment: .top) {
+                GeometryReader { geo in
+                    Color.clear
+                        .preference(
+                            key: ScrollOffsetPreferenceKey.self,
+                            value: geo.frame(in: .named("scrollView")).origin
+                        )
+                }
+                .frame(height: 0)
+                content()
+            }
+        }
+        .coordinateSpace(name: "scrollView")
+        .onPreferenceChange(
+            ScrollOffsetPreferenceKey.self,
+            perform: onScroll
+        )
+    }
+}
+
+private struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGPoint = .zero
+    static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {}
+}


### PR DESCRIPTION
### Changes
* Scrolling results when using place selector now dismisses keyboard
* Switched Auto-Suggest OFF for place selector text field

| Title  | Video |
| ------------- | ------------- |
| **Before** Issue =  Scroll Not Dismiss On Results Scroll   | ![_01PlaceSelector_Before_scrollNotDismiss](https://github.com/Skyscanner/backpack-ios/assets/391610/13a0636a-9e18-45fd-ac63-8c0efa90107e) |
| **Before** Issue =  Autocorrect Enabled When entering  | ![_01PlaceSelector_Before_AutoCorrect](https://github.com/Skyscanner/backpack-ios/assets/391610/c07feb0b-8ab8-49e9-8708-9ab920535b4a) |
| **After** Scroll Dismisses No Auto Correct  | ![_01PlaceSelector_After](https://github.com/Skyscanner/backpack-ios/assets/391610/05647a06-8a73-4f4a-bd3a-82bcd66e7d55) |

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
