### PR TITLE
ACC-453 / ACC-454 AppSearchModal accessibility fix

### DIFF
--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -96,6 +96,7 @@ struct AppSearchModalContentView: View {
             .contentShape(Rectangle())
             .onTapGesture(perform: item.onItemSelected)
             .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isButton)
         }
         
         private func subtitleLineLimit() -> Int? {

--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -74,29 +74,29 @@ struct AppSearchModalContentView: View {
         let item: BPKAppSearchModalContent.Item
         
         var body: some View {
-            HStack(spacing: .base) {
-                BPKIconView(item.icon, size: .large)
-                VStack(alignment: .leading) {
-                    BPKText(item.title, style: .bodyDefault)
-                        .lineLimit(nil)
-                        .multilineTextAlignment(.leading)
-                    if let subtitle = item.subtitle {
-                        BPKText(subtitle, style: .footnote)
-                            .lineLimit(subtitleLineLimit())
+            Button(action: item.onItemSelected) {
+                HStack(spacing: .base) {
+                    BPKIconView(item.icon, size: .large)
+                    VStack(alignment: .leading) {
+                        BPKText(item.title, style: .bodyDefault)
+                            .lineLimit(nil)
                             .multilineTextAlignment(.leading)
+                        if let subtitle = item.subtitle {
+                            BPKText(subtitle, style: .footnote)
+                                .lineLimit(subtitleLineLimit())
+                                .multilineTextAlignment(.leading)
+                        }
                     }
-                }
-                .padding(.vertical, .base)
-                Spacer()
-                if let tertiary = item.tertiaryLabel {
-                    BPKText(tertiary, style: .footnote)
-                        .foregroundColor(.textSecondaryColor)
+                    .padding(.vertical, .base)
+                    Spacer()
+                    if let tertiary = item.tertiaryLabel {
+                        BPKText(tertiary, style: .footnote)
+                            .foregroundColor(.textSecondaryColor)
+                    }
                 }
             }
             .contentShape(Rectangle())
-            .onTapGesture(perform: item.onItemSelected)
-            .accessibilityElement(children: .combine)
-            .accessibilityAddTraits(.isButton)
+            .buttonStyle(.plain)
         }
         
         private func subtitleLineLimit() -> Int? {

--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -96,12 +96,21 @@ struct AppSearchModalContentView: View {
                 }
             }
             .contentShape(Rectangle())
-            .buttonStyle(.plain)
+            .buttonStyle(ItemCellButtonStyle())
         }
         
         private func subtitleLineLimit() -> Int? {
             let isDefaultSizeOrSmaller = sizeCategory <= .large
             return isDefaultSizeOrSmaller ? 2 : nil
+        }
+    }
+    
+    // Basic button style to remove any styling for on press etc.
+    // In the future we might want to consider using .plain
+    // Or any other tap indication
+    struct ItemCellButtonStyle: ButtonStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
         }
     }
 }

--- a/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
@@ -52,6 +52,7 @@ public struct BPKAppSearchModal: View {
             if results.showTextField {
                 BPKTextField(placeholder: inputHint, $inputText)
                     .inputState(textFieldState.inputState)
+                    .accessibilityAddTraits(.isSearchField)
                     .focused($inputFieldIsFocussed)
                     .autocorrectionDisabled(true)
             }


### PR DESCRIPTION
# AppSearchModal

- Add `isButton` to each item on the search modal. This indicates the item is tappable
- Add `isSearchField` to the search input, this adds more semantic meaning and sets expectations of the input fields role. 

| Before | After | 
| --- | --- |
| https://github.com/Skyscanner/backpack-ios/assets/728889/3a23a9f4-4147-49bb-92d8-2f8d93d570aa | https://github.com/Skyscanner/backpack-ios/assets/728889/f677afa4-c8f7-4b74-a4b2-3cdc4f5dc60b |


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
