### PR TITLE
Ralp/remove ios 15 support

### DIFF
--- a/Backpack-Common.podspec
+++ b/Backpack-Common.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.ios.resource_bundle = {
     'Icons' => 'Backpack-Common/Icons/Assets/*'
   }
-  s.ios.deployment_target = '15.1'
+  s.ios.deployment_target = '16.0'
   s.source_files = 'Backpack-Common/**/*.swift'
   s.exclude_files = 'Backpack-Common/Tests/**/*.swift'
   s.requires_arc = true

--- a/Backpack-Fonts/Backpack-Fonts.podspec
+++ b/Backpack-Fonts/Backpack-Fonts.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |spec|
   spec.author           = {
     'Backpack Design System' => 'backpack@skyscanner.net'
   }
-  spec.ios.deployment_target  = '15.1'
+  spec.ios.deployment_target  = '16.0'
   spec.source = {
     git: 'https://github.com/Skyscanner/backpack-ios.git', tag: spec.version.to_s
   }

--- a/Backpack-SwiftUI.podspec
+++ b/Backpack-SwiftUI.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.source = {
     git: 'https://github.com/Skyscanner/backpack-ios.git', tag: s.version.to_s
   }
-  s.ios.deployment_target = '15.1'
+  s.ios.deployment_target = '16.0'
   s.source_files = 'Backpack-SwiftUI/*/Classes/**/*.swift'
 
   s.dependency 'Backpack-Common'

--- a/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheet.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheet.swift
@@ -91,7 +91,6 @@ public extension View {
         presentingController: UIViewController,
         @ViewBuilder bottomSheetContent: @escaping () -> BottomSheetContent
     ) -> some View {
-        if #available(iOS 16.0, *) {
             modifier(
                 BottomSheetContainerViewModifier(
                     isPresented: isPresented,
@@ -110,26 +109,6 @@ public extension View {
                     bottomSheetContent: bottomSheetContent
                 )
             )
-        } else {
-            modifier(
-                LegacyBottomSheetContainerViewModifier(
-                    isPresented: isPresented,
-                    contentMode: contentMode,
-                    header: {
-                        header(
-                            closeAction: closeAction(
-                                closeButtonAccessibilityLabel: closeButtonAccessibilityLabel,
-                                closeAction: { isPresented.wrappedValue.toggle() }
-                            ),
-                            title: title,
-                            action: action
-                        )
-                    },
-                    bottomSheetContent: bottomSheetContent,
-                    presentingController: presentingController
-                )
-            )
-        }
     }
     
     /// Presents a bottom sheet that, unless manually setting the `item` property to nil, this sheet
@@ -204,52 +183,24 @@ public extension View {
         presentingController: UIViewController,
         @ViewBuilder bottomSheetContent: @escaping (Item) -> BottomSheetContent
     ) -> some View {
-        if #available(iOS 16.0, *) {
-            modifier(
-                ItemBottomSheetContainerViewModifier(
-                    item: item,
-                    peekHeight: nil,
-                    contentMode: contentMode,
-                    header: {
-                        header(
-                            closeAction: closeAction(
-                                closeButtonAccessibilityLabel: closeButtonAccessibilityLabel,
-                                closeAction: { item.wrappedValue = nil }
-                            ),
-                            title: title,
-                            action: action
-                        )
-                    },
-                    bottomSheetContent: bottomSheetContent
-                )
+        modifier(
+            ItemBottomSheetContainerViewModifier(
+                item: item,
+                peekHeight: nil,
+                contentMode: contentMode,
+                header: {
+                    header(
+                        closeAction: closeAction(
+                            closeButtonAccessibilityLabel: closeButtonAccessibilityLabel,
+                            closeAction: { item.wrappedValue = nil }
+                        ),
+                        title: title,
+                        action: action
+                    )
+                },
+                bottomSheetContent: bottomSheetContent
             )
-        } else {
-            modifier(
-                LegacyBottomSheetContainerViewModifier(
-                    isPresented: Binding(
-                        get: { item.wrappedValue != nil },
-                        set: { _ in item.wrappedValue = nil }
-                    ),
-                    contentMode: contentMode,
-                    header: {
-                        header(
-                            closeAction: closeAction(
-                                closeButtonAccessibilityLabel: closeButtonAccessibilityLabel,
-                                closeAction: { item.wrappedValue = nil }
-                            ),
-                            title: title,
-                            action: action
-                        )
-                    },
-                    bottomSheetContent: {
-                        if let itemValue = item.wrappedValue {
-                            bottomSheetContent(itemValue)
-                        }
-                    },
-                    presentingController: presentingController
-                )
-            )
-        }
+        )
     }
     
     private func closeAction(

--- a/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheet.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BPKBottomSheet.swift
@@ -91,24 +91,24 @@ public extension View {
         presentingController: UIViewController,
         @ViewBuilder bottomSheetContent: @escaping () -> BottomSheetContent
     ) -> some View {
-            modifier(
-                BottomSheetContainerViewModifier(
-                    isPresented: isPresented,
-                    peekHeight: nil,
-                    contentMode: contentMode,
-                    header: {
-                        header(
-                            closeAction: closeAction(
-                                closeButtonAccessibilityLabel: closeButtonAccessibilityLabel,
-                                closeAction: { isPresented.wrappedValue.toggle() }
-                            ),
-                            title: title,
-                            action: action
-                        )
-                    },
-                    bottomSheetContent: bottomSheetContent
-                )
+        modifier(
+            BottomSheetContainerViewModifier(
+                isPresented: isPresented,
+                peekHeight: nil,
+                contentMode: contentMode,
+                header: {
+                    header(
+                        closeAction: closeAction(
+                            closeButtonAccessibilityLabel: closeButtonAccessibilityLabel,
+                            closeAction: { isPresented.wrappedValue.toggle() }
+                        ),
+                        title: title,
+                        action: action
+                    )
+                },
+                bottomSheetContent: bottomSheetContent
             )
+        )
     }
     
     /// Presents a bottom sheet that, unless manually setting the `item` property to nil, this sheet

--- a/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 16.0, *)
 struct BottomSheetContainerViewModifier<Header: View, BottomSheetContent: View>: ViewModifier {
     let peekHeight: CGFloat?
     @Binding var isPresented: Bool
@@ -77,7 +76,6 @@ struct BottomSheetContainerViewModifier<Header: View, BottomSheetContent: View>:
     }
 }
 
-@available(iOS 16.0, *)
 extension PresentationDetent {
     static func initialDetent(for contentMode: BPKBottomSheetContentMode) -> PresentationDetent {
         switch contentMode {

--- a/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 16.0, *)
 struct ContentFitBottomSheet<Content: View, Header: View>: View {
     let peekHeight: CGFloat?
     let header: () -> Header

--- a/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 
-@available(iOS 16.0, *)
 struct ItemBottomSheetContainerViewModifier<
     Header: View,
     BottomSheetContent: View,

--- a/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
+++ b/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
@@ -183,18 +183,11 @@ public struct BPKGraphicPromo: View {
     
     @ViewBuilder
     private var sponsorFooter: some View {
-        if #available(iOS 16.0, *) {
-            ViewThatFits {
-                HStack(spacing: .md) {
-                    sponsorLogo
-                    sponsoredText
-                }
-                VStack(alignment: .leading, spacing: .md) {
-                    sponsorLogo
-                    sponsoredText
-                }
+        ViewThatFits {
+            HStack(spacing: .md) {
+                sponsorLogo
+                sponsoredText
             }
-        } else {
             VStack(alignment: .leading, spacing: .md) {
                 sponsorLogo
                 sponsoredText

--- a/Backpack-SwiftUI/TextArea/Classes/BPKTextArea.swift
+++ b/Backpack-SwiftUI/TextArea/Classes/BPKTextArea.swift
@@ -89,14 +89,9 @@ public struct BPKTextArea: View {
     
     @ViewBuilder
     var textEditorContent: some View {
-        if #available(iOS 16.0, *) {
-            TextEditor(text: $value)
-                .font(style: .bodyDefault)
-                .scrollContentBackground(.hidden)
-        } else {
-            TextEditor(text: $value)
-                .font(style: .bodyDefault)
-        }
+        TextEditor(text: $value)
+            .font(style: .bodyDefault)
+            .scrollContentBackground(.hidden)
     }
     
     public var body: some View {

--- a/Backpack.podspec
+++ b/Backpack.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.source = {
     git: 'https://github.com/Skyscanner/backpack-ios.git', tag: s.version.to_s
   }
-  s.ios.deployment_target = '15.1'
+  s.ios.deployment_target = '16.1'
   s.source_files = 'Backpack/Backpack.h', 'Backpack/Common.h', 'Backpack/*/Classes/**/*.{h,m,swift}'
   s.exclude_files = 'Backpack/Tests/**'
   s.public_header_files = 'Backpack/Backpack.h', 'Backpack/*/Classes/**/*.h'

--- a/Backpack.podspec
+++ b/Backpack.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.source = {
     git: 'https://github.com/Skyscanner/backpack-ios.git', tag: s.version.to_s
   }
-  s.ios.deployment_target = '16.1'
+  s.ios.deployment_target = '16.0'
   s.source_files = 'Backpack/Backpack.h', 'Backpack/Common.h', 'Backpack/*/Classes/**/*.{h,m,swift}'
   s.exclude_files = 'Backpack/Tests/**'
   s.public_header_files = 'Backpack/Backpack.h', 'Backpack/*/Classes/**/*.h'

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -2148,7 +2148,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2197,7 +2197,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2227,7 +2227,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				INFOPLIST_FILE = "Backpack/Backpack-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				MODULE_NAME = ExampleApp;
@@ -2261,7 +2261,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				INFOPLIST_FILE = "Backpack/Backpack-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				MODULE_NAME = ExampleApp;
@@ -2287,7 +2287,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Backpack Screenshot/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2316,7 +2316,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Backpack Screenshot/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -2347,7 +2347,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Backpack NativeUITests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2381,7 +2381,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Backpack NativeUITests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,6 @@
 source 'https://cdn.cocoapods.org/'
 
-platform :ios, '15.1'
+platform :ios, '16.0'
 use_frameworks!
 ensure_bundler! '> 2.0'
 
@@ -23,7 +23,7 @@ post_install do |installer|
   puts 'Removing static analyzer support'
   installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.1'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
       end
 
       # Fix SwiftUI previews


### PR DESCRIPTION
I am updating backpack to no longer support iOS 15. The minimum version is now iOS 16.


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
