### PR TITLE
[Panda]PAN-2774: Fix Incorrect month format in calendar view

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
@@ -53,7 +53,11 @@ public struct BPKCalendar: View {
 
         monthHeaderDateFormatter = DateFormatter()
         monthHeaderDateFormatter.timeZone = calendar.timeZone
-        monthHeaderDateFormatter.dateFormat = "MMMM yyyy"
+        monthHeaderDateFormatter.dateFormat = DateFormatter.dateFormat(
+            fromTemplate: "MMMM yyyy",
+            options: 0,
+            locale: Locale.current
+        )
     }
     
     public var body: some View {


### PR DESCRIPTION
PAN-2774

As previously mentioned in the ticket, we currently display month names in Finnish (fi-FI) with endings like `maaliskuuta` and `huhtikuuta`. The correct forms should be `maaliskuu` and `huhtikuu` respectively. 
This PR fixes the issue by invoking a system API ([DateFormatter.dateFormat](https://developer.apple.com/documentation/foundation/dateformatter/1408112-dateformat)) to translate the generic format string into a localized date format string.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/d322d9e9-a340-49e4-befb-3312edd2618c) | ![image](https://github.com/user-attachments/assets/4aa49bb9-298b-4db2-9e01-61ee1c18d792) |


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
