### PR TITLE
AI-439 Set an optional accessibilityIdentifier on the button items in the navigation bar

### DIFF
--- a/Backpack-SwiftUI/NavigationBar/Classes/BPKNavigationView.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/BPKNavigationView.swift
@@ -124,7 +124,7 @@ struct BPKNavigationView_Previews: PreviewProvider {
     static var previews: some View {
         BPKNavigationView(
             title: "Hotels",
-            leadingItems: [.init(type: .backButton("Back"), action: {})],
+            leadingItems: [.init(type: .backButton("Back", accessibilityIdentifier: "btn_back"), action: {})],
             trailingItems: [
                 .init(type: .icon(.settings, "AI"), action: {}),
                 .init(type: .icon(.faceId, "Add"), action: {})

--- a/Backpack-SwiftUI/NavigationBar/Classes/BPKNavigationViewItem.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/BPKNavigationViewItem.swift
@@ -26,9 +26,9 @@ public struct BPKNavigationBarItem {
     }
     
     public enum ButtonType {
-        case backButton(_ accessibiltyLabel: String)
-        case closeButton(_ accessibiltyLabel: String)
-        case icon(BPKIcon, _ accessibiltyLabel: String)
+        case backButton(_ accessibiltyLabel: String, accessibilityIdentifier: String? = nil)
+        case closeButton(_ accessibiltyLabel: String, accessibilityIdentifier: String? = nil)
+        case icon(BPKIcon, _ accessibiltyLabel: String, accessibilityIdentifier: String? = nil)
         case title(String)
     }
 }

--- a/Backpack-SwiftUI/NavigationBar/Classes/CollapsedNavigationBar.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/CollapsedNavigationBar.swift
@@ -78,6 +78,7 @@ struct CollapsedNavigationBar: View {
     private func iconItemView(
         withIcon icon: BPKIcon,
         accessibilityLabel: String,
+        accessibilityIdentifier: String?,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
@@ -85,6 +86,7 @@ struct CollapsedNavigationBar: View {
         }
         .accessibilityLabel(accessibilityLabel)
         .foregroundColor(style.foregroundColor(expanded: expanded))
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
     
     // swiftlint:disable closure_body_length
@@ -93,26 +95,29 @@ struct CollapsedNavigationBar: View {
         ForEach(0..<items.count, id: \.self) { index in
             let item = items[index]
             switch item.type {
-            case .icon(let icon, let accessibilityLabel):
+            case .icon(let icon, let accessibilityLabel, let accessibilityIdentifier):
                 iconItemView(
                     withIcon: icon,
                     accessibilityLabel: accessibilityLabel,
+                    accessibilityIdentifier: accessibilityIdentifier,
                     action: item.action
                 )
             case .title(let title):
                 BPKButton(title, action: item.action)
                     .buttonStyle(.link)
                     .fixedSize()
-            case .backButton(let accessibilityLabel):
+            case .backButton(let accessibilityLabel, let accessibilityIdentifier):
                 iconItemView(
                     withIcon: .chevronLeft,
                     accessibilityLabel: accessibilityLabel,
+                    accessibilityIdentifier: accessibilityIdentifier,
                     action: item.action
                 )
-            case .closeButton(let accessibilityLabel):
+            case .closeButton(let accessibilityLabel, let accessibilityIdentifier):
                 iconItemView(
                     withIcon: .close,
                     accessibilityLabel: accessibilityLabel,
+                    accessibilityIdentifier: accessibilityIdentifier,
                     action: item.action
                 )
             }


### PR DESCRIPTION
Hola 👋 

This adds the ability to set accessibilityIDs to the navigation bar items in SwiftUI for UITest purposes

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
