### PR TITLE
DON-1067: Change calendar selection behaviour

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
@@ -30,6 +30,9 @@ import SwiftUI
 ///   - validRange: The range of dates that the calendar should allow the user to select.
 ///     This is specified as a`ClosedRange<Date>`.
 ///   - initialMonthScroll: The initial scrolling to the month using `MonthScroll`
+///   - calendarSelectionHandler: Optional date selection handler which handles a tapped date and returns new selection
+///   - showFloatYearLabel: Set weather the floating year label should be displayed or not
+///   - dayAccessoryView: An additional optional view with extra information beneath the date
 ///
 /// The `BPKCalendar` view also allows you to specify an accessory action. This is a closure that takes a string and
 ///     a date, and is called when the user interacts with an accessory in the calendar.
@@ -40,6 +43,8 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
     private var accessoryAction: ((Date) -> CalendarMonthAccessoryAction?)?
     private var initialMonthScroll: MonthScroll?
     private let monthHeaderDateFormatter: DateFormatter
+    private let singleCalendarSelectionHandler: SingleCalendarSelectionHandler
+    private let rangeCalendarSelectionHandler: RangeCalendarSelectionHandler
     private let showFloatYearLabel: Bool
     private let dayAccessoryView: (Date) -> DayAccessoryView
     @State private var currentlyShownMonth: Date
@@ -49,6 +54,8 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
         calendar: Calendar,
         validRange: ClosedRange<Date>,
         initialMonthScroll: MonthScroll? = nil,
+        singleCalendarSelectionHandler: SingleCalendarSelectionHandler? = nil,
+        rangeCalendarSelectionHandler: RangeCalendarSelectionHandler? = nil,
         showFloatYearLabel: Bool = true,
         dayAccessoryView: @escaping (Date) -> DayAccessoryView = { _ in EmptyView() }
     ) {
@@ -59,7 +66,9 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
         self.selectionType = selectionType
         self.initialMonthScroll = initialMonthScroll
         self.showFloatYearLabel = showFloatYearLabel
-
+        self.singleCalendarSelectionHandler = singleCalendarSelectionHandler ?? DefaultSingleCalendarSelectionHandler()
+        self.rangeCalendarSelectionHandler = rangeCalendarSelectionHandler ?? DefaultRangeCalendarSelectionHandler()
+        
         monthHeaderDateFormatter = DateFormatter()
         monthHeaderDateFormatter.timeZone = calendar.timeZone
         monthHeaderDateFormatter.dateFormat = DateFormatter.dateFormat(
@@ -77,6 +86,8 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
                     CalendarTypeContainerFactory(
                         selectionType: selectionType,
                         calendar: calendar,
+                        singleCalendarSelectionHandler: singleCalendarSelectionHandler,
+                        rangeCalendarSelectionHandler: rangeCalendarSelectionHandler,
                         validRange: validRange,
                         monthScroll: initialMonthScroll,
                         calculator: InMemoryCacheCalendarGridCalculator(

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
@@ -21,6 +21,8 @@ import SwiftUI
 struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: View {
     let selectionType: CalendarSelectionType
     let calendar: Calendar
+    let singleCalendarSelectionHandler: SingleCalendarSelectionHandler
+    let rangeCalendarSelectionHandler: RangeCalendarSelectionHandler
     let validRange: ClosedRange<Date>
     let monthScroll: MonthScroll?
     let calculator: CalendarGridCalculator
@@ -76,6 +78,7 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
             ),
             month: month,
             calculator: calculator,
+            selectionHandler: singleCalendarSelectionHandler,
             dayAccessoryView: dayAccessoryView
         )
     }
@@ -95,9 +98,7 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
                 dateFormatter: accessibilityDateFormatter
             ),
             month: month,
-            selectionHandler: DefaultRangeCalendarSelectionHandler(
-                instructionAfterSelectingDate: accessibilityConfigurations.returnDatePrompt
-            ),
+            selectionHandler: rangeCalendarSelectionHandler,
             calculator: calculator,
             dayAccessoryView: dayAccessoryView
         )

--- a/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarSelectionHandler.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarSelectionHandler.swift
@@ -1,0 +1,46 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public protocol RangeCalendarSelectionHandler {
+    func newRangeSelectionStateFor(
+        selection date: Date,
+        currentSelection: CalendarRangeSelectionState?,
+        dateSelectedAccessibilityCallback: (() -> Void)?
+    ) -> CalendarRangeSelectionState
+}
+
+struct DefaultRangeCalendarSelectionHandler: RangeCalendarSelectionHandler {
+    func newRangeSelectionStateFor(
+        selection date: Date,
+        currentSelection: CalendarRangeSelectionState?,
+        dateSelectedAccessibilityCallback: (() -> Void)?
+    ) -> CalendarRangeSelectionState {
+        switch currentSelection {
+        case .intermediate(let initialDateSelection):
+            if date < initialDateSelection {
+                dateSelectedAccessibilityCallback?()
+                return .intermediate(date)
+            } else {
+                return .range(initialDateSelection...date)
+            }
+        default:
+            dateSelectedAccessibilityCallback?()
+            return .intermediate(date)
+        }
+    }
+}

--- a/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
@@ -25,6 +25,7 @@ struct SingleCalendarMonthContainer<DayAccessoryView: View>: View {
     let accessibilityProvider: SingleDayAccessibilityProvider
     let month: Date
     let calculator: CalendarGridCalculator
+    let selectionHandler: SingleCalendarSelectionHandler
     @ViewBuilder let dayAccessoryView: (Date) -> DayAccessoryView
     
     @ViewBuilder
@@ -52,7 +53,7 @@ struct SingleCalendarMonthContainer<DayAccessoryView: View>: View {
                 DefaultCalendarDayCell(calendar: calendar, date: dayDate)
             }
         } onSelection: {
-            selection = .single(dayDate)
+            selection = selectionHandler.newSingleSelectionStateFor(selection: dayDate, currentSelection: selection)
         }
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(selection?.isSelected(dayDate) == true ? .isSelected : [])
@@ -96,6 +97,7 @@ struct SingleCalendarContainer_Previews: PreviewProvider {
             ),
             month: start,
             calculator: DefaultCalendarGridCalculator(calendar: calendar),
+            selectionHandler: DefaultSingleCalendarSelectionHandler(),
             dayAccessoryView: { _ in
                 BPKText("20", style: .caption)
             }

--- a/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarSelectionHandler.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarSelectionHandler.swift
@@ -1,0 +1,33 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public protocol SingleCalendarSelectionHandler {
+    func newSingleSelectionStateFor(
+        selection date: Date,
+        currentSelection: CalendarSingleSelectionState?
+    ) -> CalendarSingleSelectionState
+}
+
+struct DefaultSingleCalendarSelectionHandler: SingleCalendarSelectionHandler {
+    func newSingleSelectionStateFor(
+        selection date: Date,
+        currentSelection: CalendarSingleSelectionState?
+    ) -> CalendarSingleSelectionState {
+        return .single(date)
+    }
+}

--- a/Backpack-SwiftUI/Calendar/README.md
+++ b/Backpack-SwiftUI/Calendar/README.md
@@ -93,3 +93,66 @@ BPKCalendar(
     showFloatYearLabel: false
 )
 ```
+
+## Custom date selection handler 
+
+If you need to customise the date selection handling for any reason, you can implement your own implementation of CalendarSelectionHandler for specific date selection type you need (single date selection or range dates selection).
+
+Complete customisation of date selection handling:
+```swift
+struct CustomCalendarSelectionHandler: CalendarSelectionHandler {
+    public let rangeSelectionHandler: RangeCalendarSelectionHandler = CustomRangeCalendarSelectionHandler()
+    public let singleSelectionHandler: SingleCalendarSelectionHandler
+    
+    ....
+}
+
+struct CustomRangeCalendarSelectionHandler: RangeCalendarSelectionHandler {
+    func newRangeSelectionStateFor(
+        selection date: Date,
+        currentSelection: CalendarRangeSelectionState?,
+        dateSelectedAccessibilityCallback: (() -> Void)?
+    ) -> CalendarRangeSelectionState {
+        // Selection handling code which returns CalendarRangeSelectionState
+        // Here you also need to call `dateSelectedAccessibilityCallback` when you're about to change a date selection.
+    }
+}
+
+struct CustomSingleCalendarSelectionHandler: SingleCalendarSelectionHandler {
+    func newSingleSelectionStateFor(
+        selection date: Date,
+        currentSelection: CalendarSingleSelectionState?
+    ) -> CalendarSingleSelectionState {
+        // Selection handling code which returns CalendarSingleSelectionState
+    }
+}
+
+
+BPKCalendar(
+    selectionType: .range(selectedRange: $selectedDateRange),
+    calendar: .current,
+    validRange: validStartDate...validEndDate,
+    calendarSelectionHandler: CustomCalendarSelectionHandler()
+)
+```
+
+Customisation only one type of date selection. In this case only range selection behaviour is replaced, and the single selection is using the default behaviour:
+```swift
+struct CustomRangeCalendarSelectionHandler: RangeCalendarSelectionHandler {
+    func newRangeSelectionStateFor(
+        selection date: Date,
+        currentSelection: CalendarRangeSelectionState?,
+        dateSelectedAccessibilityCallback: (() -> Void)?
+    ) -> CalendarRangeSelectionState {
+        // Selection handling code which returns CalendarRangeSelectionState
+        // Here you also need to call `dateSelectedAccessibilityCallback` when you're about to change a date selection.
+    }
+}
+
+BPKCalendar(
+    selectionType: .range(selectedRange: $selectedDateRange),
+    calendar: .current,
+    validRange: validStartDate...validEndDate,
+    calendarSelectionHandler: DefaultCalendarSelectionHandler(rangeSelectionHandler: CustomRangeCalendarSelectionHandler())
+)
+```

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -85,7 +85,7 @@
 		53C6622929EA0DAB00BF1A62 /* AttributedTextExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C6620F29EA0DAB00BF1A62 /* AttributedTextExampleView.swift */; };
 		53C7F0B92A4C615D003A8740 /* ChipGroupSingleSelectRailExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C7F0B52A4C615D003A8740 /* ChipGroupSingleSelectRailExampleView.swift */; };
 		53C7F0BA2A4C615D003A8740 /* ChipGroupSingleSelectWrapExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C7F0B62A4C615D003A8740 /* ChipGroupSingleSelectWrapExampleView.swift */; };
-		53D4614E29E574EB0061C222 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		53D4614E29E574EB0061C222 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		53D6396F2A7D46ED007EF376 /* MapMarkerExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D6396E2A7D46ED007EF376 /* MapMarkerExampleView.swift */; };
 		53D7FBB527F715AF00DEE588 /* UIWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D7FBB427F715AF00DEE588 /* UIWindowFactory.swift */; };
 		53E075A527FC780C0033147C /* NavBarGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E075A427FC780C0033147C /* NavBarGroups.swift */; };
@@ -1661,6 +1661,7 @@
 				6003F588195388D20070C39A /* Resources */,
 				84EFE62BE1534CD46CAFBDBF /* [CP] Embed Pods Frameworks */,
 				D68AF8FA2174CB9C00BA743D /* Run Script */,
+				DDF2FC01153B0D5F803B736B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1846,6 +1847,21 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint  --strict\n";
 		};
+		DDF2FC01153B0D5F803B736B /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Backpack-Native/Pods-Backpack-Native-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1952,7 +1968,7 @@
 				5390DB612909940700F0F790 /* ColorTokensViewController.swift in Sources */,
 				794E1FF8280CF63100B965FF /* RadiusTokensView.swift in Sources */,
 				53B6DB6A27FC73A90042B7C0 /* LabelGroups.swift in Sources */,
-				53D4614E29E574EB0061C222 /* (null) in Sources */,
+				53D4614E29E574EB0061C222 /* BuildFile in Sources */,
 				53C6621329EA0DAB00BF1A62 /* SpinnerExampleView.swift in Sources */,
 				53BAC3F12A71415800236CC9 /* SectionHeaderGroups.swift in Sources */,
 				53C6622429EA0DAB00BF1A62 /* ButtonsPlaygroundView.swift in Sources */,


### PR DESCRIPTION
Goal is to give a flexibility to consumers to adapt the date selection handling mechanism.
It should be necessary if we want to change the behaviour of selecting date ranges, for example (is selected date should be a departure or return date, for example).

More details is here: https://skyscanner.atlassian.net/browse/DON-1067
 

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
