### PR TITLE
RALP-4865 Use ubuntu-22.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -58,11 +58,11 @@ jobs:
       - name: Run UIKit tests
         run: ./scripts/ci uikit test
         continue-on-error: ${{inputs.retake_snapshots}}
-      
+
       - name: Run SwiftUI tests
         run: ./scripts/ci swiftui test
         continue-on-error: ${{inputs.retake_snapshots}}
-      
+
       - name: Check snapshot changes
         id: checkSnapshotChanges
         run: changedFiles=`git status --porcelain` && echo "didChangeFiles=${changedFiles//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
@@ -83,7 +83,7 @@ jobs:
 
   NotifyChanges:
     name: "Notify about changes made"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [TestPods]
     if: ${{ needs.TestPods.outputs.changed-files != '' &&  inputs.retake_snapshots}}
     steps:

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/_build-docs.yml
 
   ReleaseDraft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/_build-docs.yml
 
   Dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     if: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Publish Pods - Backpack Common
       run: |
         set -eo pipefail
-        bundle exec pod trunk push Backpack-Common.podspec --allow-warnings --skip-tests --synchronous 
+        bundle exec pod trunk push Backpack-Common.podspec --allow-warnings --skip-tests --synchronous
         bundle exec pod repo update
       env:
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: main
-    
+
     - name: Set up node and ruby
       uses: asdf-vm/actions/install@v3 # Sets ruby and node version via `.tool-versions`
 
@@ -140,9 +140,9 @@ jobs:
         keep_files: true
         external_repository: backpack/ios
         publish_branch: main
-  
+
   SupernovaPublish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: Publishing
     steps:
       - name: Update Supernova docs

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   CheckCommitMessage:
     name: Check commit message
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       head-commit-message: ${{ steps.get_head_commit_message.outputs.headCommitMsg }}
     steps:


### PR DESCRIPTION
Using the latest ubuntu image for the github runners but using the specific YAML label instead of `latest`

All available images: https://github.com/actions/runner-images?tab=readme-ov-file#available-images