### PR TITLE
SwiftUI DynamicType toggle

### DIFF
--- a/Backpack-SwiftUI/Button/Classes/BPKButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/BPKButton.swift
@@ -173,6 +173,9 @@ private struct ButtonContentView: View {
         Text(title)
             .font(style: .label1)
             .lineLimit(lineLimit())
+            .if(!BPKFont.enableDynamicType, transform: {
+                $0.sizeCategory(.large)
+            })
     }
     
     private func lineLimit() -> Int? {

--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -36,7 +36,7 @@ public struct BPKIconView: View {
     
     private var dimension: CGFloat {
         switch size {
-        case .small: 
+        case .small:
             return BPKFont.enableDynamicType ? scaledSmallSize : smallSize
         case .large:
             return BPKFont.enableDynamicType ? scaledLargeSize : largeSize

--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -36,8 +36,10 @@ public struct BPKIconView: View {
     
     private var dimension: CGFloat {
         switch size {
-        case .small: BPKFont.enableDynamicType ? scaledSmallSize : smallSize
-        case .large: BPKFont.enableDynamicType ? scaledLargeSize : largeSize
+        case .small: 
+            return BPKFont.enableDynamicType ? scaledSmallSize : smallSize
+        case .large:
+            return BPKFont.enableDynamicType ? scaledLargeSize : largeSize
         }
     }
 

--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -28,13 +28,16 @@ public struct BPKIconView: View {
         self.size = size
     }
     
-    @ScaledMetric private var smallSize: CGFloat = 16
-    @ScaledMetric private var largeSize: CGFloat = 24
+    @ScaledMetric private var scaledSmallSize: CGFloat = 16
+    @ScaledMetric private var scaledLargeSize: CGFloat = 24
+    
+    private var smallSize: CGFloat = 16
+    private var largeSize: CGFloat = 24
     
     private var dimension: CGFloat {
         switch size {
-        case .large: return largeSize
-        case .small: return smallSize
+        case .small: BPKFont.enableDynamicType ? scaledSmallSize : smallSize
+        case .large: BPKFont.enableDynamicType ? scaledLargeSize : largeSize
         }
     }
 

--- a/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
+++ b/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
@@ -73,6 +73,9 @@ public struct BPKSearchInputSummary: View {
         .background(.surfaceDefaultColor)
         .clipShape(RoundedRectangle(cornerRadius: .sm))
         .outline(focused ? .textLinkColor : state.borderColor, cornerRadius: .sm, lineWidth: focused ? 2.0 : 1.0)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
     }
     
     @ViewBuilder

--- a/Backpack-SwiftUI/Text/Classes/BPKText.swift
+++ b/Backpack-SwiftUI/Text/Classes/BPKText.swift
@@ -43,6 +43,9 @@ public struct BPKText: View {
             .font(style: style)
             .foregroundColor(textColor)
             .lineLimit(lineLimit)
+            .if(!BPKFont.enableDynamicType, transform: {
+                $0.sizeCategory(.large)
+            })
     }
     
     /// Sets the color of the text.

--- a/Backpack-SwiftUI/TextField/Classes/BPKTextField.swift
+++ b/Backpack-SwiftUI/TextField/Classes/BPKTextField.swift
@@ -56,6 +56,9 @@ public struct BPKTextField: View {
         .background(.surfaceDefaultColor)
         .clipShape(RoundedRectangle(cornerRadius: .sm))
         .outline(state.borderColor, cornerRadius: .sm)
+        .if(!BPKFont.enableDynamicType, transform: {
+            $0.sizeCategory(.large)
+        })
     }
     
     private var accessory: some View {


### PR DESCRIPTION
We discovered that not all components follow the restriction on DynamicType font scaling. This PR now ensures all components honour the toggle and ensure consistency

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
