### PR TITLE
Fix onTapGesture for BPKDividedCard

### DIFF
--- a/Backpack-SwiftUI/Card/Classes/BPKDividedCard.swift
+++ b/Backpack-SwiftUI/Card/Classes/BPKDividedCard.swift
@@ -45,9 +45,9 @@ public struct BPKDividedCard<PrimaryContent: View, SecondaryContent: View>: View
                     .frame(height: 1)
                 secondaryContent
             }
-            .onTapGesture {
-                tapAction()
-            }
+        }
+        .onTapGesture {
+            tapAction()
         }
     }
 


### PR DESCRIPTION
The `onTapGesture` was added to the wrong place, which prevented us from executing it by double-tappping a BPKDividedCard with VoiceOver on.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
