### PR TITLE
DON-335: Add accessibility identifiers to PlaceSelector elements

### DIFF
--- a/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
@@ -85,13 +85,11 @@ public struct BPKAppSearchModal: View {
         ZStack {
             HStack {
                 BPKCloseButton(accessibilityLabel: closeAccessibilityLabel, action: onClose)
-                    .accessibilityLabel(closeAccessibilityLabel.lowercased())
                 Spacer()
             }
             BPKText(title, style: .heading5)
                 .padding(.vertical, .sm)
                 .accessibilityAddTraits(.isHeader)
-                .accessibilityLabel(title)
         }
         .padding(.vertical, .md)
     }

--- a/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
@@ -85,9 +85,6 @@ public struct BPKAppSearchModal: View {
         ZStack {
             HStack {
                 BPKCloseButton(accessibilityLabel: closeAccessibilityLabel, action: onClose)
-                    .accessibilityHidden(false)
-//                    .accessibilityRemoveTraits(.isImage)
-//                    .accessibilityAddTraits(.isButton)
                     .accessibilityLabel(closeAccessibilityLabel.lowercased())
                 Spacer()
             }

--- a/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/BPKAppSearchModal.swift
@@ -85,11 +85,16 @@ public struct BPKAppSearchModal: View {
         ZStack {
             HStack {
                 BPKCloseButton(accessibilityLabel: closeAccessibilityLabel, action: onClose)
+                    .accessibilityHidden(false)
+//                    .accessibilityRemoveTraits(.isImage)
+//                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel(closeAccessibilityLabel.lowercased())
                 Spacer()
             }
             BPKText(title, style: .heading5)
                 .padding(.vertical, .sm)
                 .accessibilityAddTraits(.isHeader)
+                .accessibilityLabel(title)
         }
         .padding(.vertical, .md)
     }

--- a/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
+++ b/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
@@ -63,8 +63,8 @@ public struct BPKSearchInputSummary: View {
                 .foregroundColor(state.textColor)
                 .disabled(state.isDisabled)
                 .focused($focused)
-                .accessibilityElement(children: .combine)
                 .accessibilityAddTraits(.isSearchField)
+                .accessibilityLabel(placeholder)
             accessory
         }
         .frame(maxWidth: .infinity, minHeight: 48.0)
@@ -82,10 +82,10 @@ public struct BPKSearchInputSummary: View {
                     BPKIconView(icon.icon)
                         .foregroundColor(icon.color)
                 }
-                .opacity(text.isEmpty ? 0.0 : 1.0)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(accessibilityLabel)
                 .accessibilityAddTraits(.isButton)
+                .opacity(text.isEmpty ? 0.0 : 1.0)
             } else {
                 BPKIconView(icon.icon)
                     .foregroundColor(icon.color)


### PR DESCRIPTION
The goal is to add accessibility identifiers for AppSearchModal elements which are used in PlaceSelector. It's needed for writing UI tests.

There is an issue with enabling the accessibility trait and keeping the search field hittable for UITests. There is a ticket to investigate that issue: https://skyscanner.atlassian.net/browse/DON-500


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
