### PR TITLE
Re-enable light/dark mode switching on the example app

### DIFF
--- a/Example/Backpack Screenshot/Screenshots.swift
+++ b/Example/Backpack Screenshot/Screenshots.swift
@@ -43,6 +43,7 @@ class Screenshots: BackpackSnapshotTestCase {
     @MainActor
     func testLightModeScreenshots() async {
        app = createApp()
+        app.launchArguments.append("FORCE_LIGHT_MODE")
        setupSnapshot(app)
        app.launch()
        await captureAllScreenshots()

--- a/Example/Backpack Screenshot/SwiftUIScreenshots.swift
+++ b/Example/Backpack Screenshot/SwiftUIScreenshots.swift
@@ -42,6 +42,7 @@ class SwiftUIScreenshots: BackpackSnapshotTestCase {
     @MainActor
     func testLightModeScreenshots() async {
         app = createApp()
+        app.launchArguments.append("FORCE_LIGHT_MODE")
         setupSnapshot(app)
         app.launch()
         await captureAllScreenshots()

--- a/Example/Backpack/SceneDelegate.swift
+++ b/Example/Backpack/SceneDelegate.swift
@@ -35,6 +35,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if ThemeHelpers.forceDarkMode() {
             window.overrideUserInterfaceStyle = .dark
         }
+        
+        if ThemeHelpers.forceLightMode() {
+            window.overrideUserInterfaceStyle = .light
+        }
+        
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/Example/Backpack/SceneDelegate.swift
+++ b/Example/Backpack/SceneDelegate.swift
@@ -34,8 +34,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = rootViewController(isUITestRun: isUITestRun)
         if ThemeHelpers.forceDarkMode() {
             window.overrideUserInterfaceStyle = .dark
-        } else {
-            window.overrideUserInterfaceStyle = .light
         }
         self.window = window
         window.makeKeyAndVisible()

--- a/Example/Backpack/Utils/ThemeHelpers.swift
+++ b/Example/Backpack/Utils/ThemeHelpers.swift
@@ -47,6 +47,10 @@ class ThemeHelpers: NSObject {
     class func forceDarkMode() -> Bool {
         return ProcessInfo.processInfo.arguments.contains("FORCE_DARK_MODE")
     }
+    
+    class func forceLightMode() -> Bool {
+        return ProcessInfo.processInfo.arguments.contains("FORCE_LIGHT_MODE")
+    }
 
     class func themeDefinition(forTheme: ThemeName) -> BPKThemeDefinition {
         switch forTheme {


### PR DESCRIPTION
# Force dark/light mode

We published a change 3 weeks ago to force light mode if force_dark_mode was not set, this however forces the example app to always run in light mode and not allow us to test simulator/phone with dark mode. 

I have added a FORCE_LIGHT_MODE equivalent to ensure light mode can be set on UI-tests as well

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
