### PR TITLE
[LMN-1700] Fix the keyboard dismisses automatically while typing in App Search Modal

### DIFF
--- a/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
+++ b/Backpack-SwiftUI/AppSearchModal/Classes/AppSearchModalContentView.swift
@@ -24,7 +24,7 @@ struct AppSearchModalContentView: View {
     var body: some View {
         
         ObservableScrollView { point in
-            if point != .zero {
+            if !CGPoint.compare(point, .zero, decimalPlaces: 5) {
                 onScroll(point)
             }
         } content: {
@@ -146,5 +146,29 @@ struct AppSearchModalContentView_Previews: PreviewProvider {
     
     static func buildShortcut(with index: Int) -> BPKAppSearchModalContent.Shortcut {
         return .init(text: "Shortcut \(index + 1)", icon: .landmark, onShortcutSelected: { })
+    }
+}
+
+private extension CGFloat {
+    // Function to round a CGFloat to a specified number of decimal places
+    func roundToDecimal(places: Int) -> CGFloat {
+        let divisor = pow(10.0, CGFloat(places))
+        return (self * divisor).rounded() / divisor
+    }
+}
+
+private extension CGPoint {
+    // Function to round a CGPoint to a certain number of decimal places
+    func roundToDecimal(_ point: CGPoint, decimalPlaces: Int) -> CGPoint {
+        let roundedX = point.x.roundToDecimal(places: decimalPlaces)
+        let roundedY = point.y.roundToDecimal(places: decimalPlaces)
+        return CGPoint(x: roundedX, y: roundedY)
+    }
+    
+    // Function to compare two CGPoint values with precision
+    static func compare(_ lhs: CGPoint, _ rhs: CGPoint, decimalPlaces: Int) -> Bool {
+        let roundedPoint1 = lhs.roundToDecimal(lhs, decimalPlaces: decimalPlaces)
+        let roundedPoint2 = rhs.roundToDecimal(rhs, decimalPlaces: decimalPlaces)
+        return roundedPoint1 == roundedPoint2
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

https://skyscanner.atlassian.net/browse/LMN-1700

- We found that the scroll position of content of App Search Modal changes which results in the keyboard dismiss as unexpected.
- To resolve it, add extensions to `CGFloat` and `CGPoint` to compare the 2 points in a certain number of decimal places.

### Before

https://github.com/user-attachments/assets/396d6c34-f137-4749-9d52-8b56b72b343d

### After

https://github.com/user-attachments/assets/d838496c-98be-4ea8-803a-1c34e997ea9a

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
