### PR TITLE
Make bundle parameter optional in BPKIcon methods

### DIFF
--- a/Backpack-SwiftUI/Icons/Classes/BPKIcon.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIcon.swift
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 
+import Backpack_Common
+
 public struct BPKIcon {
     public let name: String
     let bundle: Bundle?
 
     init (name: String, bundle: Bundle? = nil) {
         self.name = name
-        self.bundle = bundle
+        self.bundle = bundle ?? BPKCommonBundle.iconsBundle
     }
     
     public enum Size {

--- a/Backpack-SwiftUI/Icons/Classes/BPKIcon.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIcon.swift
@@ -15,13 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Backpack_Common
 
 public struct BPKIcon {
     public let name: String
-    let bundle: Bundle
+    let bundle: Bundle?
 
-    init (name: String, bundle: Bundle = BPKCommonBundle.iconsBundle) {
+    init (name: String, bundle: Bundle? = nil) {
         self.name = name
         self.bundle = bundle
     }

--- a/Backpack-SwiftUI/Icons/Classes/BPKIcon.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIcon.swift
@@ -22,7 +22,7 @@ public struct BPKIcon {
     public let name: String
     let bundle: Bundle?
 
-    init (name: String, bundle: Bundle? = nil) {
+    init(name: String, bundle: Bundle? = nil) {
         self.name = name
         self.bundle = bundle ?? BPKCommonBundle.iconsBundle
     }

--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -83,11 +83,10 @@ private extension BPKIcon.Size {
 private extension Image {
     init(icon: BPKIcon, size: BPKIcon.Size = .small, shouldEnableAccessibility: Bool) {
         let iconName = "\(icon.name)-\(size.suffix)"
-        let bundle = icon.bundle ?? BPKCommonBundle.iconsBundle
         if shouldEnableAccessibility {
-            self.init(iconName, bundle: bundle)
+            self.init(iconName, bundle: icon.bundle)
         } else {
-            self.init(decorative: iconName, bundle: bundle)
+            self.init(decorative: iconName, bundle: icon.bundle)
         }
     }
 }

--- a/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
+++ b/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift
@@ -83,10 +83,11 @@ private extension BPKIcon.Size {
 private extension Image {
     init(icon: BPKIcon, size: BPKIcon.Size = .small, shouldEnableAccessibility: Bool) {
         let iconName = "\(icon.name)-\(size.suffix)"
+        let bundle = icon.bundle ?? BPKCommonBundle.iconsBundle
         if shouldEnableAccessibility {
-            self.init(iconName, bundle: icon.bundle)
+            self.init(iconName, bundle: bundle)
         } else {
-            self.init(decorative: iconName, bundle: icon.bundle)
+            self.init(decorative: iconName, bundle: bundle)
         }
     }
 }

--- a/Backpack-SwiftUI/Icons/Classes/Generated/BPKIcons.swift
+++ b/Backpack-SwiftUI/Icons/Classes/Generated/BPKIcons.swift
@@ -297,12 +297,12 @@ public extension BPKIcon {
 }
 
 public extension BPKIcon {
-    static func named(_ iconName: String, bundle: Bundle) -> BPKIcon {
-        BPKIcon(name: iconName, bundle: bundle)
-    }
-
     // swiftlint:disable function_body_length cyclomatic_complexity
-    static func named(_ iconName: String) -> BPKIcon? {
+    static func named(_ iconName: String, bundle: Bundle?) -> BPKIcon? {
+        if let bundle {
+            return BPKIcon(name: iconName, bundle: bundle)
+        }
+
         switch iconName {
         case "accessibility": return .accessibility
         case "account--add": return .accountAdd

--- a/Backpack-SwiftUI/Icons/Classes/Generated/BPKIcons.swift
+++ b/Backpack-SwiftUI/Icons/Classes/Generated/BPKIcons.swift
@@ -298,7 +298,7 @@ public extension BPKIcon {
 
 public extension BPKIcon {
     // swiftlint:disable function_body_length cyclomatic_complexity
-    static func named(_ iconName: String, bundle: Bundle?) -> BPKIcon? {
+    static func named(_ iconName: String, bundle: Bundle? = nil) -> BPKIcon? {
         if let bundle {
             return BPKIcon(name: iconName, bundle: bundle)
         }

--- a/templates/swiftui/BPKIcons.njk
+++ b/templates/swiftui/BPKIcons.njk
@@ -25,7 +25,7 @@ public extension BPKIcon {
 
 public extension BPKIcon {
     // swiftlint:disable function_body_length cyclomatic_complexity
-    static func named(_ iconName: String, bundle: Bundle?) -> BPKIcon? {
+    static func named(_ iconName: String, bundle: Bundle? = nil) -> BPKIcon? {
         if let bundle {
             return BPKIcon(name: iconName, bundle: bundle)
         }

--- a/templates/swiftui/BPKIcons.njk
+++ b/templates/swiftui/BPKIcons.njk
@@ -24,12 +24,12 @@ public extension BPKIcon {
 }
 
 public extension BPKIcon {
-    static func named(_ iconName: String, bundle: Bundle) -> BPKIcon {
-        BPKIcon(name: iconName, bundle: bundle)
-    }
-
     // swiftlint:disable function_body_length cyclomatic_complexity
-    static func named(_ iconName: String) -> BPKIcon? {
+    static func named(_ iconName: String, bundle: Bundle?) -> BPKIcon? {
+        if let bundle {
+            return BPKIcon(name: iconName, bundle: bundle)
+        }
+
         switch iconName {
         {% for icon in icons -%}
         case "{{icon.file}}": return .{{icon.name}}


### PR DESCRIPTION
Update BPKIcon to make the bundle parameter optional, set a default bundle if none is provided, and refactor the initializer for improved readability.