### PR TITLE
SONIC-2889: fix BPKCardCarousel's scrolling in right to left languages

### DIFF
--- a/Backpack-SwiftUI/CardCarousel/Classes/BPKCardCarousel.swift
+++ b/Backpack-SwiftUI/CardCarousel/Classes/BPKCardCarousel.swift
@@ -52,7 +52,8 @@ internal struct InternalCardCarousel<Content: View>: View {
     @AccessibilityFocusState private var focusOnCard: Int?
     
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    
+    @Environment(\.layoutDirection) var layoutDirection
+
     private let content: [Content]
     private let size: CGSize
     
@@ -141,7 +142,11 @@ internal struct InternalCardCarousel<Content: View>: View {
     private var dragGesture: some Gesture {
         DragGesture()
         .updating($totalDrag, body: { value, state, _ in
-            state = value.translation.width
+            if layoutDirection == .leftToRight {
+                state = value.translation.width
+            } else {
+                state = -value.translation.width
+            }
         })
         .updating($isDragging, body: { _, state, _ in
             state = true
@@ -167,9 +172,9 @@ internal struct InternalCardCarousel<Content: View>: View {
         withAnimation(dragAnimation) {
             let draggingWindow = (cardWidth / 4.0)
             if value.translation.width < -draggingWindow {
-                handleLeftSwipe()
+                layoutDirection == .leftToRight ? handleLeftSwipe() : handleRightSwipe()
             } else if value.translation.width > draggingWindow {
-                handleRightSwipe()
+                layoutDirection == .leftToRight ? handleRightSwipe() : handleLeftSwipe()
             }
         }
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Fix BPKCardCarousel's inverted scroll direction in Right to left languages 


| Before | After |
|--------|-------|
|  ![before fix](https://github.com/user-attachments/assets/aaf857e0-384f-4007-b7bc-0435b937a6ec)     |  ![after fix](https://github.com/user-attachments/assets/1dffe7da-9c7f-4538-9836-9f79e4036930)  |

## Notes
- If you want to test it locally, you will need to add arabic & build the Example project 
![Screenshot 2024-09-02 at 12 20 46](https://github.com/user-attachments/assets/19b5d72c-28b7-4442-8755-6b18b7164277)


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `README.md`
+ [x] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
