### PR TITLE
Update Xcode version to 14.2 in GitHub Actions workflow for Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Bundle Install
       run: bundle install --jobs 4 --retry 3
 
+    - name: Select Xcode 14
+      run: sudo xcode-select --switch /Applications/Xcode_14.2.app
+
     - name: Publish Pods - Backpack Common
       run: |
         set -eo pipefail
@@ -58,6 +61,9 @@ jobs:
     - name: Bundle Install
       run: bundle install --jobs 4 --retry 3
 
+    - name: Select Xcode 14
+      run: sudo xcode-select --switch /Applications/Xcode_14.2.app
+
     - name: Publish Pods - Backpack UIKit
       run: |
         set -eo pipefail
@@ -83,6 +89,9 @@ jobs:
 
     - name: Bundle Install
       run: bundle install --jobs 4 --retry 3
+
+    - name: Select Xcode 14
+      run: sudo xcode-select --switch /Applications/Xcode_14.2.app
 
     - name: Publish Pods - Backpack SwiftUI
       run: |


### PR DESCRIPTION
This pull request updates the Xcode version to 14.2 in the GitHub Actions workflow for Releases. This ensures that the correct version of Xcode is used during the release process.