### PR TITLE
[DON-962] Initial scroll to month in Backpack Calendar

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
@@ -29,6 +29,7 @@ import SwiftUI
 ///     the `Calendar` struct in Swift.
 ///   - validRange: The range of dates that the calendar should allow the user to select.
 ///     This is specified as a`ClosedRange<Date>`.
+///   - initialMonthScroll: The initial scrolling to the month using `MonthScroll`
 ///
 /// The `BPKCalendar` view also allows you to specify an accessory action. This is a closure that takes a string and
 ///     a date, and is called when the user interacts with an accessory in the calendar.
@@ -36,6 +37,7 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
     let calendar: Calendar
     let selectionType: CalendarSelectionType
     let validRange: ClosedRange<Date>
+    private var initialMonthScroll: MonthScroll?
     private var accessoryAction: CalendarMonthAccessoryAction?
     private let monthHeaderDateFormatter: DateFormatter
 
@@ -46,6 +48,7 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
         selectionType: CalendarSelectionType,
         calendar: Calendar,
         validRange: ClosedRange<Date>,
+        initialMonthScroll: MonthScroll? = nil,
         dayAccessoryView: @escaping (Date) -> DayAccessoryView = { _ in EmptyView() }
     ) {
         self.dayAccessoryView = dayAccessoryView
@@ -53,6 +56,7 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
         self.validRange = validRange
         self.calendar = calendar
         self.selectionType = selectionType
+        self.initialMonthScroll = initialMonthScroll
 
         monthHeaderDateFormatter = DateFormatter()
         monthHeaderDateFormatter.timeZone = calendar.timeZone
@@ -72,6 +76,7 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
                         selectionType: selectionType,
                         calendar: calendar,
                         validRange: validRange,
+                        monthScroll: initialMonthScroll,
                         monthHeader: { monthDate in
                             CalendarMonthHeader(
                                 monthDate: monthDate,

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
@@ -51,6 +51,7 @@ struct CalendarContainer<MonthContent: View>: View {
 
     private func scrollIfNeeded(scrollProxy: ScrollViewProxy) {
         guard !hasScrolledToItem, let monthScroll else { return }
+        hasScrolledToItem = true
         let scrollAction = {
             scrollProxy.scrollTo(
                 monthScroll.scrollId,

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
@@ -45,8 +45,10 @@ struct CalendarContainer<MonthContent: View>: View {
         }
     }
 
+    /// Generates a unique identifier for a given `Date` using the "yyyy-MM" format.
+    /// - Example: For a date of December 25, 2024, this method returns `"2024-12"`.
     private func scrollId(date: Date) -> String? {
-        return monthScroll?.generateIdFor(date: date)
+        return monthScroll?.formatter.string(from: date)
     }
 
     private func scrollIfNeeded(scrollProxy: ScrollViewProxy) {

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
@@ -50,14 +50,15 @@ struct CalendarContainer<MonthContent: View>: View {
     }
 
     private func scrollIfNeeded(scrollProxy: ScrollViewProxy) {
-        guard !hasScrolledToItem, let id = monthScroll?.scrollId else { return }
-        hasScrolledToItem = true
-        withAnimation {
+        guard !hasScrolledToItem, let monthScroll else { return }
+        let scrollAction = {
             scrollProxy.scrollTo(
-                id,
-                anchor: UnitPoint(x: 0, y: 0.1) // slightly lower than top
+                monthScroll.scrollId,
+                anchor: monthScroll.anchor
             )
         }
+
+        monthScroll.animated ? withAnimation { scrollAction() } : scrollAction()
     }
 
     private var monthsToShow: Int {

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
@@ -31,7 +31,12 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
         formatter.dateStyle = .full
         return formatter
     }
-    
+
+    private var monthScroll: MonthScroll? {
+        guard let date = selectionType.startDateIfAny else { return nil }
+        return MonthScroll(monthToScroll: date)
+    }
+
     var body: some View {
         switch selectionType {
         case .range(let selection, let accessibilityConfigurations):
@@ -43,6 +48,7 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
                     accessibilityConfigurations: accessibilityConfigurations,
                     dateFormatter: accessibilityDateFormatter
                 ),
+                monthScroll: monthScroll,
                 monthHeader: monthHeader,
                 dayAccessoryView: dayAccessoryView
             )
@@ -55,6 +61,7 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
                     accessibilityConfigurations: accessibilityConfigurations,
                     dateFormatter: accessibilityDateFormatter
                 ),
+                monthScroll: monthScroll,
                 monthHeader: monthHeader,
                 dayAccessoryView: dayAccessoryView
             )

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
@@ -22,6 +22,7 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
     let selectionType: CalendarSelectionType
     let calendar: Calendar
     let validRange: ClosedRange<Date>
+    let monthScroll: MonthScroll?
     @ViewBuilder let monthHeader: (_ monthDate: Date) -> MonthHeader
     @ViewBuilder let dayAccessoryView: (Date) -> DayAccessoryView
     
@@ -30,11 +31,6 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
         formatter.locale = calendar.locale
         formatter.dateStyle = .full
         return formatter
-    }
-
-    private var monthScroll: MonthScroll? {
-        guard let date = selectionType.startDateIfAny else { return nil }
-        return MonthScroll(monthToScroll: date)
     }
 
     var body: some View {

--- a/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
@@ -29,9 +29,9 @@ public struct MonthScroll {
     /// Whether to animate the change in scroll position or not
     let animated: Bool
 
-    /// Static `DateFormatter` to format dates as "yyyy-MM" strings, used for generating `scrollId`s.
+    /// The `DateFormatter` to format dates as "yyyy-MM" strings, used for generating `scrollId`s.
     /// - Example: For a date of December 25, 2024, it produces `"2024-12"`.
-    private let formatter: DateFormatter
+    let formatter: DateFormatter
 
     // MARK: - Initialiser
 
@@ -44,15 +44,5 @@ public struct MonthScroll {
         self.anchor = anchor
         self.animated = animated
         self.formatter = dateFormatter
-    }
-
-    // MARK: - Public Methods
-
-    /// Generates a unique identifier for a given `Date` using the "yyyy-MM" format.
-    /// - Parameter date: The date to format.
-    /// - Returns: A string representing the date in "yyyy-MM" format.
-    /// - Example: For a date of December 25, 2024, this method returns `"2024-12"`.
-    func generateIdFor(date: Date) -> String {
-        formatter.string(from: date)
     }
 }

--- a/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
@@ -21,36 +21,29 @@ import SwiftUI
 /// Represents a scrollable month with a unique identifier and anchor point for positioning.
 public struct MonthScroll {
     /// Unique identifier for the scroll item.
-    var scrollId: String
+    let scrollId: String
 
     /// Anchor point for the scroll position, defaulting to `.top`.
-    var anchor: UnitPoint
+    let anchor: UnitPoint
 
     /// Whether to animate the change in scroll position or not
-    var animated: Bool
+    let animated: Bool
 
     /// Static `DateFormatter` to format dates as "yyyy-MM" strings, used for generating `scrollId`s.
     /// - Example: For a date of December 25, 2024, it produces `"2024-12"`.
-    private static let formatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM"
-        return dateFormatter
-    }()
+    private let formatter: DateFormatter
 
-    // MARK: - Initialisers
-
-    /// Initialises `MonthScroll` with a specified `scrollId` and `anchor`.
-    public init(scrollId: String, anchor: UnitPoint = .top, animated: Bool = false) {
-        self.scrollId = scrollId
-        self.anchor = anchor
-        self.animated = animated
-    }
+    // MARK: - Initialiser
 
     /// Initialises `MonthScroll` using a `Date` to generate the `scrollId`, with `anchor`.
     public init(monthToScroll: Date, anchor: UnitPoint = .top, animated: Bool = false) {
-        self.scrollId = MonthScroll.formatter.string(from: monthToScroll)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM"
+
+        self.scrollId = dateFormatter.string(from: monthToScroll)
         self.anchor = anchor
         self.animated = animated
+        self.formatter = dateFormatter
     }
 
     // MARK: - Public Methods
@@ -60,6 +53,6 @@ public struct MonthScroll {
     /// - Returns: A string representing the date in "yyyy-MM" format.
     /// - Example: For a date of December 25, 2024, this method returns `"2024-12"`.
     func generateIdFor(date: Date) -> String {
-        MonthScroll.formatter.string(from: date)
+        formatter.string(from: date)
     }
 }

--- a/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
@@ -18,51 +18,48 @@
 
 import SwiftUI
 
-struct MonthScroll {
-    var scrollId: String?
-    let formatter: DateFormatter
+/// Represents a scrollable month with a unique identifier and anchor point for positioning.
+public struct MonthScroll {
+    /// Unique identifier for the scroll item.
+    var scrollId: String
 
-    init(scrollId: String? = nil) {
-        self.scrollId = scrollId
+    /// Anchor point for the scroll position, defaulting to `.top`.
+    var anchor: UnitPoint
 
+    /// Whether to animate the change in scroll position or not
+    var animated: Bool
+
+    /// Static `DateFormatter` to format dates as "yyyy-MM" strings, used for generating `scrollId`s.
+    /// - Example: For a date of December 25, 2024, it produces `"2024-12"`.
+    private static let formatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM"
-        self.formatter = dateFormatter
+        return dateFormatter
+    }()
+
+    // MARK: - Initialisers
+
+    /// Initialises `MonthScroll` with a specified `scrollId` and `anchor`.
+    public init(scrollId: String, anchor: UnitPoint = .top, animated: Bool = false) {
+        self.scrollId = scrollId
+        self.anchor = anchor
+        self.animated = animated
     }
 
-    init(monthToScroll: Date) {
-        self.init()
-        self.scrollId = formatter.string(from: monthToScroll)
+    /// Initialises `MonthScroll` using a `Date` to generate the `scrollId`, with `anchor`.
+    public init(monthToScroll: Date, anchor: UnitPoint = .top, animated: Bool = false) {
+        self.scrollId = MonthScroll.formatter.string(from: monthToScroll)
+        self.anchor = anchor
+        self.animated = animated
     }
 
+    // MARK: - Public Methods
+
+    /// Generates a unique identifier for a given `Date` using the "yyyy-MM" format.
+    /// - Parameter date: The date to format.
+    /// - Returns: A string representing the date in "yyyy-MM" format.
+    /// - Example: For a date of December 25, 2024, this method returns `"2024-12"`.
     func generateIdFor(date: Date) -> String {
-        formatter.string(from: date)
-    }
-}
-
-// MARK: - Start Date for scrolling
-
-extension CalendarSelectionType {
-    var startDateIfAny: Date? {
-        switch self {
-        case .range(let selection, _):
-            if let rangeState = selection.wrappedValue {
-                return rangeState.startDateIfAny
-            }
-            return nil
-        case .single(let selection, _):
-            return selection.wrappedValue
-        }
-    }
-}
-
-extension CalendarRangeSelectionState {
-    var startDateIfAny: Date? {
-        switch self {
-        case .intermediate(let startDate):
-            return startDate
-        case .range(let selectedDateRange):
-            return selectedDateRange.lowerBound
-        }
+        MonthScroll.formatter.string(from: date)
     }
 }

--- a/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
@@ -1,0 +1,68 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+
+struct MonthScroll {
+    var scrollId: String?
+    let formatter: DateFormatter
+
+    init(scrollId: String? = nil) {
+        self.scrollId = scrollId
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM"
+        self.formatter = dateFormatter
+    }
+
+    init(monthToScroll: Date) {
+        self.init()
+        self.scrollId = formatter.string(from: monthToScroll)
+    }
+
+    func generateIdFor(date: Date) -> String {
+        formatter.string(from: date)
+    }
+}
+
+// MARK: - Start Date for scrolling
+
+extension CalendarSelectionType {
+    var startDateIfAny: Date? {
+        switch self {
+        case .range(let selection, _):
+            if let rangeState = selection.wrappedValue {
+                return rangeState.startDateIfAny
+            }
+            return nil
+        case .single(let selection, _):
+            return selection.wrappedValue
+        }
+    }
+}
+
+extension CalendarRangeSelectionState {
+    var startDateIfAny: Date? {
+        switch self {
+        case .intermediate(let startDate):
+            return startDate
+        case .range(let selectedDateRange):
+            return selectedDateRange.lowerBound
+        }
+    }
+}

--- a/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
@@ -175,7 +175,6 @@ struct RangeCalendarContainer_Previews: PreviewProvider {
         
         let startSelection = calendar.date(from: .init(year: 2023, month: 10, day: 30))!
         let endSelection = calendar.date(from: .init(year: 2023, month: 11, day: 10))!
-        let monthScroll = MonthScroll(monthToScroll: start)
 
         RangeCalendarContainer(
             selectionState: .constant(.range(startSelection...endSelection)),
@@ -193,7 +192,7 @@ struct RangeCalendarContainer_Previews: PreviewProvider {
                 ),
                 dateFormatter: Self.formatter
             ),
-            monthScroll: monthScroll,
+            monthScroll: nil,
             monthHeader: { month in
                 BPKText("\(Self.formatter.string(from: month))")
             },

--- a/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
@@ -23,6 +23,7 @@ struct RangeCalendarContainer<MonthHeader: View, DayAccessoryView: View>: View {
     let calendar: Calendar
     let validRange: ClosedRange<Date>
     let accessibilityProvider: RangeDayAccessibilityProvider
+    let monthScroll: MonthScroll?
     @ViewBuilder let monthHeader: (_ monthDate: Date) -> MonthHeader
     @ViewBuilder let dayAccessoryView: (Date) -> DayAccessoryView
     
@@ -105,7 +106,8 @@ struct RangeCalendarContainer<MonthHeader: View, DayAccessoryView: View>: View {
     var body: some View {
         CalendarContainer(
             calendar: calendar,
-            validRange: validRange
+            validRange: validRange,
+            monthScroll: monthScroll
         ) { month in
             monthHeader(month)
             CalendarMonthGrid(
@@ -173,7 +175,8 @@ struct RangeCalendarContainer_Previews: PreviewProvider {
         
         let startSelection = calendar.date(from: .init(year: 2023, month: 10, day: 30))!
         let endSelection = calendar.date(from: .init(year: 2023, month: 11, day: 10))!
-        
+        let monthScroll = MonthScroll(monthToScroll: start)
+
         RangeCalendarContainer(
             selectionState: .constant(.range(startSelection...endSelection)),
             calendar: calendar,
@@ -190,6 +193,7 @@ struct RangeCalendarContainer_Previews: PreviewProvider {
                 ),
                 dateFormatter: Self.formatter
             ),
+            monthScroll: monthScroll,
             monthHeader: { month in
                 BPKText("\(Self.formatter.string(from: month))")
             },

--- a/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
@@ -75,7 +75,6 @@ struct SingleCalendarContainer_Previews: PreviewProvider {
         let calendar = Calendar.current
         let start = calendar.date(from: .init(year: 2023, month: 10, day: 30))!
         let end = calendar.date(from: .init(year: 2025, month: 12, day: 25))!
-        let monthScroll = MonthScroll(monthToScroll: start)
 
         SingleCalendarContainer(
             selection: .constant(calendar.date(from: .init(year: 2023, month: 11, day: 10))!),
@@ -85,7 +84,7 @@ struct SingleCalendarContainer_Previews: PreviewProvider {
                 accessibilityConfigurations: .init(selectionHint: ""),
                 dateFormatter: Self.formatter
             ),
-            monthScroll: monthScroll,
+            monthScroll: nil,
             monthHeader: { month in
                 BPKText("\(Self.formatter.string(from: month))")
             },

--- a/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
@@ -23,6 +23,7 @@ struct SingleCalendarContainer<MonthHeader: View, DayAccessoryView: View>: View 
     let calendar: Calendar
     let validRange: ClosedRange<Date>
     let accessibilityProvider: SingleDayAccessibilityProvider
+    let monthScroll: MonthScroll?
     @ViewBuilder let monthHeader: (_ monthDate: Date) -> MonthHeader
     @ViewBuilder let dayAccessoryView: (Date) -> DayAccessoryView
     
@@ -44,7 +45,11 @@ struct SingleCalendarContainer<MonthHeader: View, DayAccessoryView: View>: View 
     }
     
     var body: some View {
-        CalendarContainer(calendar: calendar, validRange: validRange) { month in
+        CalendarContainer(
+            calendar: calendar,
+            validRange: validRange,
+            monthScroll: monthScroll
+        ) { month in
             monthHeader(month)
             CalendarMonthGrid(
                 monthDate: month,
@@ -70,7 +75,8 @@ struct SingleCalendarContainer_Previews: PreviewProvider {
         let calendar = Calendar.current
         let start = calendar.date(from: .init(year: 2023, month: 10, day: 30))!
         let end = calendar.date(from: .init(year: 2025, month: 12, day: 25))!
-        
+        let monthScroll = MonthScroll(monthToScroll: start)
+
         SingleCalendarContainer(
             selection: .constant(calendar.date(from: .init(year: 2023, month: 11, day: 10))!),
             calendar: calendar,
@@ -79,6 +85,7 @@ struct SingleCalendarContainer_Previews: PreviewProvider {
                 accessibilityConfigurations: .init(selectionHint: ""),
                 dateFormatter: Self.formatter
             ),
+            monthScroll: monthScroll,
             monthHeader: { month in
                 BPKText("\(Self.formatter.string(from: month))")
             },

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
@@ -22,13 +22,15 @@ import Backpack_SwiftUI
 
 struct CalendarExampleRangeView: View {
     @State var selection: CalendarRangeSelectionState?
-    
+    private var monthScroll: MonthScroll?
+
     let validRange: ClosedRange<Date>
     let calendar: Calendar
     let formatter: DateFormatter
     let showAccessoryViews: Bool
-    
-    init(showAccessoryViews: Bool) {
+    let makeInitialMonthScroll: Bool
+
+    init(showAccessoryViews: Bool, makeInitialMonthScroll: Bool = false) {
         let calendar = Calendar.current
         let start = calendar.date(from: .init(year: 2023, month: 11, day: 6))!
         let end = calendar.date(from: .init(year: 2024, month: 11, day: 28))!
@@ -42,8 +44,16 @@ struct CalendarExampleRangeView: View {
         formatter.timeZone = calendar.timeZone
         self.formatter = formatter
         self.showAccessoryViews = showAccessoryViews
-        let selectionStart = calendar.date(from: .init(year: 2023, month: 11, day: 23))!
-        let selectionEnd = calendar.date(from: .init(year: 2023, month: 12, day: 2))!
+        self.makeInitialMonthScroll = makeInitialMonthScroll
+        var selectionStart = calendar.date(from: .init(year: 2023, month: 11, day: 23))!
+        var selectionEnd = calendar.date(from: .init(year: 2023, month: 12, day: 2))!
+
+        if makeInitialMonthScroll {
+            selectionStart = calendar.date(from: .init(year: 2024, month: 2, day: 5))!
+            selectionEnd = calendar.date(from: .init(year: 2024, month: 2, day: 10))!
+            self.monthScroll = .init(monthToScroll: selectionStart)
+        }
+
         _selection = State(initialValue: .range(selectionStart...selectionEnd))
     }
     
@@ -98,7 +108,8 @@ struct CalendarExampleRangeView: View {
                     accessibilityConfigurations: accessibilityConfigurations
                 ),
                 calendar: calendar,
-                validRange: validRange
+                validRange: validRange,
+                initialMonthScroll: monthScroll
             )
         }
     }
@@ -106,6 +117,6 @@ struct CalendarExampleRangeView: View {
 
 struct CalendarExampleRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        CalendarExampleRangeView(showAccessoryViews: true)
+        CalendarExampleRangeView(showAccessoryViews: true, makeInitialMonthScroll: false)
     }
 }

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
@@ -22,13 +22,12 @@ import Backpack_SwiftUI
 
 struct CalendarExampleRangeView: View {
     @State var selection: CalendarRangeSelectionState?
-    private var monthScroll: MonthScroll?
+    private let monthScroll: MonthScroll?
 
     let validRange: ClosedRange<Date>
     let calendar: Calendar
     let formatter: DateFormatter
     let showAccessoryViews: Bool
-    let makeInitialMonthScroll: Bool
 
     init(showAccessoryViews: Bool, makeInitialMonthScroll: Bool = false) {
         let calendar = Calendar.current
@@ -44,7 +43,6 @@ struct CalendarExampleRangeView: View {
         formatter.timeZone = calendar.timeZone
         self.formatter = formatter
         self.showAccessoryViews = showAccessoryViews
-        self.makeInitialMonthScroll = makeInitialMonthScroll
         var selectionStart = calendar.date(from: .init(year: 2023, month: 11, day: 23))!
         var selectionEnd = calendar.date(from: .init(year: 2023, month: 12, day: 2))!
 
@@ -52,6 +50,8 @@ struct CalendarExampleRangeView: View {
             selectionStart = calendar.date(from: .init(year: 2024, month: 2, day: 5))!
             selectionEnd = calendar.date(from: .init(year: 2024, month: 2, day: 10))!
             self.monthScroll = .init(monthToScroll: selectionStart)
+        } else {
+            self.monthScroll = nil
         }
 
         _selection = State(initialValue: .range(selectionStart...selectionEnd))

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleRangeView.swift
@@ -117,6 +117,6 @@ struct CalendarExampleRangeView: View {
 
 struct CalendarExampleRangeView_Previews: PreviewProvider {
     static var previews: some View {
-        CalendarExampleRangeView(showAccessoryViews: true, makeInitialMonthScroll: false)
+        CalendarExampleRangeView(showAccessoryViews: true)
     }
 }

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleSingleView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleSingleView.swift
@@ -22,12 +22,13 @@ import Backpack_SwiftUI
 
 struct CalendarExampleSingleView: View {
     @State var selectedDate: Date?
-    
+    private var monthScroll: MonthScroll?
+
     let validRange: ClosedRange<Date>
     let calendar: Calendar
     let formatter: DateFormatter
-    
-    init() {
+
+    init(makeInitialMonthScrollWithAnimation: Bool = false) {
         let calendar = Calendar.current
         let start = calendar.date(from: .init(year: 2023, month: 11, day: 6))!
         let end = calendar.date(from: .init(year: 2024, month: 11, day: 28))!
@@ -40,8 +41,15 @@ struct CalendarExampleSingleView: View {
         formatter.locale = calendar.locale
         formatter.timeZone = calendar.timeZone
         self.formatter = formatter
-        
-        _selectedDate = State(initialValue: calendar.date(from: .init(year: 2023, month: 11, day: 15))!)
+
+        var date = calendar.date(from: .init(year: 2023, month: 11, day: 15))!
+
+        if makeInitialMonthScrollWithAnimation {
+            date = calendar.date(from: .init(year: 2024, month: 04, day: 15))!
+            self.monthScroll = .init(monthToScroll: date, animated: true)
+        }
+
+        _selectedDate = State(initialValue: date)
     }
     
     var body: some View {
@@ -60,7 +68,8 @@ struct CalendarExampleSingleView: View {
                     )
                 ),
                 calendar: calendar,
-                validRange: validRange
+                validRange: validRange,
+                initialMonthScroll: monthScroll
             )
         }
     }

--- a/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
+++ b/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
@@ -79,7 +79,15 @@ struct CalendarGroupsProvider {
             cellDataSources: [
                 presentableCalendar("Range Selection", view: CalendarExampleRangeView(showAccessoryViews: false)),
                 presentableCalendar("Single Selection", view: CalendarExampleSingleView()),
-                presentableCalendar("With Accessory Views", view: CalendarExampleRangeView(showAccessoryViews: true))
+                presentableCalendar("With Accessory Views", view: CalendarExampleRangeView(showAccessoryViews: true)),
+                presentableCalendar(
+                    "With Initial Month Scrolling",
+                    view: CalendarExampleRangeView(showAccessoryViews: false, makeInitialMonthScroll: true)
+                ),
+                presentableCalendar(
+                    "With Initial Month Scrolling and animation",
+                    view: CalendarExampleSingleView(makeInitialMonthScrollWithAnimation: true)
+                )
             ]
         ).groups()
     }


### PR DESCRIPTION
This PR is about giving the capability to have Initial scroll in Calendar based on the product alignment.

### Demo
https://github.com/user-attachments/assets/ddf964e4-aa5a-45f4-8abd-49be6766dae3



+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
