### PR TITLE
fix: Move content shape to HSTack to allow custom button to be tappable

### DIFF
--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -94,8 +94,8 @@ struct AppSearchModalContentView: View {
                             .foregroundColor(.textSecondaryColor)
                     }
                 }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
             .buttonStyle(ItemCellButtonStyle())
         }
         


### PR DESCRIPTION
# App search modal

- Change the contentShape modifier to apply to the button content, this way the entire button is tappable and not just the text content

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
