### PR TITLE
Fix drag direction issue in BPKSlider for RTL layouts

### DIFF
--- a/Backpack-SwiftUI/Slider/Classes/BPKRangeSlider.swift
+++ b/Backpack-SwiftUI/Slider/Classes/BPKRangeSlider.swift
@@ -49,6 +49,8 @@ public struct BPKRangeSlider: View {
     
     @State var height: CGFloat = .zero
     
+    @Environment(\.layoutDirection) private var layoutDirection
+    
     /// Creates a new instance of `BPKRangeSlider`.
     ///
     /// If the selected range is outside the bounds of the slider, it will be clamped to the bounds.
@@ -228,7 +230,8 @@ public struct BPKRangeSlider: View {
             sliderWidth: sliderSize.width,
             thumbSize: thumbSize,
             sliderBounds: sliderBounds,
-            step: step
+            step: step,
+            layoutDirection: layoutDirection
         )
         let isGreaterThanLeadingThumb = roundedValue >= selectedRange.lowerBound
         let isSmallerThanUpperBound = roundedValue <= sliderBounds.upperBound
@@ -244,7 +247,8 @@ public struct BPKRangeSlider: View {
             sliderWidth: sliderSize.width,
             thumbSize: thumbSize,
             sliderBounds: sliderBounds,
-            step: step
+            step: step,
+            layoutDirection: layoutDirection
         )
         let isSmallerThanTrailingThumb = roundedValue <= selectedRange.upperBound
         let isGreaterThanLowerBound = roundedValue >= sliderBounds.lowerBound

--- a/Backpack-SwiftUI/Slider/Classes/BPKSlider.swift
+++ b/Backpack-SwiftUI/Slider/Classes/BPKSlider.swift
@@ -30,6 +30,8 @@ public struct BPKSlider: View {
     private let thumbSize: CGFloat = 20
     private var thumbAccessibilityLabel = ""
     
+    @Environment(\.layoutDirection) private var layoutDirection
+    
     /// Creates a new instance of `BPKSlider`.
     ///
     /// If the value is outside the bounds of the slider, it will be clamped to the bounds.
@@ -132,7 +134,8 @@ public struct BPKSlider: View {
             sliderWidth: sliderSize.width,
             thumbSize: thumbSize,
             sliderBounds: sliderBounds,
-            step: step
+            step: step,
+            layoutDirection: layoutDirection
         )
         if roundedValue >= sliderBounds.lowerBound && roundedValue <= sliderBounds.upperBound {
             value = roundedValue

--- a/Backpack-SwiftUI/Slider/Classes/BPKSliderHelpers.swift
+++ b/Backpack-SwiftUI/Slider/Classes/BPKSliderHelpers.swift
@@ -16,17 +16,22 @@
  * limitations under the License.
  */
 
+import SwiftUI
+
 struct BPKSliderHelpers {
     
     /// Calculates the new value for the slider based on the drag gesture.
+    // swiftlint:disable function_parameter_count
     static func calculateNewValueFromDrag(
         xLocation: CGFloat,
         sliderWidth: CGFloat,
         thumbSize: CGFloat,
         sliderBounds: ClosedRange<Float>,
-        step: Float
+        step: Float,
+        layoutDirection: LayoutDirection
     ) -> Float {
-        let adjustedThumbPosition = xLocation - thumbSize / 2 + sliderWidth / 2
+        let directionMultiplier: CGFloat = (layoutDirection == .rightToLeft) ? -1 : 1
+        let adjustedThumbPosition = (xLocation - thumbSize / 2) * directionMultiplier + sliderWidth / 2
         let percentageForPosition = adjustedThumbPosition / sliderWidth
         let newValue = Self.valueForPercentage(Float(percentageForPosition), sliderBounds: sliderBounds)
         return round(newValue / step) * step

--- a/Backpack-SwiftUI/Tests/Slider/SliderTests.swift
+++ b/Backpack-SwiftUI/Tests/Slider/SliderTests.swift
@@ -49,9 +49,22 @@ class SliderTests: XCTestCase {
             sliderWidth: 200,
             thumbSize: 20,
             sliderBounds: -20...50,
-            step: 1
+            step: 1,
+            layoutDirection: .leftToRight
         )
         XCTAssertEqual(newValue, 47.0)
+    }
+    
+    func testCanCalculateNewValueFromDragOnRTL() {
+        let newValue = BPKSliderHelpers.calculateNewValueFromDrag(
+            xLocation: 100,
+            sliderWidth: 200,
+            thumbSize: 20,
+            sliderBounds: -20...50,
+            step: 1,
+            layoutDirection: .rightToLeft
+        )
+        XCTAssertEqual(newValue, -17.0)
     }
 
     func testCanCalculateNewValueFromDrawWithStep() {
@@ -60,7 +73,8 @@ class SliderTests: XCTestCase {
             sliderWidth: 200,
             thumbSize: 20,
             sliderBounds: -20...50,
-            step: 5
+            step: 5,
+            layoutDirection: .leftToRight
         )
         XCTAssertEqual(newValue, 45.0)
     }

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -85,7 +85,7 @@
 		53C6622929EA0DAB00BF1A62 /* AttributedTextExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C6620F29EA0DAB00BF1A62 /* AttributedTextExampleView.swift */; };
 		53C7F0B92A4C615D003A8740 /* ChipGroupSingleSelectRailExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C7F0B52A4C615D003A8740 /* ChipGroupSingleSelectRailExampleView.swift */; };
 		53C7F0BA2A4C615D003A8740 /* ChipGroupSingleSelectWrapExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C7F0B62A4C615D003A8740 /* ChipGroupSingleSelectWrapExampleView.swift */; };
-		53D4614E29E574EB0061C222 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		53D4614E29E574EB0061C222 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		53D6396F2A7D46ED007EF376 /* MapMarkerExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D6396E2A7D46ED007EF376 /* MapMarkerExampleView.swift */; };
 		53D7FBB527F715AF00DEE588 /* UIWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D7FBB427F715AF00DEE588 /* UIWindowFactory.swift */; };
 		53E075A527FC780C0033147C /* NavBarGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E075A427FC780C0033147C /* NavBarGroups.swift */; };
@@ -1650,6 +1650,7 @@
 				6003F588195388D20070C39A /* Resources */,
 				84EFE62BE1534CD46CAFBDBF /* [CP] Embed Pods Frameworks */,
 				D68AF8FA2174CB9C00BA743D /* Run Script */,
+				5059D4BC2567A5EB643578E0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1806,6 +1807,21 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		5059D4BC2567A5EB643578E0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Backpack-Native/Pods-Backpack-Native-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		84EFE62BE1534CD46CAFBDBF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1941,7 +1957,7 @@
 				5390DB612909940700F0F790 /* ColorTokensViewController.swift in Sources */,
 				794E1FF8280CF63100B965FF /* RadiusTokensView.swift in Sources */,
 				53B6DB6A27FC73A90042B7C0 /* LabelGroups.swift in Sources */,
-				53D4614E29E574EB0061C222 /* (null) in Sources */,
+				53D4614E29E574EB0061C222 /* BuildFile in Sources */,
 				53C6621329EA0DAB00BF1A62 /* SpinnerExampleView.swift in Sources */,
 				53BAC3F12A71415800236CC9 /* SectionHeaderGroups.swift in Sources */,
 				53C6622429EA0DAB00BF1A62 /* ButtonsPlaygroundView.swift in Sources */,


### PR DESCRIPTION
The `BPKSlider` does not change value according to drag direction in RTL layouts

https://github.com/user-attachments/assets/25c3af2e-ec08-479f-b17c-842bf996b0f5


**Screen recording after the fix**
RTL

https://github.com/user-attachments/assets/3eed5a6e-7e4e-479c-8e4f-e667dd5b83f1 

LTR

https://github.com/user-attachments/assets/523aed6e-11ff-43aa-afe6-048a7275ccf5


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
