### PR TITLE
Image Grid and Slideshow to use different view builders

### DIFF
--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
@@ -18,9 +18,10 @@
 
 import SwiftUI
 
-struct ImageGalleryGrid<Categories: View, ImageView: View>: ViewModifier {
+struct ImageGalleryGrid<Categories: View, GridImageView: View, SlideshowImageView: View>: ViewModifier {
     let categories: () -> Categories
-    let images: [BPKImageGalleryImage<ImageView>]
+    let gridImages: [BPKGridGalleryImage<GridImageView>]
+    let slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>]
     let closeAccessibilityLabel: String
     let onImageTapped: (_ category: Int, _ image: Int) -> Void
     let onCloseTapped: () -> Void
@@ -32,7 +33,8 @@ struct ImageGalleryGrid<Categories: View, ImageView: View>: ViewModifier {
             .fullScreenCover(isPresented: $isPresented) {
                 ImageGalleryGridContentView(
                     categories: categories,
-                    images: images,
+                    gridImages: gridImages,
+                    slideshowImages: slideshowImages,
                     closeAccessibilityLabel: closeAccessibilityLabel,
                     imageTapped: { selectedCategory, image in
                         onImageTapped(selectedCategory, image)
@@ -47,10 +49,10 @@ struct ImageGalleryGrid<Categories: View, ImageView: View>: ViewModifier {
 public extension View {
     // swiftlint:disable function_parameter_count
     @ViewBuilder
-    func bpkImageGalleryGrid<CategoryView, Content>(
+    func bpkImageGalleryGrid<CategoryView, GridImage, SlideshowImage>(
         isPresented: Binding<Bool>,
         selectedCategory: Binding<Int>,
-        categories: [BPKImageGalleryImageCategory<CategoryView, Content>],
+        categories: [BPKImageGalleryImageCategory<CategoryView, GridImage, SlideshowImage>],
         closeAccessibilityLabel: String,
         onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
         onCloseTapped: @escaping () -> Void
@@ -68,7 +70,8 @@ public extension View {
                         selectedCategory: selectedCategory
                     )
                 },
-                images: categories[selectedCategory.wrappedValue].images,
+                gridImages: categories[selectedCategory.wrappedValue].gridImages,
+                slideshowImages: categories[selectedCategory.wrappedValue].slideshowImages,
                 closeAccessibilityLabel: closeAccessibilityLabel,
                 onImageTapped: onImageTapped,
                 onCloseTapped: onCloseTapped,
@@ -80,10 +83,10 @@ public extension View {
     
     // swiftlint:disable function_parameter_count
     @ViewBuilder
-    func bpkImageGalleryGrid<Content>(
+    func bpkImageGalleryGrid<GridImage, SlideshowImage>(
         isPresented: Binding<Bool>,
         selectedCategory: Binding<Int>,
-        categories: [BPKImageGalleryChipCategory<Content>],
+        categories: [BPKImageGalleryChipCategory<GridImage, SlideshowImage>],
         closeAccessibilityLabel: String,
         onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
         onCloseTapped: @escaping () -> Void
@@ -96,7 +99,8 @@ public extension View {
                         selectedCategoryIndex: selectedCategory
                     )
                 },
-                images: categories[selectedCategory.wrappedValue].images,
+                gridImages: categories[selectedCategory.wrappedValue].gridImages,
+                slideshowImages: categories[selectedCategory.wrappedValue].slideshowImages,
                 closeAccessibilityLabel: closeAccessibilityLabel,
                 onImageTapped: onImageTapped,
                 onCloseTapped: onCloseTapped,
@@ -133,48 +137,60 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             .previewDisplayName("Chips")
     }
     
-    private static var testChipCategories: [BPKImageGalleryChipCategory<Color>] {
+    private static var testChipCategories: [BPKImageGalleryChipCategory<Color, Color>] {
         [
             .init(
                 title: "Green but with very long title indeed (40)",
-                images: testImages(40, color: .green)
+                gridImages: testGridImages(40, color: .green),
+                slideshowImages: testSlideshowImages(40, color: .green)
             ),
             .init(
                 title: "Blue photos (10)",
-                images: testImages(5, color: .blue)
+                gridImages: testGridImages(5, color: .blue),
+                slideshowImages: testSlideshowImages(5, color: .blue)
             ),
             .init(
                 title: "Red photos (10)",
-                images: testImages(6, color: .red)
+                gridImages: testGridImages(6, color: .red),
+                slideshowImages: testSlideshowImages(6, color: .red)
             )
         ]
     }
     
-    private static var testImageCategories: [BPKImageGalleryImageCategory<Color, Color>] {
+    private static var testImageCategories: [BPKImageGalleryImageCategory<Color, Color, Color>] {
         [
             .init(
                 title: "Green but with very long title indeed (40)",
-                images: testImages(40, color: .green),
+                gridImages: testGridImages(40, color: .green),
+                slideshowImages: testSlideshowImages(40, color: .green),
                 categoryImage: { Color.green }
             ),
             .init(
                 title: "Blue photos (10)",
-                images: testImages(5, color: .blue),
+                gridImages: testGridImages(5, color: .blue),
+                slideshowImages: testSlideshowImages(5, color: .blue),
                 categoryImage: { Color.blue }
             ),
             .init(
                 title: "Red photos (10)",
-                images: testImages(6, color: .red),
+                gridImages: testGridImages(6, color: .red),
+                slideshowImages: testSlideshowImages(6, color: .red),
                 categoryImage: { Color.red }
             )
         ]
     }
     
-    private static func testImages(_ amount: Int, color: Color) -> [BPKImageGalleryImage<Color>] {
+    private static func testSlideshowImages(_ amount: Int, color: Color) -> [BPKSlideshowGalleryImage<Color>] {
         return (0..<amount).map { _ in
-            BPKImageGalleryImage(title: "image \(amount)") {
+            BPKSlideshowGalleryImage(title: "image \(amount)") {
                 color
             }
+        }
+    }
+    
+    private static func testGridImages(_ amount: Int, color: Color) -> [BPKGridGalleryImage<Color>] {
+        return (0..<amount).map { _ in
+            BPKGridGalleryImage { color }
         }
     }
 }

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryImageGridStyle.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryImageGridStyle.swift
@@ -18,31 +18,37 @@
 
 import SwiftUI
 
-public struct BPKImageGalleryChipCategory<ImageView: View> {
+public struct BPKImageGalleryChipCategory<GridImageView: View, SlideshowImageView: View> {
     public let title: String
-    public let images: [BPKImageGalleryImage<ImageView>]
+    public let gridImages: [BPKGridGalleryImage<GridImageView>]
+    public let slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>]
     
     public init(
         title: String,
-        images: [BPKImageGalleryImage<ImageView>]
+        gridImages: [BPKGridGalleryImage<GridImageView>],
+        slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>]
     ) {
         self.title = title
-        self.images = images
+        self.gridImages = gridImages
+        self.slideshowImages = slideshowImages
     }
 }
 
-public struct BPKImageGalleryImageCategory<CategoryImageView: View, ImageView: View> {
+public struct BPKImageGalleryImageCategory<CategoryImageView: View, GridImageView: View, SlideshowImageView: View> {
     public let title: String
-    public let images: [BPKImageGalleryImage<ImageView>]
+    public let gridImages: [BPKGridGalleryImage<GridImageView>]
+    public let slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>]
     public let categoryImage: () -> CategoryImageView
 
     public init(
         title: String,
-        images: [BPKImageGalleryImage<ImageView>],
+        gridImages: [BPKGridGalleryImage<GridImageView>],
+        slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>],
         categoryImage: @escaping () -> CategoryImageView
     ) {
         self.title = title
-        self.images = images
+        self.gridImages = gridImages
+        self.slideshowImages = slideshowImages
         self.categoryImage = categoryImage
     }
 }

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
@@ -18,10 +18,11 @@
 
 import SwiftUI
 
-struct ImageGalleryGridContentView<Categories: View, ImageView: View>: View {
+struct ImageGalleryGridContentView<Categories: View, GridImageView: View, SlideshowImageView: View>: View {
     private let itemHeightInGrid: CGFloat = 192
     let categories: () -> Categories
-    let images: [BPKImageGalleryImage<ImageView>]
+    let gridImages: [BPKGridGalleryImage<GridImageView>]
+    let slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>]
     let closeAccessibilityLabel: String
     let imageTapped: (_ category: Int, _ image: Int) -> Void
     let onCloseTapped: () -> Void
@@ -36,7 +37,7 @@ struct ImageGalleryGridContentView<Categories: View, ImageView: View>: View {
             VStack(spacing: 12) {
                 categories()
                 TwoRowGrid(
-                    items: images
+                    items: gridImages
                 ) { item, index in
                     item.content()
                         .aspectRatio(contentMode: .fill)
@@ -56,7 +57,7 @@ struct ImageGalleryGridContentView<Categories: View, ImageView: View>: View {
         .background(Color(.canvasContrastColor))
         .bpkImageGallerySlideshow(
             isPresented: $isSlideshowPresented,
-            images: images,
+            images: slideshowImages,
             closeAccessibilityLabel: closeAccessibilityLabel,
             currentIndex: $imageIndexInCategory,
             onCloseTapped: { isSlideshowPresented = false }
@@ -79,7 +80,11 @@ struct ImageGalleryGridContentView_Previews: PreviewProvider {
             categories: {
                 Text("categories")
             },
-            images: [
+            gridImages: [
+                .init(content: { Color.red }),
+                .init(content: { Color.green })
+            ],
+            slideshowImages: [
                 .init(title: "Image", content: {
                     Color.red
                 }),

--- a/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGalleryImage.swift
+++ b/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGalleryImage.swift
@@ -18,7 +18,7 @@
 
 import SwiftUI
 
-public struct BPKImageGalleryImage<Content: View> {
+public struct BPKSlideshowGalleryImage<Content: View> {
     public let title: String
     public let description: String?
     public let credit: String?
@@ -33,6 +33,14 @@ public struct BPKImageGalleryImage<Content: View> {
         self.title = title
         self.description = description
         self.credit = credit
+        self.content = content
+    }
+}
+
+public struct BPKGridGalleryImage<Content: View> {
+    public let content: () -> Content
+
+    public init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content
     }
 }

--- a/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
+++ b/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
@@ -19,7 +19,7 @@
 import SwiftUI
 
 struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
-    let images: [BPKImageGalleryImage<ImageView>]
+    let images: [BPKSlideshowGalleryImage<ImageView>]
     let closeAccessibilityLabel: String
     let onCloseTapped: () -> Void
     @Binding var currentIndex: Int
@@ -38,7 +38,7 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
     }
     
     struct ContentView: View {
-        let images: [BPKImageGalleryImage<ImageView>]
+        let images: [BPKSlideshowGalleryImage<ImageView>]
         let closeAccessibilityLabel: String
         let onCloseTapped: () -> Void
         @Binding var currentIndex: Int
@@ -138,7 +138,7 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
 public extension View {
     func bpkImageGallerySlideshow<Content>(
         isPresented: Binding<Bool>,
-        images: [BPKImageGalleryImage<Content>],
+        images: [BPKSlideshowGalleryImage<Content>],
         closeAccessibilityLabel: String,
         currentIndex: Binding<Int>,
         onCloseTapped: @escaping () -> Void
@@ -159,17 +159,17 @@ struct BPKImageGallerySlideshow_Previews: PreviewProvider {
     static var previews: some View {
         ImageGallerySlideshow.ContentView(
             images: [
-                BPKImageGalleryImage(title: "Red") {
+                BPKSlideshowGalleryImage(title: "Red") {
                     Color.red
                 },
-                BPKImageGalleryImage(
+                BPKSlideshowGalleryImage(
                     title: "Pumphouse Point",
                     description: "Walk deep into the surrounds of St Clair, world you left behind.",
                     credit: "@PhotographerName"
                 ) {
                     Color.yellow
                 },
-                BPKImageGalleryImage(title: "Green") {
+                BPKSlideshowGalleryImage(title: "Green") {
                     Color.green
                 }
             ],

--- a/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
+++ b/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
@@ -35,7 +35,8 @@ class ImageGalleryGridTests: XCTestCase {
                         selectedCategoryIndex: .constant(1)
                     )
                 },
-                images: (0...4).map { _ in
+                gridImages: (0...4).map { _ in .init(content: createImage) },
+                slideshowImages: (0...4).map { _ in
                     .init(
                         title: "Title for the image",
                         description: "The description of the image goes here.",
@@ -66,7 +67,8 @@ class ImageGalleryGridTests: XCTestCase {
                         selectedCategory: .constant(1)
                     )
                 },
-                images: (0...4).map { _ in
+                gridImages: (0...4).map { _ in .init(content: createImage) },
+                slideshowImages: (0...4).map { _ in
                     .init(
                         title: "Title for the image",
                         description: "The description of the image goes here.",

--- a/Example/Backpack/SwiftUI/Components/ImageGalleryGridView/ImageGalleryGridExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/ImageGalleryGridView/ImageGalleryGridExampleView.swift
@@ -78,13 +78,16 @@ struct ImageGalleryGridExampleView: View {
     private func imageCategories<Category: View, Image: View>(
         imageForIndex: @escaping (Int) -> Image,
         categoryImageForIndex: @escaping (Int) -> Category
-    ) -> [BPKImageGalleryImageCategory<Category, Image>] {
+    ) -> [BPKImageGalleryImageCategory<Category, Image, Image>] {
         (0...3)
             .map { categoryIndex in
                 .init(
                     title: categoryName(categoryIndex),
-                    images: (0...(10 + categoryIndex)).map { index in
-                        BPKImageGalleryImage(
+                    gridImages: (0...(10 + categoryIndex)).map { index in
+                        BPKGridGalleryImage { imageForIndex(index) }
+                    },
+                    slideshowImages: (0...(10 + categoryIndex)).map { index in
+                        BPKSlideshowGalleryImage(
                             title: "image \(index)",
                             description: "Image at Index: \(index)",
                             credit: "@photographer",
@@ -100,12 +103,15 @@ struct ImageGalleryGridExampleView: View {
     
     private func chipCategories<Image: View>(
         imageForIndex: @escaping (Int) -> Image
-    ) -> [BPKImageGalleryChipCategory<Image>] {
+    ) -> [BPKImageGalleryChipCategory<Image, Image>] {
         (0...3).map { categoryIndex in
             .init(
                 title: categoryName(categoryIndex),
-                images: (0...(10 + categoryIndex)).map { index in
-                    BPKImageGalleryImage(
+                gridImages: (0...(10 + categoryIndex)).map { index in
+                    BPKGridGalleryImage { imageForIndex(index) }
+                },
+                slideshowImages: (0...(10 + categoryIndex)).map { index in
+                    BPKSlideshowGalleryImage(
                         title: "image \(index)",
                         description: "Image at Index: \(index)",
                         credit: "@photographer",

--- a/Example/Backpack/SwiftUI/Components/ImageGallerySlideshow/ImageGallerySlideshowExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/ImageGallerySlideshow/ImageGallerySlideshowExampleView.swift
@@ -30,7 +30,7 @@ struct ImageGallerySlideshowExampleView: View {
         .bpkImageGallerySlideshow(
             isPresented: $isPresented,
             images: (1...4).map { index in
-                BPKImageGalleryImage(
+                BPKSlideshowGalleryImage(
                     title: "Pumphouse Point",
                     description: "\(index) Walk deep into the fjord-like surrounds of Lake St Clair.",
                     credit: "@PhotographerName",


### PR DESCRIPTION
This pull request updates the usage of `BPKImageGalleryImage` to `BPKSlideshowGalleryImage` in the SwiftUI components. The changes include updating the struct names, replacing instances of `BPKImageGalleryImage` with `BPKSlideshowGalleryImage`, and updating the references in the tests. This update ensures consistency and improves clarity in the codebase.