### PR TITLE
[DON-1037] Fix BPKCalendar scroll view

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
@@ -29,7 +29,7 @@ struct CalendarContainer<MonthContent: View>: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                VStack(spacing: BPKSpacing.none) {
+                LazyVStack(spacing: BPKSpacing.none) {
                     ForEach(0...monthsToShow, id: \.self) { monthIndex in
                         let firstDayOfMonth = firstDayOf(monthIndex: monthIndex)
                         monthContent(firstDayOfMonth)


### PR DESCRIPTION
When you provide a month to scroll, it has a weird behaviour when you change a selection in some cases.
LazyVStack should have better optimisation for scroll views and it's recommended using it over VStack.

More info and video with an example: https://skyscanner.atlassian.net/browse/DON-1037

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
