### PR TITLE
Refactor BPKImageGalleryImageGridStyle to use structs for chip and image categories

### DIFF
--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
@@ -47,55 +47,63 @@ struct ImageGalleryGrid<Categories: View, ImageView: View>: ViewModifier {
 public extension View {
     // swiftlint:disable function_parameter_count
     @ViewBuilder
-    func bpkImageGalleryGrid<Content>(
+    func bpkImageGalleryGrid<CategoryView, Content>(
         isPresented: Binding<Bool>,
         selectedCategory: Binding<Int>,
-        style: BPKImageGalleryImageGridStyle<Content>,
+        categories: [BPKImageGalleryImageCategory<CategoryView, Content>],
         closeAccessibilityLabel: String,
         onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
         onCloseTapped: @escaping () -> Void
     ) -> some View {
-        switch style {
-        case .chip(let categories):
-            modifier(
-                ImageGalleryGrid(
-                    categories: {
-                        ImageGalleryChipCategoryView(
-                            categories: categories.map(\.title),
-                            selectedCategoryIndex: selectedCategory
-                        )
-                    },
-                    images: categories[selectedCategory.wrappedValue].images,
-                    closeAccessibilityLabel: closeAccessibilityLabel,
-                    onImageTapped: onImageTapped,
-                    onCloseTapped: onCloseTapped,
-                    selectedCategoryIndex: selectedCategory,
-                    isPresented: isPresented
-                )
+        modifier(
+            ImageGalleryGrid(
+                categories: {
+                    ImageGalleryImageCategoryView(
+                        categories: categories.map {
+                            .init(
+                                title: $0.title,
+                                categoryImage: $0.categoryImage
+                            )
+                        },
+                        selectedCategory: selectedCategory
+                    )
+                },
+                images: categories[selectedCategory.wrappedValue].images,
+                closeAccessibilityLabel: closeAccessibilityLabel,
+                onImageTapped: onImageTapped,
+                onCloseTapped: onCloseTapped,
+                selectedCategoryIndex: selectedCategory,
+                isPresented: isPresented
             )
-        case .image(let categories):
-            modifier(
-                ImageGalleryGrid(
-                    categories: {
-                        ImageGalleryImageCategoryView(
-                            categories: categories.map {
-                                .init(
-                                    title: $0.title,
-                                    categoryImage: $0.categoryImage
-                                )
-                            },
-                            selectedCategory: selectedCategory
-                        )
-                    },
-                    images: categories[selectedCategory.wrappedValue].images,
-                    closeAccessibilityLabel: closeAccessibilityLabel,
-                    onImageTapped: onImageTapped,
-                    onCloseTapped: onCloseTapped,
-                    selectedCategoryIndex: selectedCategory,
-                    isPresented: isPresented
-                )
+        )
+    }
+    
+    // swiftlint:disable function_parameter_count
+    @ViewBuilder
+    func bpkImageGalleryGrid<Content>(
+        isPresented: Binding<Bool>,
+        selectedCategory: Binding<Int>,
+        categories: [BPKImageGalleryChipCategory<Content>],
+        closeAccessibilityLabel: String,
+        onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
+        onCloseTapped: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            ImageGalleryGrid(
+                categories: {
+                    ImageGalleryChipCategoryView(
+                        categories: categories.map(\.title),
+                        selectedCategoryIndex: selectedCategory
+                    )
+                },
+                images: categories[selectedCategory.wrappedValue].images,
+                closeAccessibilityLabel: closeAccessibilityLabel,
+                onImageTapped: onImageTapped,
+                onCloseTapped: onCloseTapped,
+                selectedCategoryIndex: selectedCategory,
+                isPresented: isPresented
             )
-        }
+        )
     }
 }
 
@@ -106,7 +114,7 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             .bpkImageGalleryGrid(
                 isPresented: .constant(true),
                 selectedCategory: .constant(0),
-                style: .image(testImageCategories),
+                categories: testImageCategories,
                 closeAccessibilityLabel: "Close",
                 onImageTapped: { _, _ in },
                 onCloseTapped: {}
@@ -117,7 +125,7 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             .bpkImageGalleryGrid(
                 isPresented: .constant(true),
                 selectedCategory: .constant(0),
-                style: .chip(testChipCategories),
+                categories: testChipCategories,
                 closeAccessibilityLabel: "Close",
                 onImageTapped: { _, _ in },
                 onCloseTapped: {}
@@ -125,36 +133,36 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             .previewDisplayName("Chips")
     }
     
-    private static var testChipCategories: [BPKImageGalleryImageGridStyle<Color>.ChipCategory] {
+    private static var testChipCategories: [BPKImageGalleryChipCategory<Color>] {
         [
-            BPKImageGalleryImageGridStyle.ChipCategory(
+            .init(
                 title: "Green but with very long title indeed (40)",
                 images: testImages(40, color: .green)
             ),
-            BPKImageGalleryImageGridStyle.ChipCategory(
+            .init(
                 title: "Blue photos (10)",
                 images: testImages(5, color: .blue)
             ),
-            BPKImageGalleryImageGridStyle.ChipCategory(
+            .init(
                 title: "Red photos (10)",
                 images: testImages(6, color: .red)
             )
         ]
     }
     
-    private static var testImageCategories: [BPKImageGalleryImageGridStyle<Color>.ImageCategory] {
+    private static var testImageCategories: [BPKImageGalleryImageCategory<Color, Color>] {
         [
-            BPKImageGalleryImageGridStyle.ImageCategory(
+            .init(
                 title: "Green but with very long title indeed (40)",
                 images: testImages(40, color: .green),
                 categoryImage: { Color.green }
             ),
-            BPKImageGalleryImageGridStyle.ImageCategory(
+            .init(
                 title: "Blue photos (10)",
                 images: testImages(5, color: .blue),
                 categoryImage: { Color.blue }
             ),
-            BPKImageGalleryImageGridStyle.ImageCategory(
+            .init(
                 title: "Red photos (10)",
                 images: testImages(6, color: .red),
                 categoryImage: { Color.red }

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryImageGridStyle.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryImageGridStyle.swift
@@ -18,36 +18,31 @@
 
 import SwiftUI
 
-public enum BPKImageGalleryImageGridStyle<ImageView: View> {
-    case chip(_ categories: [ChipCategory])
-    case image(_ categories: [ImageCategory])
+public struct BPKImageGalleryChipCategory<ImageView: View> {
+    public let title: String
+    public let images: [BPKImageGalleryImage<ImageView>]
     
-    public struct ChipCategory {
-        public let title: String
-        public let images: [BPKImageGalleryImage<ImageView>]
-        
-        public init(
-            title: String,
-            images: [BPKImageGalleryImage<ImageView>]
-        ) {
-            self.title = title
-            self.images = images
-        }
+    public init(
+        title: String,
+        images: [BPKImageGalleryImage<ImageView>]
+    ) {
+        self.title = title
+        self.images = images
     }
-    
-    public struct ImageCategory {
-        public let title: String
-        public let images: [BPKImageGalleryImage<ImageView>]
-        public let categoryImage: () -> ImageView
+}
 
-        public init(
-            title: String,
-            images: [BPKImageGalleryImage<ImageView>],
-            categoryImage: @escaping () -> ImageView
-        ) {
-            self.title = title
-            self.images = images
-            self.categoryImage = categoryImage
-        }
+public struct BPKImageGalleryImageCategory<CategoryImageView: View, ImageView: View> {
+    public let title: String
+    public let images: [BPKImageGalleryImage<ImageView>]
+    public let categoryImage: () -> CategoryImageView
+
+    public init(
+        title: String,
+        images: [BPKImageGalleryImage<ImageView>],
+        categoryImage: @escaping () -> CategoryImageView
+    ) {
+        self.title = title
+        self.images = images
+        self.categoryImage = categoryImage
     }
 }

--- a/Example/Backpack/SwiftUI/Components/ImageGalleryGridView/ImageGalleryGridExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/ImageGalleryGridView/ImageGalleryGridExampleView.swift
@@ -40,7 +40,7 @@ struct ImageGalleryGridExampleView: View {
         .bpkImageGalleryGrid(
             isPresented: $chipsPresented,
             selectedCategory: $selectedCategory,
-            style: .chip(chipCategories(imageForIndex: image(forIndex:))),
+            categories: chipCategories(imageForIndex: image(forIndex:)),
             closeAccessibilityLabel: "Close Gallery",
             onImageTapped: { category, image in
                 onImageTapped(category: category, image: image)
@@ -50,7 +50,10 @@ struct ImageGalleryGridExampleView: View {
         .bpkImageGalleryGrid(
             isPresented: $imagesPresented,
             selectedCategory: $selectedCategory,
-            style: .image(imageCategories(imageForIndex: image(forIndex:))),
+            categories: imageCategories(
+                imageForIndex: image(forIndex:),
+                categoryImageForIndex: image(forIndex:)
+            ),
             closeAccessibilityLabel: "Close Gallery",
             onImageTapped: { category, image in
                 onImageTapped(category: category, image: image)
@@ -72,9 +75,10 @@ struct ImageGalleryGridExampleView: View {
         ][categoryIndex]
     }
     
-    private func imageCategories<Image: View>(
-        imageForIndex: @escaping (Int) -> Image
-    ) -> [BPKImageGalleryImageGridStyle<Image>.ImageCategory] {
+    private func imageCategories<Category: View, Image: View>(
+        imageForIndex: @escaping (Int) -> Image,
+        categoryImageForIndex: @escaping (Int) -> Category
+    ) -> [BPKImageGalleryImageCategory<Category, Image>] {
         (0...3)
             .map { categoryIndex in
                 .init(
@@ -88,7 +92,7 @@ struct ImageGalleryGridExampleView: View {
                         )
                     },
                     categoryImage: {
-                        imageForIndex(categoryIndex)
+                        categoryImageForIndex(categoryIndex)
                     }
                 )
             }
@@ -96,7 +100,7 @@ struct ImageGalleryGridExampleView: View {
     
     private func chipCategories<Image: View>(
         imageForIndex: @escaping (Int) -> Image
-    ) -> [BPKImageGalleryImageGridStyle<Image>.ChipCategory] {
+    ) -> [BPKImageGalleryChipCategory<Image>] {
         (0...3).map { categoryIndex in
             .init(
                 title: categoryName(categoryIndex),


### PR DESCRIPTION
This pull request refactors the BPKImageGalleryImageGridStyle to use structs for chip and image categories. This improves code organization and readability.