### PR TITLE
Update GitHub Actions to use macOS 15 for all workflows

### DIFF
--- a/.github/workflows/_build-docs.yml
+++ b/.github/workflows/_build-docs.yml
@@ -10,7 +10,7 @@ defaults:
 jobs:
   BuildDocs:
     name: Build Docs
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       statuses: write
       pull-requests: write

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -10,7 +10,7 @@ defaults:
 jobs:
   Setup:
     name: Install Dependencies
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 
@@ -22,7 +22,7 @@ jobs:
 
   Lint:
     name: Lint Project
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [Setup]
     steps:
       - name: Checkout code
@@ -90,7 +90,7 @@ jobs:
 
   AnalyzePods:
     name: Analyzing pods
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [Setup]
     strategy:
       fail-fast: false
@@ -137,7 +137,7 @@ jobs:
 
   UploadArtifacts:
     name: Upload Artifacts
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [TestPods]
     steps:
       - name: Save assets

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   TestPods:
     name: Testing Pods
-    runs-on: macos-14
+    runs-on: macos-15
     outputs:
       changed-files: ${{ steps.checkSnapshotChanges.outputs.didChangeFiles }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       uses: ./.github/workflows/_build.yml
   Deploy-Common:
     name: Release Common to Cocoapods
-    runs-on: macos-14
+    runs-on: macos-15
     environment: Publishing
     needs: [Build]
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   Deploy-UIKit:
     name: Release UIKit to Cocoapods
-    runs-on: macos-14
+    runs-on: macos-15
     environment: Publishing
     needs: [Build]
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   Deploy-SwiftUI:
     name: Release SwiftUI to Cocoapods
-    runs-on: macos-14
+    runs-on: macos-15
     environment: Publishing
     needs: [Build]
     steps:
@@ -104,7 +104,7 @@ jobs:
 
   Deploy-Docs:
     name: Release Backpack Docs
-    runs-on: macos-14
+    runs-on: macos-15
     environment: Publishing
     needs: [Deploy-SwiftUI, Deploy-UIKit, Deploy-Common]
     steps:


### PR DESCRIPTION
Upgrade all GitHub Actions workflows to run on macOS 15, ensuring compatibility with the latest environment.