### PR TITLE
Fix: BPKChip goes beyond its parent when the text is too long

### DIFF
--- a/Backpack-SwiftUI/Chip/Classes/ChipButtonStyle.swift
+++ b/Backpack-SwiftUI/Chip/Classes/ChipButtonStyle.swift
@@ -26,7 +26,7 @@ struct ChipButtonStyle: ButtonStyle {
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
             .frame(minHeight: .xl)
-            .fixedSize(horizontal: true, vertical: false)
+            .lineLimit(1)
             .background(backgroundColor(configuration.isPressed))
             .foregroundColor(foregroundColor(configuration.isPressed))
             .clipShape(RoundedRectangle(cornerRadius: .sm))

--- a/Backpack-SwiftUI/FlowStackView/Classes/BPKFlowStackView.swift
+++ b/Backpack-SwiftUI/FlowStackView/Classes/BPKFlowStackView.swift
@@ -92,8 +92,10 @@ public struct BPKFlowStackView<Data: Collection, Content: View>: View where Data
             let doesNotFitInCurrentRow = elementSize.width + spacing.width > remainingWidth
             
             if doesNotFitInCurrentRow { // new row
-                remainingWidth = availableWidth
-                currentRow += 1
+                if rows.indices.contains(currentRow) {
+                    currentRow += 1
+                    remainingWidth = availableWidth
+                }
                 rows.append([Item(id: currentIndex, data: element)])
             } else { // existing row
                 if !rows.indices.contains(currentRow) {
@@ -125,7 +127,10 @@ struct BPKFlowStackView_Previews: PreviewProvider {
     
     @ViewBuilder
     static func makeBadge(index: Int) -> some View {
-        BPKBadge("Hello" + Array(repeating: "👋", count: index % 5).joined())
-            .badgeStyle(.brand)
+        if index == 0 {
+            BPKChip(Array(repeating: "Hello", count: 15).joined(separator: " ")) { }
+        } else {
+            BPKChip("Hello" + Array(repeating: "👋", count: index % 5).joined()) { }
+        }
     }
 }


### PR DESCRIPTION
**Changes**

* Use `.lineLimit(1)` instead of `.fixedSize(horizontal: true, vertical: false)` in `ChipButtonStyle` so that `BPKChip` will not go beyond its parent due to too long text.
* Fix bug on `BPKFlowStackView` when computing Rows

**Preview**
| Before | After |
| ------- | ----- |
| ![](https://github.com/user-attachments/assets/071d4c8a-c159-4bdc-8554-79c541a5871d) | ![](https://github.com/user-attachments/assets/cb665e03-0ec6-4360-8697-71a31cfff656) |

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
