### PR TITLE
DON-386: Add accessibility support to BPKNudger

### DIFF
--- a/Backpack-SwiftUI/Nudger/Classes/BPKNudger.swift
+++ b/Backpack-SwiftUI/Nudger/Classes/BPKNudger.swift
@@ -33,6 +33,7 @@ public struct BPKNudger: View {
     private var maxValue: Int
     private var step: Int
     private let minWidth: CGFloat = BPKSpacing.lg.value
+    var accessibilityPrefix: String?
     
     /// Creates a `BPKNudger`.
     /// - Parameters:
@@ -114,10 +115,13 @@ public struct BPKNudger: View {
             Group {
                 BPKButton(icon: .minus, accessibilityLabel: "", enabled: $canDecrement, action: decrement)
                     .buttonStyle(.secondary)
+                    .accessibilityIdentifier(accessibilityIdentifier(for: "minus"))
                 BPKText("\(value)", style: .heading5)
                     .frame(minWidth: minWidth)
+                    .accessibilityIdentifier(accessibilityIdentifier(for: "value_label"))
                 BPKButton(icon: .plus, accessibilityLabel: "", enabled: $canIncrement, action: increment)
                     .buttonStyle(.secondary)
+                    .accessibilityIdentifier(accessibilityIdentifier(for: "plus"))
             }
             .accessibilityElement(children: .ignore)
         }
@@ -163,12 +167,28 @@ public struct BPKNudger: View {
         value = max(value - step, minValue)
         updateButtonStates()
     }
+    
+    private func accessibilityIdentifier(for label: String) -> String {
+        if let prefix = accessibilityPrefix {
+            return "\(prefix)_\(label)"
+        }
+        return ""
+    }
+}
+
+public extension BPKNudger {
+    func accessibilityPrefix(_ prefix: String?) -> BPKNudger {
+        var result = self
+        result.accessibilityPrefix = prefix
+        return result
+    }
 }
 
 struct BPKNudger_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             BPKNudger(value: .constant(0), min: 0, max: 10)
+                .accessibilityPrefix(" ")
             BPKNudger(value: .constant(5), min: 0, max: 10)
             BPKNudger(value: .constant(10), min: 0, max: 10)
             BPKNudger(title: "Adults", subtitle: "Aged 16 and older", value: .constant(1), min: 1, max: 10)

--- a/Example/Backpack/SwiftUI/Components/Nudger/NudgerExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/Nudger/NudgerExampleView.swift
@@ -26,6 +26,7 @@ struct NudgerExampleView: View {
     var body: some View {
         VStack {
             BPKNudger(value: $value, min: 1, max: 10, step: 1)
+                .accessibilityPrefix("Prefix")
                 .accessibilityLabel("Passengers")
             BPKNudger(title: "Adults", subtitle: "Aged 16+", value: $value, min: 1, max: 10)
             BPKNudger(title: "Rooms", value: $value, min: 1, max: 10)


### PR DESCRIPTION
In the scope of improving feature tests of the traveller selector there is essential change for BPKNudger, which is using as a stepper component in TravellerSelector.

The problem is some small components like increment and decrement buttons are unavailable for clicking in UITests due to combining those elements into one Nudger accessibility element.

Those changes make smaller elements accessible without any changes for screen reader for actual accessibility users.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
