### PR TITLE
Add the missing identifier to SearchInputSummary

### DIFF
--- a/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
+++ b/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
@@ -38,6 +38,7 @@ public struct BPKSearchInputSummary: View {
     private let placeholder: String
     private let inputPrefix: InputPrefix?
     private var style: Style = .default
+    private let accessibilityIdentifier: String
     private var customAccessibilityValue: String?
     private let readOnly: Bool
     private let clearAction: ClearAction
@@ -57,6 +58,7 @@ public struct BPKSearchInputSummary: View {
         inputPrefix: InputPrefix? = nil,
         clearAction: ClearAction,
         readOnly: Bool = false,
+        accessibilityIdentifier: String = "search_field",
         customAccessibilityValue: String? = nil,
         _ text: Binding<String>
     ) {
@@ -64,6 +66,7 @@ public struct BPKSearchInputSummary: View {
         self.inputPrefix = inputPrefix
         self.clearAction = clearAction
         self.readOnly = readOnly
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.customAccessibilityValue = customAccessibilityValue
         self._text = text
     }
@@ -82,6 +85,7 @@ public struct BPKSearchInputSummary: View {
                 .accessibilityValue(customAccessibilityValue ?? text)
                 .accessibilityLabel(placeholder)
                 .accessibilityAddTraits(readOnly ? [] : .isSearchField)
+                .accessibilityIdentifier(accessibilityIdentifier)
                 .focused($focused)
             accessory
         }


### PR DESCRIPTION
An accessibility identifier required for the automated test has been removed in the following PR:
https://github.com/Skyscanner/backpack-ios/pull/2066/files#diff-0df197ad1c29c184f5dab226161c3658be5fdfffc53bb83d23529f1863aa1300L68

This PR purpose is to bring it back and fix the testing pipeline.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
