### PR TITLE
Update BPKMultiSelectChipGroup to handle dropdown type in chip items

### DIFF
--- a/Backpack-SwiftUI/ChipGroup/Classes/BPKMultiSelectChipGroup.swift
+++ b/Backpack-SwiftUI/ChipGroup/Classes/BPKMultiSelectChipGroup.swift
@@ -78,8 +78,16 @@ public struct BPKMultiSelectChipGroup: View {
     @ViewBuilder
     private func chip(for chip: ChipItem) -> some View {
         switch chip.type {
-        case .option, .dropdown:
+        case .option:
             BPKChip(
+                chip.text,
+                icon: chip.icon,
+                selected: chip.selected,
+                style: style,
+                onClick: chip.onClick
+            )
+        case .dropdown:
+            BPKDropdownChip(
                 chip.text,
                 icon: chip.icon,
                 selected: chip.selected,

--- a/Example/Backpack/SwiftUI/Components/ChipGroup/MultiSelect/ChipGroupMultipleSelectWrapExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/ChipGroup/MultiSelect/ChipGroupMultipleSelectWrapExampleView.swift
@@ -23,22 +23,26 @@ import Backpack_SwiftUI
 struct ChipGroupMultipleSelectWrapExampleView: View {
     struct ChipData {
         let name: String
+        let type: BPKMultiSelectChipGroup.ChipItem.ChipType
         var selected: Bool
     }
     
     @State var chipsData = [
-        ChipData(name: "Shenzhen", selected: true),
-        ChipData(name: "London", selected: false),
-        ChipData(name: "Edinburgh", selected: true),
-        ChipData(name: "Manchester", selected: false),
-        ChipData(name: "Belfast", selected: false),
-        ChipData(name: "Glasgow", selected: false)
+        ChipData(name: "Shenzhen", type: .option, selected: true),
+        ChipData(name: "London", type: .dropdown, selected: false),
+        ChipData(name: "Edinburgh", type: .option, selected: true),
+        ChipData(name: "Manchester", type: .dismiss, selected: false),
+        ChipData(name: "Belfast", type: .option, selected: false),
+        ChipData(name: "Glasgow", type: .option, selected: false)
     ]
     
     var chips: [BPKMultiSelectChipGroup.ChipItem] {
         chipsData.enumerated().map({ (index, chip) in
             BPKMultiSelectChipGroup.ChipItem(
-                text: chip.name, selected: chip.selected, onClick: { chipsData[index].selected.toggle() }
+                text: chip.name,
+                type: chip.type,
+                selected: chip.selected,
+                onClick: { chipsData[index].selected.toggle() }
             )
         })
     }


### PR DESCRIPTION
This pull request updates the `BPKMultiSelectChipGroup` to handle the dropdown type in chip items. Previously, the chip group only supported option type chips, but now it also supports dropdown type chips. The `BPKMultiSelectChipGroup` struct has been modified to include a new case for dropdown chips, and the `ChipGroupMultipleSelectWrapExampleView` has been updated to include dropdown chips in its `chipsData` array. This allows users to select and toggle dropdown chips in the chip group.