### PR TITLE
DON-1051: Fix dark mode colours in BPKCalendar

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/Range/Cells/LowerBoundSelectedCell.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/Cells/LowerBoundSelectedCell.swift
@@ -45,7 +45,7 @@ struct LowerBoundSelectedCell: View {
     }
 
     private var textColor: BPKColor {
-        highlighted ? .textPrimaryInverseColor : .black
+        highlighted ? .textPrimaryInverseColor : .textPrimaryColor
     }
 }
 

--- a/Backpack-SwiftUI/Calendar/Classes/Range/Cells/UpperBoundSelectedCell.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/Cells/UpperBoundSelectedCell.swift
@@ -44,7 +44,7 @@ struct UpperBoundSelectedCell: View {
     }
 
     private var textColor: BPKColor {
-        highlighted ? .textPrimaryInverseColor : .black
+        highlighted ? .textPrimaryInverseColor : .textPrimaryColor
     }
 }
 


### PR DESCRIPTION
Fixing an incorrect colour of first and last days in BPKCalendar if those dates are not highlighted in dark mode.

Bug example:
![image](https://github.com/user-attachments/assets/cd893106-b0ce-483e-ae1b-64638cad0a2d)

Fixed version:
![image](https://github.com/user-attachments/assets/ba251f40-aee6-4b91-ade1-3341d80262ab)


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
