### PR TITLE
[LMN-1746] When user selects an image incorrect picture is brought up.

### DIFF
--- a/Backpack-SwiftUI/Utils/Classes/TwoRowGrid.swift
+++ b/Backpack-SwiftUI/Utils/Classes/TwoRowGrid.swift
@@ -68,11 +68,13 @@ struct TwoRowGrid<Item, ItemView: View>: View {
     
     private func column(proxy: GeometryProxy, columnIndex index: Int, rowIndex: Int) -> some View {
         let itemTuple = items[rowIndex][index]
+        let shape = RoundedRectangle(cornerRadius: .md)
         return itemView(itemTuple.0, itemTuple.1)
             .if(rowIndex % 2 != 0) {
                 $0.frame(width: (proxy.size.width / 2) - (spacing.value / 2))
             }
-            .clipShape(RoundedRectangle(cornerRadius: .md))
+            .clipShape(shape)
+            .contentShape(shape)
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

LMN-1746

| Before | After |
| -- | -- |
| ![backpack-trimmed mp4](https://github.com/user-attachments/assets/976a14bf-e177-4387-8397-388cab9093f0) | ![backpack-fixed mp4](https://github.com/user-attachments/assets/221adad1-5fcf-423f-9d5c-5217591ba495) |

When tapping through the last 4 images in sequence, we can see: tapping the first image triggered an incorrect slideshow modal, before this fix applied.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
