### PR TITLE
[Lumen] LMN-1740: move geometry reader inside the component

### DIFF
--- a/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
+++ b/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
@@ -44,15 +44,15 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
         @Binding var currentIndex: Int
         
         var body: some View {
-            GeometryReader { proxy in
-                VStack(spacing: .xl) {
-                    ImageGalleryHeader(
-                        closeAccessibilityLabel: closeAccessibilityLabel,
-                        onCloseTapped: onCloseTapped
-                    )
-                    .padding([.leading, .top], .base)
-                    
-                    ZStack(alignment: .bottom) {
+            VStack(spacing: .xl) {
+                ImageGalleryHeader(
+                    closeAccessibilityLabel: closeAccessibilityLabel,
+                    onCloseTapped: onCloseTapped
+                )
+                .padding([.leading, .top], .base)
+                
+                ZStack(alignment: .bottom) {
+                    GeometryReader { proxy in
                         InternalCarouselWrapper(
                             images: images.map {
                                 $0.content()
@@ -62,16 +62,15 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
                             currentIndex: $currentIndex
                         )
                         .frame(maxWidth: 400, maxHeight: 400)
-                        BPKBadge("\(currentIndex + 1)/\(images.count)")
-                            .badgeStyle(.strong)
-                            .padding(.bottom, 20)
                     }
-                    
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityHidden(true)
-                    
-                    footer
+                    BPKBadge("\(currentIndex + 1)/\(images.count)")
+                        .badgeStyle(.strong)
+                        .padding(.bottom, 20)
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityHidden(true)
+                
+                footer
             }
             .background(Color(.canvasContrastColor))
         }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Recently, we found that the review gallery failed to show image in iOS 18 devices, here we try to resolve it

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/4402c123-4306-45c9-b0d0-2de441ffc3c0) | ![image](https://github.com/user-attachments/assets/626e80ef-b123-4b5c-b4b5-52ea6f40db53) |

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
