### PR TITLE
Add original copyright to files ported from external libraries

### DIFF
--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendar.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendar.h
@@ -16,6 +16,23 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendar.h
+//  FSCalendar
+//
+//  Created by Wenchao Ding on 29/1/15.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+// 
+//  https://github.com/WenchaoD
+//
+//  FSCalendar is a superior awesome calendar control with high performance, high customizablility and very simple usage.
+//
+//  @see FSCalendarDataSource
+//  @see FSCalendarDelegate
+//  @see FSCalendarDelegateAppearance
+//  @see FSCalendarAppearance
+//
+
 #import "FSCalendarAppearance.h"
 #import "FSCalendarCell.h"
 #import "FSCalendarConstants.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendar.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendar.h
@@ -16,22 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendar.h
-//  FSCalendar
-//
-//  Created by Wenchao Ding on 29/1/15.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-// 
-//  https://github.com/WenchaoD
-//
-//  FSCalendar is a superior awesome calendar control with high performance, high customizablility and very simple usage.
-//
-//  @see FSCalendarDataSource
-//  @see FSCalendarDelegate
-//  @see FSCalendarDelegateAppearance
-//  @see FSCalendarAppearance
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarAppearance.h"
 #import "FSCalendarCell.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendar.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendar.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendar.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendar.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendar.m
-//  FSCalendar
-//
-//  Created by Wenchao Ding on 29/1/15.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendar.h"
 #import "FSCalendarCollectionViewLayout.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendar.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendar.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendar.m
+//  FSCalendar
+//
+//  Created by Wenchao Ding on 29/1/15.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendar.h"
 #import "FSCalendarCollectionViewLayout.h"
 #import "FSCalendarHeaderView.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendar.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendar.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.h
@@ -16,15 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarAppearance.h
-//  Pods
-//
-//  Created by DingWenchao on 6/29/15.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
-//  https://github.com/WenchaoD
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarConstants.h"
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.h
@@ -16,6 +16,16 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarAppearance.h
+//  Pods
+//
+//  Created by DingWenchao on 6/29/15.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+//  https://github.com/WenchaoD
+//
+
 #import "FSCalendarConstants.h"
 
 @class FSCalendar;

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.m
@@ -16,6 +16,16 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarAppearance.m
+//  Pods
+//
+//  Created by DingWenchao on 6/29/15.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+//  https://github.com/WenchaoD
+//
+
 #import "FSCalendarAppearance.h"
 #import "FSCalendarDynamicHeader.h"
 #import "FSCalendarExtensions.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarAppearance.m
@@ -16,15 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarAppearance.m
-//  Pods
-//
-//  Created by DingWenchao on 6/29/15.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
-//  https://github.com/WenchaoD
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarAppearance.h"
 #import "FSCalendarDynamicHeader.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarCalculator.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 30/10/2016.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendar.h"
 #import <Foundation/Foundation.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarCalculator.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 30/10/2016.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendar.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarCalculator.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 30/10/2016.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendarCalculator.h"
 #import "FSCalendar.h"
 #import "FSCalendarDynamicHeader.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCalculator.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarCalculator.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 30/10/2016.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarCalculator.h"
 #import "FSCalendar.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarCell.h
-//  Pods
-//
-//  Created by Wenchao Ding on 12/3/15.
-//
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarCell.h
+//  Pods
+//
+//  Created by Wenchao Ding on 12/3/15.
+//
+//
+
 #import <UIKit/UIKit.h>
 
 @class FSCalendar, FSCalendarAppearance, FSCalendarEventIndicator;

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarCell.m
-//  Pods
-//
-//  Created by Wenchao Ding on 12/3/15.
-//
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarCell.h"
 #import "FSCalendar.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarCell.m
+//  Pods
+//
+//  Created by Wenchao Ding on 12/3/15.
+//
+//
+
 #import "FSCalendarCell.h"
 #import "FSCalendar.h"
 #import "FSCalendarConstants.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCell.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarCollectionView.h
-//  FSCalendar
-//
-//  Created by Wenchao Ding on 10/25/15.
-//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <UIKit/UIKit.h>
 @class FSCalendarCollectionView;

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarCollectionView.h
+//  FSCalendar
+//
+//  Created by Wenchao Ding on 10/25/15.
+//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
+//
+
 #import <UIKit/UIKit.h>
 @class FSCalendarCollectionView;
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.m
@@ -16,14 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarCollectionView.m
-//  FSCalendar
-//
-//  Created by Wenchao Ding on 10/25/15.
-//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
-//
-//  Reject -[UIScrollView(UIScrollViewInternal) _adjustContentOffsetIfNecessary]
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarCollectionView.h"
 #import "FSCalendarConstants.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionView.m
@@ -16,6 +16,15 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarCollectionView.m
+//  FSCalendar
+//
+//  Created by Wenchao Ding on 10/25/15.
+//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
+//
+//  Reject -[UIScrollView(UIScrollViewInternal) _adjustContentOffsetIfNecessary]
+
 #import "FSCalendarCollectionView.h"
 #import "FSCalendarConstants.h"
 #import "FSCalendarExtensions.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarAnimationLayout.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 1/3/16.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import <UIKit/UIKit.h>
 
 @class FSCalendar;

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarAnimationLayout.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 1/3/16.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarAnimationLayout.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 1/3/16.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarCollectionViewLayout.h"
 #import "FSCalendar.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarCollectionViewLayout.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarAnimationLayout.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 1/3/16.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendarCollectionViewLayout.h"
 #import "FSCalendar.h"
 #import "FSCalendarCollectionView.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.h
@@ -16,6 +16,16 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarConstants.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 8/28/15.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+//  https://github.com/WenchaoD
+//
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.h
@@ -16,15 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarConstants.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 8/28/15.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
-//  https://github.com/WenchaoD
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.m
@@ -16,15 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarConstants.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 8/28/15.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
-//  https://github.com/WenchaoD
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarConstants.h"
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarConstants.m
@@ -16,6 +16,16 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarConstants.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 8/28/15.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+//  https://github.com/WenchaoD
+//
+
 #import "FSCalendarConstants.h"
 
 CGFloat const FSCalendarStandardHeaderHeight = 40;

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarDelegationFactory.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 19/12/2016.
-//  Copyright © 2016 wenchaoios. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarDelegationProxy.h"
 #import <Foundation/Foundation.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarDelegationFactory.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 19/12/2016.
+//  Copyright © 2016 wenchaoios. All rights reserved.
+//
+
 #import "FSCalendarDelegationProxy.h"
 #import <Foundation/Foundation.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarDelegationFactory.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 19/12/2016.
+//  Copyright © 2016 wenchaoios. All rights reserved.
+//
+
 #import "FSCalendarDelegationFactory.h"
 
 @implementation FSCalendarDelegationFactory

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationFactory.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarDelegationFactory.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 19/12/2016.
-//  Copyright © 2016 wenchaoios. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarDelegationFactory.h"
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.h
@@ -16,6 +16,19 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarDelegationProxy.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 11/12/2016.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+//  https://github.com/WenchaoD
+//
+//  1. Smart proxy delegation http://petersteinberger.com/blog/2013/smart-proxy-delegation/
+//  2. Manage deprecated delegation functions
+//
+
 #import "FSCalendar.h"
 #import <Foundation/Foundation.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.h
@@ -16,18 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarDelegationProxy.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 11/12/2016.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
-//  https://github.com/WenchaoD
-//
-//  1. Smart proxy delegation http://petersteinberger.com/blog/2013/smart-proxy-delegation/
-//  2. Manage deprecated delegation functions
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendar.h"
 #import <Foundation/Foundation.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarDelegationProxy.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 11/12/2016.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarDelegationProxy.h"
 #import <objc/runtime.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDelegationProxy.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarDelegationProxy.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 11/12/2016.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendarDelegationProxy.h"
 #import <objc/runtime.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDynamicHeader.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDynamicHeader.h
@@ -16,6 +16,16 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarDynamicHeader.h
+//  Pods
+//
+//  Created by DingWenchao on 6/29/15.
+//
+//  动感头文件，仅供框架内部使用。
+//  Private header, don't use it.
+//
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDynamicHeader.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDynamicHeader.h
@@ -16,15 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarDynamicHeader.h
-//  Pods
-//
-//  Created by DingWenchao on 6/29/15.
-//
-//  动感头文件，仅供框架内部使用。
-//  Private header, don't use it.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarDynamicHeader.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarDynamicHeader.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarExtensions.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 10/8/16.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarExtensions.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 10/8/16.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarExtensions.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 10/8/16.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarExtensions.h"
 #import <objc/runtime.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarExtensions.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 10/8/16.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendarExtensions.h"
 #import <objc/runtime.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarExtensions.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarHeader.h
+//  Pods
+//
+//  Created by Wenchao Ding on 29/1/15.
+//
+//
+
 #import <UIKit/UIKit.h>
 
 @class FSCalendar, FSCalendarAppearance, FSCalendarHeaderLayout, FSCalendarCollectionView;

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarHeader.h
-//  Pods
-//
-//  Created by Wenchao Ding on 29/1/15.
-//
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarHeader.m
-//  Pods
-//
-//  Created by Wenchao Ding on 29/1/15.
-//
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarHeaderView.h"
 #import "FSCalendar.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarHeaderView.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarHeader.m
+//  Pods
+//
+//  Created by Wenchao Ding on 29/1/15.
+//
+//
+
 #import "FSCalendarHeaderView.h"
 #import "FSCalendar.h"
 #import "FSCalendarCollectionView.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarSeparatorDecorationView.h
+//  FSCalendar
+//
+//  Created by 丁文超 on 2018/10/10.
+//  Copyright © 2018 wenchaoios. All rights reserved.
+//
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarSeparatorDecorationView.h
-//  FSCalendar
-//
-//  Created by 丁文超 on 2018/10/10.
-//  Copyright © 2018 wenchaoios. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarSeparatorDecorationView.m
+//  FSCalendar
+//
+//  Created by 丁文超 on 2018/10/10.
+//  Copyright © 2018 wenchaoios. All rights reserved.
+//
+
 #import "FSCalendarSeparatorDecorationView.h"
 #import "FSCalendarConstants.h"
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarSeparatorDecorationView.m
-//  FSCalendar
-//
-//  Created by 丁文超 on 2018/10/10.
-//  Copyright © 2018 wenchaoios. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarSeparatorDecorationView.h"
 #import "FSCalendarConstants.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarSeparatorDecorationView.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarStaticHeader.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 9/17/15.
-//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarStaticHeader.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 9/17/15.
+//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
+//
+
 #import <UIKit/UIKit.h>
 
 @class FSCalendar, FSCalendarAppearance;

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarStaticHeader.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 9/17/15.
-//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarStickyHeader.h"
 #import "FSCalendar.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarStickyHeader.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarStaticHeader.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 9/17/15.
+//  Copyright (c) 2015 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendarStickyHeader.h"
 #import "FSCalendar.h"
 #import "FSCalendarConstants.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarTransitionCoordinator.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 3/13/16.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendar.h"
 #import "FSCalendarCollectionView.h"
 #import "FSCalendarCollectionViewLayout.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarTransitionCoordinator.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 3/13/16.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendar.h"
 #import "FSCalendarCollectionView.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarTransitionCoordinator.m
+//  FSCalendar
+//
+//  Created by Wenchao Ding on 3/13/16.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendarTransitionCoordinator.h"
 #import "FSCalendarDynamicHeader.h"
 #import "FSCalendarExtensions.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarTransitionCoordinator.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarTransitionCoordinator.m
-//  FSCalendar
-//
-//  Created by Wenchao Ding on 3/13/16.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarTransitionCoordinator.h"
 #import "FSCalendarDynamicHeader.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.h
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarWeekdayView.h
-//  FSCalendar
-//
-//  Created by dingwenchao on 03/11/2016.
-//  Copyright © 2016 dingwenchao. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.h
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.h
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarWeekdayView.h
+//  FSCalendar
+//
+//  Created by dingwenchao on 03/11/2016.
+//  Copyright © 2016 dingwenchao. All rights reserved.
+//
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.m
@@ -16,13 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  FSCalendarWeekdayView.m
-//  FSCalendar
-//
-//  Created by dingwenchao on 03/11/2016.
-//  Copyright © 2016 Wenchao Ding. All rights reserved.
-//
+/*
+ * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "FSCalendarWeekdayView.h"
 #import "FSCalendar.h"

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright (c) 2013-2016 FSCalendar (https://github.com/WenchaoD/FSCalendar)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.m
+++ b/Backpack/Calendar/Classes/FSCalendar/FSCalendarWeekdayView.m
@@ -16,6 +16,14 @@
  * limitations under the License.
  */
 
+//
+//  FSCalendarWeekdayView.m
+//  FSCalendar
+//
+//  Created by dingwenchao on 03/11/2016.
+//  Copyright © 2016 Wenchao Ding. All rights reserved.
+//
+
 #import "FSCalendarWeekdayView.h"
 #import "FSCalendar.h"
 #import "FSCalendarDynamicHeader.h"

--- a/Backpack/Toast/Classes/MBProgressHUD.h
+++ b/Backpack/Toast/Classes/MBProgressHUD.h
@@ -16,33 +16,27 @@
  * limitations under the License.
  */
 
-//
-//  MBProgressHUD.h
-//  Version 1.2.0
-//  Created by Matej Bukovinski on 2.4.09.
-//
-
-// This code is distributed under the terms and conditions of the MIT license.
-
-// Copyright © 2009-2020 Matej Bukovinski
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+/*
+ * Copyright © 2009-2020 Matej Bukovinski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>

--- a/Backpack/Toast/Classes/MBProgressHUD.h
+++ b/Backpack/Toast/Classes/MBProgressHUD.h
@@ -16,6 +16,34 @@
  * limitations under the License.
  */
 
+//
+//  MBProgressHUD.h
+//  Version 1.2.0
+//  Created by Matej Bukovinski on 2.4.09.
+//
+
+// This code is distributed under the terms and conditions of the MIT license.
+
+// Copyright © 2009-2020 Matej Bukovinski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/Backpack/Toast/Classes/MBProgressHUD.h
+++ b/Backpack/Toast/Classes/MBProgressHUD.h
@@ -18,17 +18,17 @@
 
 /*
  * Copyright © 2009-2020 Matej Bukovinski
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Backpack/Toast/Classes/MBProgressHUD.m
+++ b/Backpack/Toast/Classes/MBProgressHUD.m
@@ -16,11 +16,27 @@
  * limitations under the License.
  */
 
-//
-// MBProgressHUD.m
-// Version 1.2.0
-// Created by Matej Bukovinski on 2.4.09.
-//
+/*
+ * Copyright © 2009-2020 Matej Bukovinski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #import "MBProgressHUD.h"
 #import <tgmath.h>

--- a/Backpack/Toast/Classes/MBProgressHUD.m
+++ b/Backpack/Toast/Classes/MBProgressHUD.m
@@ -16,6 +16,12 @@
  * limitations under the License.
  */
 
+//
+// MBProgressHUD.m
+// Version 1.2.0
+// Created by Matej Bukovinski on 2.4.09.
+//
+
 #import "MBProgressHUD.h"
 #import <tgmath.h>
 

--- a/Backpack/Toast/Classes/MBProgressHUD.m
+++ b/Backpack/Toast/Classes/MBProgressHUD.m
@@ -18,17 +18,17 @@
 
 /*
  * Copyright © 2009-2020 Matej Bukovinski
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
This pull request adds the original copyright to the files that were ported from external libraries. This ensures that the appropriate attribution is given to the original authors of the code.