### PR TITLE
Remove app center dependency

### DIFF
--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -83,7 +83,7 @@
 		53C6622929EA0DAB00BF1A62 /* AttributedTextExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C6620F29EA0DAB00BF1A62 /* AttributedTextExampleView.swift */; };
 		53C7F0B92A4C615D003A8740 /* ChipGroupSingleSelectRailExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C7F0B52A4C615D003A8740 /* ChipGroupSingleSelectRailExampleView.swift */; };
 		53C7F0BA2A4C615D003A8740 /* ChipGroupSingleSelectWrapExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C7F0B62A4C615D003A8740 /* ChipGroupSingleSelectWrapExampleView.swift */; };
-		53D4614E29E574EB0061C222 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		53D4614E29E574EB0061C222 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		53D6396F2A7D46ED007EF376 /* MapMarkerExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D6396E2A7D46ED007EF376 /* MapMarkerExampleView.swift */; };
 		53D7FBB527F715AF00DEE588 /* UIWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D7FBB427F715AF00DEE588 /* UIWindowFactory.swift */; };
 		53E075A527FC780C0033147C /* NavBarGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E075A427FC780C0033147C /* NavBarGroups.swift */; };
@@ -1647,7 +1647,6 @@
 				6003F588195388D20070C39A /* Resources */,
 				84EFE62BE1534CD46CAFBDBF /* [CP] Embed Pods Frameworks */,
 				D68AF8FA2174CB9C00BA743D /* Run Script */,
-				EFF4B5AAADA028B292046E74 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1834,21 +1833,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint  --strict\n";
 		};
-		EFF4B5AAADA028B292046E74 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Backpack-Native/Pods-Backpack-Native-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1953,7 +1937,7 @@
 				5390DB612909940700F0F790 /* ColorTokensViewController.swift in Sources */,
 				794E1FF8280CF63100B965FF /* RadiusTokensView.swift in Sources */,
 				53B6DB6A27FC73A90042B7C0 /* LabelGroups.swift in Sources */,
-				53D4614E29E574EB0061C222 /* (null) in Sources */,
+				53D4614E29E574EB0061C222 /* BuildFile in Sources */,
 				53C6621329EA0DAB00BF1A62 /* SpinnerExampleView.swift in Sources */,
 				53BAC3F12A71415800236CC9 /* SectionHeaderGroups.swift in Sources */,
 				53C6622429EA0DAB00BF1A62 /* ButtonsPlaygroundView.swift in Sources */,

--- a/Example/Backpack/AppDelegate.swift
+++ b/Example/Backpack/AppDelegate.swift
@@ -17,17 +17,12 @@
  */
 
 import UIKit
-import AppCenter
-import AppCenterDistribute
-import AppCenterAnalytics
-import AppCenterCrashes
 
 import Backpack
 import Backpack_SwiftUI
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    // swiftlint:disable indentation_width
     private func setupAppearance() {
         UINavigationBar.appearance().tintColor = BPKColor.textPrimaryColor
         BPKAppearance.apply()
@@ -51,8 +46,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         setupRelativeFont()
         setupAppearance()
-        AppCenter.start(withAppSecret: "$(APP_CENTER_SECRET)",
-                        services: [Analytics.self, Crashes.self, Distribute.self])
         return true
     }
 }

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -12,8 +12,6 @@ target 'Backpack-Native' do
   pod 'Backpack-Fonts', :path => '../Backpack-Fonts'
   pod 'Backpack-Common', :path => '../', :testspecs => ['Tests']
   pod 'SwiftLint', '~> 0.43.1'
-  pod 'AppCenter', '~> 4.2.0'
-  pod 'AppCenter/Distribute', '~> 4.2.0'
 end
 
 post_install do |installer|

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,4 @@
 PODS:
-  - AppCenter (4.2.0):
-    - AppCenter/Analytics (= 4.2.0)
-    - AppCenter/Crashes (= 4.2.0)
-  - AppCenter/Analytics (4.2.0):
-    - AppCenter/Core
-  - AppCenter/Core (4.2.0)
-  - AppCenter/Crashes (4.2.0):
-    - AppCenter/Core
-  - AppCenter/Distribute (4.2.0):
-    - AppCenter/Core
   - Backpack (1.0):
     - Backpack-Common
     - FloatingPanel (= 2.8.6)
@@ -34,8 +24,6 @@ PODS:
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
-  - AppCenter (~> 4.2.0)
-  - AppCenter/Distribute (~> 4.2.0)
   - Backpack (from `../`)
   - Backpack-Common (from `../`)
   - Backpack-Common/Tests (from `../`)
@@ -48,7 +36,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - AppCenter
     - FloatingPanel
     - OCMock
     - SnapshotTesting
@@ -65,7 +52,6 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AppCenter: 87ef6eefd8ade4df59e88951288587429f3dd2a5
   Backpack: e3425ead05d6899a35380765d24ffbc968da6067
   Backpack-Common: 9a47d236de2f7fea7366f7a893423b8375ee7a39
   Backpack-Fonts: 8d10ac600d738cb7ae6e49fee969800c2db51f6b
@@ -75,6 +61,6 @@ SPEC CHECKSUMS:
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: 6f3760e0d599df3dad733e29f6051402af5454c4
+PODFILE CHECKSUM: ce1ed5d2d7a80a7517dac9d0bb8d6822dc6d16c7
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
# App center
The app center cocoapod was in our code, but we never set up app center properly with the secret key.
It's not part of our plist, run scheme or environment on git.

![SCR-20241108-kagb](https://github.com/user-attachments/assets/f8544ec6-1fc4-4175-9ff3-2da92309beca)


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
