### PR TITLE
Add decision doc for accessibility identifiers in UI-tests

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -7,6 +7,7 @@ For decisions that apply to **all** Backpack repos, see [Backpack decisions](htt
 ## Decisions
 
 <!-- Please keep this in alphabetical order. -->
++ [UI test accessibility identifiers](./ui-test-accessibility-identifiers.md)
 + [Assume non-null by default in Objective-C](./assume-non-null-by-default.md)
 + [Components preview](./components-preview.md)
 + [Import ordering](./import-ordering.md)

--- a/decisions/ui-test-accessibility-identifiers.md
+++ b/decisions/ui-test-accessibility-identifiers.md
@@ -31,7 +31,7 @@ Based on how we expect the component to be used we can decide whether to add har
 For components that likely take a single instance in a UI, we can add hardcoded accessibility identifiers. This is because the component is likely to be used in a single place and the identifier is not likely to change. 
 
 **Example**
-- Check out `AppSearchModal
+- Check out `AppSearchModal`
 
 In other cases like `BpkNudger` where the component can be reused in multiple places, we can add dynamic accessibility identifiers. Dynamic identifiers are added to components using a specialised modifier for each identifier we want to add. This allows us to add multiple instances of the same component to a UI and have them be uniquely identifiable.
 

--- a/decisions/ui-test-accessibility-identifiers.md
+++ b/decisions/ui-test-accessibility-identifiers.md
@@ -26,20 +26,19 @@ BPKButton("Search") {
 ```
 
 ### Interactive components that are part of a larger UI
-Components that are part of a larger UI are typically composed of other components. 
-Examples of these components are `BpkAppSearchModal`, `BpkImageGalleryImageGrid`, `BpkNudger`, etc.
-
 These components contain nested interactive elements and need to be exposed to UI tests. 
 We need to add accessibility identifiers to these elements inside the component to make them testable.
 Based on how we expect the component to be used we can decide whether to 
 add hardcoded or dynamic accessibility identifiers to the interactive elements.
 
-For components that likely take a single instance in a UI like `AppSearchModal`, 
-we can add hardcoded accessibility identifiers. This is because the component is likely to be 
-used in a single place and the identifier is not likely to change.
+Examples of these components are `BpkAppSearchModal`, `BpkImageGalleryImageGrid`, `BpkNudger`, etc.
+
+For components are likely to be used only once per screen like `AppSearchModal`, 
+we can add hardcoded accessibility identifiers. When a component is used only once, 
+we don't run the risk of duplicate identifiers on the screen.
 
 In other cases like `BpkNudger` where the component can be reused in multiple places, 
-we can add dynamic accessibility identifiers. Dynamic identifiers are added to components 
+we add dynamic accessibility identifiers. Dynamic identifiers are added to components 
 using a specialised modifier for each identifier we want to add. 
 This allows us to add multiple instances of the same component to a UI and have them be uniquely identifiable.
 

--- a/decisions/ui-test-accessibility-identifiers.md
+++ b/decisions/ui-test-accessibility-identifiers.md
@@ -9,9 +9,12 @@
 ## Thinking
 
 ### Standalone components
-Standalone components are components that are not part of a larger UI. They are typically used in isolation and are not composed of other components. Examples of standalone components are `BpkButton`, `BpkText`, `BpkIcon`, etc.
+Standalone components are components that are not part of a larger UI. 
+They are typically used in isolation and are not composed of other components. 
+Examples of standalone components are `BpkButton`, `BpkText`, `BpkIcon`, etc.
 
-These components can receive accessibility identifiers from the consumer if they need to be tested in a UI test. This is because the consumer is the one that knows the context in which the component is being used.
+These components can receive accessibility identifiers from the consumer if they need to be tested in a UI test. 
+This is because the consumer is the one that knows the context in which the component is being used.
 
 **Example**
 
@@ -23,17 +26,23 @@ BPKButton("Search") {
 ```
 
 ### Components that are part of a larger UI
-Components that are part of a larger UI are typically composed of other components. Examples of these components are `BpkAppSearchModal`, `BpkImageGalleryImageGrid`, `BpkNudger`, etc.
+Components that are part of a larger UI are typically composed of other components. 
+Examples of these components are `BpkAppSearchModal`, `BpkImageGalleryImageGrid`, `BpkNudger`, etc.
 
-These components contain nested interactive elements and need to be exposed to UI tests. We need to add accessibility identifiers to these components to make them testable.
-Based on how we expect the component to be used we can decide whether to add hardcoded or dynamic accessibility identifiers.
+These components contain nested interactive elements and need to be exposed to UI tests. 
+We need to add accessibility identifiers to these elements inside the component to make them testable.
+Based on how we expect the component to be used we can decide whether to 
+add hardcoded or dynamic accessibility identifiers to the interactive elements.
 
-For components that likely take a single instance in a UI, we can add hardcoded accessibility identifiers. This is because the component is likely to be used in a single place and the identifier is not likely to change. 
+For components that likely take a single instance in a UI like `AppSearchModal`, 
+we can add hardcoded accessibility identifiers. This is because the component is likely to be 
+used in a single place and the identifier is not likely to change.
+
+In other cases like `BpkNudger` where the component can be reused in multiple places, 
+we can add dynamic accessibility identifiers. Dynamic identifiers are added to components 
+using a specialised modifier for each identifier we want to add. 
+This allows us to add multiple instances of the same component to a UI and have them be uniquely identifiable.
 
 **Example**
-- Check out `AppSearchModal`
-
-In other cases like `BpkNudger` where the component can be reused in multiple places, we can add dynamic accessibility identifiers. Dynamic identifiers are added to components using a specialised modifier for each identifier we want to add. This allows us to add multiple instances of the same component to a UI and have them be uniquely identifiable.
-
-**Example**
-- Check out `BpkNudger`
+- [Static identifiers in AppSearchModal](../Backpack-SwiftUI/AppSearchModal)
+- [Dynamic identifiers in BpkNudger](../Backpack-SwiftUI/Nudger)

--- a/decisions/ui-test-accessibility-identifiers.md
+++ b/decisions/ui-test-accessibility-identifiers.md
@@ -2,7 +2,7 @@
 
 ## Decision
 * **Standalone Components**: No accessibility identifiers for UI tests. Consumers can add them as needed.
-* **Components in Larger UIs**:
+* **Interactive components in Larger UIs**:
   * **Hardcoded identifiers** if the component is used in a single place.
   * **Dynamic identifiers** if the component is reused in multiple places.
 
@@ -25,7 +25,7 @@ BPKButton("Search") {
 .accessibilityIdentifier("search_button")
 ```
 
-### Components that are part of a larger UI
+### Interactive components that are part of a larger UI
 Components that are part of a larger UI are typically composed of other components. 
 Examples of these components are `BpkAppSearchModal`, `BpkImageGalleryImageGrid`, `BpkNudger`, etc.
 

--- a/decisions/ui-test-accessibility-identifiers.md
+++ b/decisions/ui-test-accessibility-identifiers.md
@@ -13,14 +13,27 @@ Standalone components are components that are not part of a larger UI. They are 
 
 These components can receive accessibility identifiers from the consumer if they need to be tested in a UI test. This is because the consumer is the one that knows the context in which the component is being used.
 
+**Example**
+
+```swift
+BPKButton("Search") {
+    /* Tap code */
+}
+.accessibilityIdentifier("search_button")
+```
+
 ### Components that are part of a larger UI
 Components that are part of a larger UI are typically composed of other components. Examples of these components are `BpkAppSearchModal`, `BpkImageGalleryImageGrid`, `BpkNudger`, etc.
 
 These components contain nested interactive elements and need to be exposed to UI tests. We need to add accessibility identifiers to these components to make them testable.
 Based on how we expect the component to be used we can decide whether to add hardcoded or dynamic accessibility identifiers.
 
-For components that likely take a single instance in a UI, we can add hardcoded accessibility identifiers. This is because the component is likely to be used in a single place and the identifier is not likely to change. In other cases like `BpkNudger` where the component can be reused in multiple places, we can add dynamic accessibility identifiers.
+For components that likely take a single instance in a UI, we can add hardcoded accessibility identifiers. This is because the component is likely to be used in a single place and the identifier is not likely to change. 
 
-Dynamic identifiers are added to components using a specialised modifier for each identifier we want to add. This allows us to add multiple instances of the same component to a UI and have them be uniquely identifiable.
+**Example**
+- Check out `AppSearchModal
 
+In other cases like `BpkNudger` where the component can be reused in multiple places, we can add dynamic accessibility identifiers. Dynamic identifiers are added to components using a specialised modifier for each identifier we want to add. This allows us to add multiple instances of the same component to a UI and have them be uniquely identifiable.
 
+**Example**
+- Check out `BpkNudger`

--- a/decisions/ui-test-accessibility-identifiers.md
+++ b/decisions/ui-test-accessibility-identifiers.md
@@ -1,0 +1,26 @@
+# UI test accessibility identifiers
+
+## Decision
+* **Standalone Components**: No accessibility identifiers for UI tests. Consumers can add them as needed.
+* **Components in Larger UIs**:
+  * **Hardcoded identifiers** if the component is used in a single place.
+  * **Dynamic identifiers** if the component is reused in multiple places.
+
+## Thinking
+
+### Standalone components
+Standalone components are components that are not part of a larger UI. They are typically used in isolation and are not composed of other components. Examples of standalone components are `BpkButton`, `BpkText`, `BpkIcon`, etc.
+
+These components can receive accessibility identifiers from the consumer if they need to be tested in a UI test. This is because the consumer is the one that knows the context in which the component is being used.
+
+### Components that are part of a larger UI
+Components that are part of a larger UI are typically composed of other components. Examples of these components are `BpkAppSearchModal`, `BpkImageGalleryImageGrid`, `BpkNudger`, etc.
+
+These components contain nested interactive elements and need to be exposed to UI tests. We need to add accessibility identifiers to these components to make them testable.
+Based on how we expect the component to be used we can decide whether to add hardcoded or dynamic accessibility identifiers.
+
+For components that likely take a single instance in a UI, we can add hardcoded accessibility identifiers. This is because the component is likely to be used in a single place and the identifier is not likely to change. In other cases like `BpkNudger` where the component can be reused in multiple places, we can add dynamic accessibility identifiers.
+
+Dynamic identifiers are added to components using a specialised modifier for each identifier we want to add. This allows us to add multiple instances of the same component to a UI and have them be uniquely identifiable.
+
+


### PR DESCRIPTION
# Accessibility Identifiers

Our stance on how we want to enable UI-testing of our components has been unclear in the past. This is leading to different implementations across our components.

This decision doc provides clarity on how we intend to facilitate ui-testing of our components. The full rationale and decision is in the decision doc. A TL;DR is added to the PR description below:

TL;DR
* **Standalone Components**: No accessibility identifiers for UI tests. Consumers can add them as needed.
* **Components in Larger UIs**:
  * **Hardcoded identifiers** if the component is used in a single place.
  * **Dynamic identifiers** if the component is reused in multiple places.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
