### PR TITLE
Make medium bottom sheet expansion configurable

### DIFF
--- a/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheetContentMode.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheetContentMode.swift
@@ -23,9 +23,14 @@ public enum BPKBottomSheetContentMode {
     case large
     
     /// The sheet shows at half the screen
+    /// Sheet is only expansible if `expansible` is set to `true`.
+    /// Use `Spacer` in your content to define expansion behaviour
+    case medium(_ expansible: Bool)
+    
+    /// The sheet shows at half the screen
     /// Sheet is expansible
     /// Use `Spacer` in your content to define expansion behaviour
-    case medium
+    public static let medium = BPKBottomSheetContentMode.medium(true)
     
     /// The sheet resizes to fit its content
     /// Sheet is not expansible

--- a/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
@@ -46,8 +46,9 @@ struct BottomSheetContainerViewModifier<Header: View, BottomSheetContent: View>:
                 switch contentMode {
                 case .large:
                     bottomSheetContent(for: [.large])
-                case .medium:
-                    bottomSheetContent(for: [.medium, .large])
+                case .medium(let expansible):
+                    let detents: Set<PresentationDetent> = expansible ? [.medium, .large] : [.medium]
+                    bottomSheetContent(for: detents)
                 case .fitContent:
                     ContentFitBottomSheet(
                         header: header,

--- a/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
@@ -50,8 +50,9 @@ struct ItemBottomSheetContainerViewModifier<
                 switch contentMode {
                 case .large:
                     bottomSheetContent(for: [.large], item: item)
-                case .medium:
-                    bottomSheetContent(for: [.medium, .large], item: item)
+                case .medium(let expansible):
+                    let detents: Set<PresentationDetent> = expansible ? [.medium, .large] : [.medium]
+                    bottomSheetContent(for: detents, item: item)
                 case .fitContent:
                     ContentFitBottomSheet(
                         header: header,

--- a/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
@@ -29,6 +29,7 @@ struct BottomSheetExampleView: View {
     @State private var closableBottomSheetShown = false
     @State private var largeBottomSheetShown = false
     @State private var mediumBottomSheetShown = false
+    @State private var mediumFixedBottomSheetShown = false
     @State private var fitContentBottomSheetShown = false
     @State private var itemToShow: ExampleItem?
 
@@ -50,6 +51,9 @@ struct BottomSheetExampleView: View {
             }
             BPKButton("Show medium bottom sheet") {
                 mediumBottomSheetShown.toggle()
+            }
+            BPKButton("Show medium bottom sheet (fixed)") {
+                mediumFixedBottomSheetShown.toggle()
             }
             BPKButton("Show fit content bottom sheet") {
                 fitContentBottomSheetShown.toggle()
@@ -87,6 +91,17 @@ struct BottomSheetExampleView: View {
         .bpkBottomSheet(
             isPresented: $mediumBottomSheetShown,
             contentMode: .medium,
+            title: "Title",
+            action: BPKBottomSheetAction(
+                title: "Action",
+                action: { mediumBottomSheetShown.toggle() }
+            ),
+            presentingController: rootViewController,
+            bottomSheetContent: { content() }
+        )
+        .bpkBottomSheet(
+            isPresented: $mediumFixedBottomSheetShown,
+            contentMode: .medium(false),
             title: "Title",
             action: BPKBottomSheetAction(
                 title: "Action",


### PR DESCRIPTION
This pull request adds the ability to configure the expansion behavior of the medium bottom sheet in the code. Previously, the medium bottom sheet was always expansible, but now it can be set to be non-expansible if desired. This provides more flexibility in customizing the behavior of the medium bottom sheet.