### PR TITLE
Bellagio/LMN 1706 add one more line in the BpkPrice

### DIFF
--- a/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
+++ b/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
@@ -31,6 +31,7 @@ public struct BPKPrice: View {
     private let price: String
     private let leadingText: String?
     private let previousPrice: String?
+    private let middleText: String?
     private let trailingText: String?
     private let alignment: Alignment
     private let size: Size
@@ -39,6 +40,7 @@ public struct BPKPrice: View {
         price: String,
         leadingText: String? = nil,
         previousPrice: String? = nil,
+        middleText: String? = nil,
         trailingText: String? = nil,
         alignment: Alignment = .leading,
         size: Size
@@ -46,6 +48,7 @@ public struct BPKPrice: View {
         self.price = price
         self.leadingText = leadingText
         self.previousPrice = previousPrice
+        self.middleText = middleText
         self.trailingText = trailingText
         self.alignment = alignment
         self.size = size
@@ -102,6 +105,10 @@ public struct BPKPrice: View {
     @ViewBuilder
     private var priceLabel: some View {
         BPKText(price, style: priceFontStyle)
+        if let middleText = middleText {
+            BPKText(middleText, style: accessoryFontStyle)
+                .foregroundColor(.textSecondaryColor)
+        }
         if let trailingText = trailingText {
             BPKText(trailingText, style: accessoryFontStyle)
                 .foregroundColor(.textSecondaryColor)
@@ -153,6 +160,7 @@ struct BPKPrice_Previews: PreviewProvider {
             price: "£1830",
             leadingText: "App only deal",
             previousPrice: "£2030",
+            middleText: "total",
             trailingText: "per day",
             alignment: .leading,
             size: .large

--- a/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
+++ b/Backpack-SwiftUI/Price/Classes/BPKPrice.swift
@@ -31,7 +31,6 @@ public struct BPKPrice: View {
     private let price: String
     private let leadingText: String?
     private let previousPrice: String?
-    private let middleText: String?
     private let trailingText: String?
     private let alignment: Alignment
     private let size: Size
@@ -40,7 +39,6 @@ public struct BPKPrice: View {
         price: String,
         leadingText: String? = nil,
         previousPrice: String? = nil,
-        middleText: String? = nil,
         trailingText: String? = nil,
         alignment: Alignment = .leading,
         size: Size
@@ -48,7 +46,6 @@ public struct BPKPrice: View {
         self.price = price
         self.leadingText = leadingText
         self.previousPrice = previousPrice
-        self.middleText = middleText
         self.trailingText = trailingText
         self.alignment = alignment
         self.size = size
@@ -105,10 +102,6 @@ public struct BPKPrice: View {
     @ViewBuilder
     private var priceLabel: some View {
         BPKText(price, style: priceFontStyle)
-        if let middleText = middleText {
-            BPKText(middleText, style: accessoryFontStyle)
-                .foregroundColor(.textSecondaryColor)
-        }
         if let trailingText = trailingText {
             BPKText(trailingText, style: accessoryFontStyle)
                 .foregroundColor(.textSecondaryColor)
@@ -160,7 +153,6 @@ struct BPKPrice_Previews: PreviewProvider {
             price: "£1830",
             leadingText: "App only deal",
             previousPrice: "£2030",
-            middleText: "total",
             trailingText: "per day",
             alignment: .leading,
             size: .large


### PR DESCRIPTION
Add middle text in BpkPrice, so could add per night for choosing 1 night, total for choosing more than 1 night in the price section.

<img width="224" alt="Screenshot 2024-09-05 at 10 03 11 PM" src="https://github.com/user-attachments/assets/8286eb19-aa69-463a-8d6b-6525df78b9fa"><img width="300" alt="Screenshot 2024-09-06 at 10 04 12 AM" src="https://github.com/user-attachments/assets/d0653a36-a96e-4e3b-bc75-6954e087219c">


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
