### PR TITLE
Add accessory view to each day in the calendar

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
@@ -18,11 +18,12 @@
 
 import SwiftUI
 
-struct CalendarTypeContainerFactory<MonthHeader: View>: View {
+struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: View {
     let selectionType: CalendarSelectionType
     let calendar: Calendar
     let validRange: ClosedRange<Date>
     @ViewBuilder let monthHeader: (_ monthDate: Date) -> MonthHeader
+    @ViewBuilder let dayAccessoryView: (Date) -> DayAccessoryView
     
     private var accessibilityDateFormatter: DateFormatter {
         let formatter = DateFormatter()
@@ -42,7 +43,8 @@ struct CalendarTypeContainerFactory<MonthHeader: View>: View {
                     accessibilityConfigurations: accessibilityConfigurations,
                     dateFormatter: accessibilityDateFormatter
                 ),
-                monthHeader: monthHeader
+                monthHeader: monthHeader,
+                dayAccessoryView: dayAccessoryView
             )
         case .single(let selected, let accessibilityConfigurations):
             SingleCalendarContainer(
@@ -53,7 +55,8 @@ struct CalendarTypeContainerFactory<MonthHeader: View>: View {
                     accessibilityConfigurations: accessibilityConfigurations,
                     dateFormatter: accessibilityDateFormatter
                 ),
-                monthHeader: monthHeader
+                monthHeader: monthHeader,
+                dayAccessoryView: dayAccessoryView
             )
         }
     }

--- a/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
@@ -18,12 +18,13 @@
 
 import SwiftUI
 
-struct RangeCalendarContainer<MonthHeader: View>: View {
+struct RangeCalendarContainer<MonthHeader: View, DayAccessoryView: View>: View {
     @Binding var selectionState: CalendarRangeSelectionState?
     let calendar: Calendar
     let validRange: ClosedRange<Date>
     let accessibilityProvider: RangeDayAccessibilityProvider
     @ViewBuilder let monthHeader: (_ monthDate: Date) -> MonthHeader
+    @ViewBuilder let dayAccessoryView: (Date) -> DayAccessoryView
     
     private func handleSelection(_ date: Date) {
         switch selectionState {
@@ -82,22 +83,18 @@ struct RangeCalendarContainer<MonthHeader: View>: View {
     
     @ViewBuilder
     private func makeDayCell(_ dayDate: Date) -> some View {
-        if !validRange.contains(dayDate) {
-            DisabledCalendarDayCell(calendar: calendar, date: dayDate)
-        } else {
-            CalendarSelectableCell {
-                cell(dayDate)
-            } onSelection: {
-                handleSelection(dayDate)
-            }
-            .accessibilityHint(Text(
-                accessibilityProvider.accessibilityHint(
-                    for: dayDate,
-                    rangeSelectionState: selectionState
-                )
-            ))
-            .accessibility(addTraits: .isButton)
+        CalendarSelectableCell {
+            cell(dayDate)
+        } onSelection: {
+            handleSelection(dayDate)
         }
+        .accessibilityHint(Text(
+            accessibilityProvider.accessibilityHint(
+                for: dayDate,
+                rangeSelectionState: selectionState
+            )
+        ))
+        .accessibility(addTraits: .isButton)
     }
     
     private func initialSelection(_ initialDateSelection: Date, matchesDate date: Date) -> Bool {
@@ -117,7 +114,8 @@ struct RangeCalendarContainer<MonthHeader: View>: View {
                 validRange: validRange,
                 dayCell: makeDayCell,
                 emptyLeadingDayCell: { makeEmptyLeadingDayCell(for: month) },
-                emptyTrailingDayCell: { makeEmptyTrailingDayCell(for: month) }
+                emptyTrailingDayCell: { makeEmptyTrailingDayCell(for: month) },
+                dayAccessoryView: dayAccessoryView
             )
         }
     }
@@ -194,6 +192,9 @@ struct RangeCalendarContainer_Previews: PreviewProvider {
             ),
             monthHeader: { month in
                 BPKText("\(Self.formatter.string(from: month))")
+            },
+            dayAccessoryView: { _ in
+                BPKText("20", style: .caption)
             }
         )
     }

--- a/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
@@ -18,12 +18,13 @@
 
 import SwiftUI
 
-struct SingleCalendarContainer<MonthHeader: View>: View {
+struct SingleCalendarContainer<MonthHeader: View, DayAccessoryView: View>: View {
     @Binding var selection: Date?
     let calendar: Calendar
     let validRange: ClosedRange<Date>
     let accessibilityProvider: SingleDayAccessibilityProvider
     @ViewBuilder let monthHeader: (_ monthDate: Date) -> MonthHeader
+    @ViewBuilder let dayAccessoryView: (Date) -> DayAccessoryView
     
     @ViewBuilder
     private func makeDayCell(_ dayDate: Date) -> some View {
@@ -51,7 +52,8 @@ struct SingleCalendarContainer<MonthHeader: View>: View {
                 validRange: validRange,
                 dayCell: makeDayCell,
                 emptyLeadingDayCell: { DefaultEmptyCalendarDayCell() },
-                emptyTrailingDayCell: { DefaultEmptyCalendarDayCell() }
+                emptyTrailingDayCell: { DefaultEmptyCalendarDayCell() },
+                dayAccessoryView: dayAccessoryView
             )
         }
     }
@@ -79,6 +81,9 @@ struct SingleCalendarContainer_Previews: PreviewProvider {
             ),
             monthHeader: { month in
                 BPKText("\(Self.formatter.string(from: month))")
+            },
+            dayAccessoryView: { _ in
+                BPKText("20", style: .caption)
             }
         )
     }

--- a/Backpack-SwiftUI/Calendar/README.md
+++ b/Backpack-SwiftUI/Calendar/README.md
@@ -64,3 +64,19 @@ BPKCalendar(
     validRange: startDate...endDate
 )
 ```
+
+## Adding an accessory view to each day
+
+An accessory view can be added to each day in the calendar. This can be used to display additional information or actions for each day.
+
+```swift
+BPKCalendar(
+    selectionType: .single(selected: $selectedDate),
+    calendar: .current,
+    validRange: startDate...endDate
+    dayAccessoryView: { date in
+        BPKText("$200 \(date)", style: .caption)
+            .foregroundColor(.accentColor)
+    }
+)
+```

--- a/Backpack-SwiftUI/Tests/Calendar/BPKCalendarTests.swift
+++ b/Backpack-SwiftUI/Tests/Calendar/BPKCalendarTests.swift
@@ -86,6 +86,27 @@ class BPKCalendarTests: XCTestCase {
         )
     }
     
+    func test_rangeSelectionCalendar_withAccessoryView() {
+        let selectionStart = Calendar.current.date(from: DateComponents(year: 2020, month: 1, day: 28))!
+        let selectionEnd = Calendar.current.date(from: DateComponents(year: 2020, month: 2, day: 5))!
+        
+        assertSnapshot(
+            BPKCalendar(
+                selectionType: .range(
+                    selection: .constant(.range(selectionStart...selectionEnd)),
+                    accessibilityConfigurations: rangeAccessibilityConfig
+                ),
+                calendar: Calendar.current,
+                validRange: validStart...validEnd,
+                dayAccessoryView: { _ in
+                    BPKIconView(.search, size: .small)
+                        .foregroundColor(.accentColor)
+                }
+            )
+            .frame(width: 320, height: 720)
+        )
+    }
+    
     func test_rangeSelectionCalendar_sameDay() {
         let selectionStart = Calendar.current.date(from: DateComponents(year: 2020, month: 2, day: 5))!
         let selectionEnd = Calendar.current.date(from: DateComponents(year: 2020, month: 2, day: 5))!

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
@@ -26,8 +26,9 @@ struct CalendarExampleRangeView: View {
     let validRange: ClosedRange<Date>
     let calendar: Calendar
     let formatter: DateFormatter
+    let showAccessoryViews: Bool
     
-    init() {
+    init(showAccessoryViews: Bool) {
         let calendar = Calendar.current
         let start = calendar.date(from: .init(year: 2023, month: 11, day: 6))!
         let end = calendar.date(from: .init(year: 2024, month: 11, day: 28))!
@@ -40,23 +41,14 @@ struct CalendarExampleRangeView: View {
         formatter.locale = calendar.locale
         formatter.timeZone = calendar.timeZone
         self.formatter = formatter
-        
+        self.showAccessoryViews = showAccessoryViews
         let selectionStart = calendar.date(from: .init(year: 2023, month: 11, day: 23))!
         let selectionEnd = calendar.date(from: .init(year: 2023, month: 12, day: 2))!
         _selection = State(initialValue: .range(selectionStart...selectionEnd))
     }
     
     var body: some View {
-        let accessibilityConfigurations = RangeAccessibilityConfigurations(
-            startSelectionHint: "Double tap to select departure date",
-            endSelectionHint: "Double tap to select return date",
-            startSelectionState: "Selected as departure date",
-            endSelectionState: "Selected as return date",
-            betweenSelectionState: "Between departure and return date",
-            startAndEndSelectionState: "Selected as both departure and return date",
-            returnDatePrompt: "Now please select a return date"
-        )
-        return VStack {
+        VStack {
             HStack {
                 BPKText("Selected inbound:", style: .caption)
                 if case .range(let selectedRange) = selection {
@@ -71,6 +63,35 @@ struct CalendarExampleRangeView: View {
                     BPKText("\(formatter.string(from: selectedRange.upperBound))", style: .caption)
                 }
             }
+            calendarView
+        }
+    }
+    
+    @ViewBuilder
+    var calendarView: some View {
+        let accessibilityConfigurations = RangeAccessibilityConfigurations(
+            startSelectionHint: "Double tap to select departure date",
+            endSelectionHint: "Double tap to select return date",
+            startSelectionState: "Selected as departure date",
+            endSelectionState: "Selected as return date",
+            betweenSelectionState: "Between departure and return date",
+            startAndEndSelectionState: "Selected as both departure and return date",
+            returnDatePrompt: "Now please select a return date"
+        )
+        if showAccessoryViews {
+            BPKCalendar(
+                selectionType: .range(
+                    selection: $selection,
+                    accessibilityConfigurations: accessibilityConfigurations
+                ),
+                calendar: calendar,
+                validRange: validRange,
+                dayAccessoryView: { _ in
+                    BPKIconView(.search, size: .small)
+                        .foregroundColor(.accentColor)
+                }
+            )
+        } else {
             BPKCalendar(
                 selectionType: .range(
                     selection: $selection,
@@ -85,6 +106,6 @@ struct CalendarExampleRangeView: View {
 
 struct CalendarExampleRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        CalendarExampleRangeView()
+        CalendarExampleRangeView(showAccessoryViews: true)
     }
 }

--- a/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
+++ b/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
@@ -77,8 +77,9 @@ struct CalendarGroupsProvider {
     func swiftUIGroups() -> [Components.Group] {
         SingleGroupProvider(
             cellDataSources: [
-                presentableCalendar("Range Selection", view: CalendarExampleRangeView()),
-                presentableCalendar("Single Selection", view: CalendarExampleSingleView())
+                presentableCalendar("Range Selection", view: CalendarExampleRangeView(showAccessoryViews: false)),
+                presentableCalendar("Single Selection", view: CalendarExampleSingleView()),
+                presentableCalendar("With Accessory Views", view: CalendarExampleRangeView(showAccessoryViews: true))
             ]
         ).groups()
     }


### PR DESCRIPTION
This pull request adds the ability to add an accessory view to each day in the calendar. The accessory view can be used to display additional information or actions for each day. The changes include adding a `dayAccessoryView` parameter to the `BPKCalendar` struct and updating the `SingleCalendarContainer` and `CalendarTypeContainerFactory` structs to support the new accessory view.