### PR TITLE
[LMN1597][BpkImageGalleryGrid] Fix switching reset scroll view position

### DIFF
--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
@@ -36,7 +36,7 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
             header
             VStack(spacing: 12) {
                 categories()
-                ScrollViewReader{ proxy in
+                ScrollViewReader { proxy in
                     TwoRowGrid(
                         items: gridImages
                     ) { item, index in
@@ -50,7 +50,7 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
                                 imageIndexInCategory = index
                                 isSlideshowPresented.toggle()
                             }
-                            .onChange(of: selectedCategoryIndex){ index in
+                            .onChange(of: selectedCategoryIndex) { index in
                                 proxy.scrollTo(0)
                             }
                     }

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
@@ -50,7 +50,7 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
                                 imageIndexInCategory = index
                                 isSlideshowPresented.toggle()
                             }
-                            .onChange(of: selectedCategoryIndex) { index in
+                            .onChange(of: selectedCategoryIndex) { _ in
                                 proxy.scrollTo(0)
                             }
                     }

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
@@ -36,21 +36,26 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
             header
             VStack(spacing: 12) {
                 categories()
-                TwoRowGrid(
-                    items: gridImages
-                ) { item, index in
-                    item.content()
-                        .aspectRatio(contentMode: .fill)
-                        .clipped()
-                        .frame(height: itemHeightInGrid)
-                        .accessibilityAddTraits(.isButton)
-                        .onTapGesture {
-                            imageTapped(selectedCategoryIndex, index)
-                            imageIndexInCategory = index
-                            isSlideshowPresented.toggle()
-                        }
+                ScrollViewReader{ proxy in
+                    TwoRowGrid(
+                        items: gridImages
+                    ) { item, index in
+                        item.content()
+                            .aspectRatio(contentMode: .fill)
+                            .clipped()
+                            .frame(height: itemHeightInGrid)
+                            .accessibilityAddTraits(.isButton)
+                            .onTapGesture {
+                                imageTapped(selectedCategoryIndex, index)
+                                imageIndexInCategory = index
+                                isSlideshowPresented.toggle()
+                            }
+                            .onChange(of: selectedCategoryIndex){ index in
+                                proxy.scrollTo(0)
+                            }
+                    }
+                    .padding(.horizontal, .lg)
                 }
-                .padding(.horizontal, .lg)
             }
             .padding(.bottom, .base)
         }


### PR DESCRIPTION
[[LMN1597]](https://skyscanner.atlassian.net/browse/LMN-1597)
Fixing the problem: When switching tab in the gallery the scroll position gets maintained. It should be reset to 0 to avoid confusion as the content between tabs is different.

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-14 at 18 26 42](https://github.com/user-attachments/assets/52453a67-f379-437b-a4fb-7a7c68c687ce)



+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `README.md`
+ [x] Tests
+ [x] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
