### PR TITLE
[AI-1071]: Fit content in scrollview when overflowing

### DIFF
--- a/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
@@ -52,11 +52,14 @@ struct BottomSheetContainerViewModifier<Header: View, BottomSheetContent: View>:
                     let detents: Set<PresentationDetent> = expansible ? [.medium, .large] : [.medium]
                     bottomSheetContent(for: detents)
                 case .fitContent:
-                    ContentFitBottomSheet(
-                        peekHeight: peekHeight,
-                        header: header,
-                        bottomSheetContent: bottomSheetContent
-                    )
+                    GeometryReader { reader in
+                        ContentFitBottomSheet(
+                            peekHeight: peekHeight,
+                            header: header,
+                            bottomSheetContent: bottomSheetContent,
+                            sheetProxy: reader
+                        )
+                    }
                 }
             }
     }

--- a/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/BottomSheetContainerViewModifier.swift
@@ -57,7 +57,7 @@ struct BottomSheetContainerViewModifier<Header: View, BottomSheetContent: View>:
                             peekHeight: peekHeight,
                             header: header,
                             bottomSheetContent: bottomSheetContent,
-                            sheetProxy: reader
+                            sheetProxy: reader.size
                         )
                     }
                 }

--- a/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
@@ -22,6 +22,10 @@ struct ContentFitBottomSheet<Content: View, Header: View>: View {
     let peekHeight: CGFloat?
     let header: () -> Header
     let bottomSheetContent: () -> Content
+    let sheetProxy: GeometryProxy
+    
+    @State private var showInScrollView: Bool = false
+    @State private var viewHeight: CGFloat = 0
     
     @State private var detentHeight: CGFloat = 0
     
@@ -33,12 +37,55 @@ struct ContentFitBottomSheet<Content: View, Header: View>: View {
         return finalDetents
     }
     
+//    func isItScrollView() -> some View {
+//        if sheetProxy.size.height + 5.0 < detentHeight {
+//            print("--- Computed ---")
+//            return
+//                ScrollView {
+//                    bottomSheetContent()
+//                }
+//        } else {
+//            print("--- Computed1 ---")
+//            return bottomSheetContent()
+//        }
+////        print("--- Computed ---")
+////        print(sheetProxy.size.height + 5.0 < detentHeight)
+////        print("--- Computed ---")
+////        return sheetProxy.size.height + 5.0 < detentHeight
+//    }
+    
     var body: some View {
         VStack {
             header()
-            bottomSheetContent()
-                .presentationDetents(detents)
+            if sheetProxy.size.height > UIScreen.main.bounds.height * 0.93 {
+                BPKText("SCROLL")
+
+                bottomSheetContent()
+                    .background(
+                        GeometryReader { reader in
+                            Color.clear.onChange(of: reader.size.height, perform: { _ in
+                                showInScrollView = sheetProxy.size.height + 5.0 < detentHeight
+                                viewHeight = reader.size.height
+                            })
+                        }
+                    )
+
+            } else {
+                BPKText("height: \(sheetProxy.size.height)")
+                BPKText("is it true: \(sheetProxy.size.height < UIScreen.main.bounds.height)")
+                
+                bottomSheetContent()
+                    .background(
+                        GeometryReader { reader in
+                            Color.clear.onChange(of: reader.size.height, perform: { _ in
+                                showInScrollView = sheetProxy.size.height + 5.0 < detentHeight
+                                viewHeight = reader.size.height
+                            })
+                        }
+                    )
+            }
         }
+        .presentationDetents(detents)
         .presentationDragIndicator(.visible)
         .readHeight()
         .onPreferenceChange(HeightPreferenceKey.self) { height in

--- a/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
@@ -37,55 +37,19 @@ struct ContentFitBottomSheet<Content: View, Header: View>: View {
         return finalDetents
     }
     
-//    func isItScrollView() -> some View {
-//        if sheetProxy.size.height + 5.0 < detentHeight {
-//            print("--- Computed ---")
-//            return
-//                ScrollView {
-//                    bottomSheetContent()
-//                }
-//        } else {
-//            print("--- Computed1 ---")
-//            return bottomSheetContent()
-//        }
-////        print("--- Computed ---")
-////        print(sheetProxy.size.height + 5.0 < detentHeight)
-////        print("--- Computed ---")
-////        return sheetProxy.size.height + 5.0 < detentHeight
-//    }
-    
     var body: some View {
         VStack {
             header()
-            if sheetProxy.size.height > UIScreen.main.bounds.height * 0.93 {
-                BPKText("SCROLL")
-
-                bottomSheetContent()
-                    .background(
-                        GeometryReader { reader in
-                            Color.clear.onChange(of: reader.size.height, perform: { _ in
-                                showInScrollView = sheetProxy.size.height + 5.0 < detentHeight
-                                viewHeight = reader.size.height
-                            })
-                        }
-                    )
-
+            if sheetProxy.size.height > UIScreen.main.bounds.height * 0.94 {
+                ScrollView {
+                    sheetContent()
+                        .presentationDetents([.large])
+                }
             } else {
-                BPKText("height: \(sheetProxy.size.height)")
-                BPKText("is it true: \(sheetProxy.size.height < UIScreen.main.bounds.height)")
-                
-                bottomSheetContent()
-                    .background(
-                        GeometryReader { reader in
-                            Color.clear.onChange(of: reader.size.height, perform: { _ in
-                                showInScrollView = sheetProxy.size.height + 5.0 < detentHeight
-                                viewHeight = reader.size.height
-                            })
-                        }
-                    )
+                sheetContent()
+                    .presentationDetents(detents)
             }
         }
-        .presentationDetents(detents)
         .presentationDragIndicator(.visible)
         .readHeight()
         .onPreferenceChange(HeightPreferenceKey.self) { height in
@@ -93,6 +57,12 @@ struct ContentFitBottomSheet<Content: View, Header: View>: View {
                 self.detentHeight = height
             }
         }
+    }
+    
+    @ViewBuilder
+    func sheetContent() -> some View {
+        bottomSheetContent()
+            .frame(width: sheetProxy.size.width)
     }
 }
 

--- a/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ContentFitBottomSheet.swift
@@ -48,7 +48,7 @@ struct ContentFitBottomSheet<Content: View, Header: View>: View {
                     }
                 })
                 .onChange(of: sheetProxy, perform: {
-                    if !isPanelInitialising {
+                    if $0.height != 0.0 {
                         showInScroll = $0.height < detentHeight
                     }
                 })
@@ -65,7 +65,6 @@ struct ContentFitBottomSheet<Content: View, Header: View>: View {
         .presentationDragIndicator(.visible)
         .onGeometryChange(for: CGSize.self, of: { $0.size }, action: {
             detentHeight = $0.height
-            isPanelInitialising = sheetProxy.height == 0.0
         })
     }
 }

--- a/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
@@ -31,6 +31,8 @@ struct ItemBottomSheetContainerViewModifier<
     
     @State var selectedSheetDetent: PresentationDetent
     
+    @State private var contentFitSize: CGSize = .zero
+    
     init(
         item: Binding<Item?>,
         peekHeight: CGFloat?,
@@ -61,7 +63,7 @@ struct ItemBottomSheetContainerViewModifier<
                             peekHeight: peekHeight,
                             header: header,
                             bottomSheetContent: { bottomSheetContent(item) },
-                            sheetProxy: reader
+                            sheetProxy: reader.size
                         )
                     }
                 }

--- a/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
@@ -31,8 +31,6 @@ struct ItemBottomSheetContainerViewModifier<
     
     @State var selectedSheetDetent: PresentationDetent
     
-    @State private var contentFitSize: CGSize = .zero
-    
     init(
         item: Binding<Item?>,
         peekHeight: CGFloat?,

--- a/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/ItemBottomSheetContainerViewModifier.swift
@@ -56,11 +56,14 @@ struct ItemBottomSheetContainerViewModifier<
                     let detents: Set<PresentationDetent> = expansible ? [.medium, .large] : [.medium]
                     bottomSheetContent(for: detents, item: item)
                 case .fitContent:
-                    ContentFitBottomSheet(
-                        peekHeight: peekHeight,
-                        header: header,
-                        bottomSheetContent: { bottomSheetContent(item) }
-                    )
+                    GeometryReader { reader in
+                        ContentFitBottomSheet(
+                            peekHeight: peekHeight,
+                            header: header,
+                            bottomSheetContent: { bottomSheetContent(item) },
+                            sheetProxy: reader
+                        )
+                    }
                 }
             }
     }

--- a/Example/Backpack.xcodeproj/project.pbxproj
+++ b/Example/Backpack.xcodeproj/project.pbxproj
@@ -1661,7 +1661,6 @@
 				6003F588195388D20070C39A /* Resources */,
 				84EFE62BE1534CD46CAFBDBF /* [CP] Embed Pods Frameworks */,
 				D68AF8FA2174CB9C00BA743D /* Run Script */,
-				DDF2FC01153B0D5F803B736B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1846,21 +1845,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint  --strict\n";
-		};
-		DDF2FC01153B0D5F803B736B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Backpack-Native/Pods-Backpack-Native-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
@@ -33,8 +33,6 @@ struct BottomSheetExampleView: View {
     @State private var mediumFixedBottomSheetShown = false
     @State private var fitContentBottomSheetShown = false
     @State private var itemToShow: ExampleItem?
-    
-    @State private var noOfItems: Int = 0
 
     func content(_ text: String = "Bottom sheet content") -> some View {
         VStack {
@@ -102,16 +100,9 @@ struct BottomSheetExampleView: View {
                 presentingController: rootViewController,
                 bottomSheetContent: {
                     VStack {
-                        ForEach(0..<noOfItems, id: \.self) { _ in
-                            Text("Hello, World!")
-                        }
-                        
-                        BPKButton("Add one") {
-                            noOfItems += 1
-                        }
-                        
+                        BPKText("Bottom sheet content")
                         BPKButton("Do Action") {
-                            noOfItems -= 1
+                            fitContentBottomSheetShown.toggle()
                         }
                     }
                     .padding()
@@ -176,3 +167,4 @@ struct BottomSheetExampleView_Previews: PreviewProvider {
         BottomSheetExampleView()
     }
 }
+

--- a/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
@@ -33,6 +33,8 @@ struct BottomSheetExampleView: View {
     @State private var mediumFixedBottomSheetShown = false
     @State private var fitContentBottomSheetShown = false
     @State private var itemToShow: ExampleItem?
+    
+    @State private var noOfItems: Int = 0
 
     func content(_ text: String = "Bottom sheet content") -> some View {
         VStack {
@@ -100,9 +102,16 @@ struct BottomSheetExampleView: View {
                 presentingController: rootViewController,
                 bottomSheetContent: {
                     VStack {
-                        BPKText("Bottom sheet content")
+                        ForEach(0..<noOfItems, id: \.self) { _ in
+                            Text("Hello, World!")
+                        }
+                        
+                        BPKButton("Add one") {
+                            noOfItems += 1
+                        }
+                        
                         BPKButton("Do Action") {
-                            fitContentBottomSheetShown.toggle()
+                            noOfItems -= 1
                         }
                     }
                     .padding()

--- a/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/BottomSheet/BottomSheetExampleView.swift
@@ -167,4 +167,3 @@ struct BottomSheetExampleView_Previews: PreviewProvider {
         BottomSheetExampleView()
     }
 }
-


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Fit content bottom sheet changes to put content into scroll view when content doesn't fit fully in the available space

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
