### PR TITLE
AI-1071: Fix ContentFitBottomSheet

### DIFF
--- a/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
@@ -1,0 +1,58 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+
+struct KeyboardAvoidingModifier: ViewModifier {
+    @State private var keyboardHeight: CGFloat = 0
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.bottom, keyboardHeight)
+            .onAppear {
+                observeKeyboardChanges()
+            }
+            .onDisappear {
+                removeKeyboardObservers()
+            }
+    }
+    
+    // MARK: - Keyboard Handling
+    private func observeKeyboardChanges() {
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
+            if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                keyboardHeight = keyboardFrame.height
+            }
+        }
+        
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
+            keyboardHeight = 0
+        }
+    }
+    
+    private func removeKeyboardObservers() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+}
+
+extension View {
+    func avoidKeyboard() -> some View {
+        modifier(KeyboardAvoidingModifier())
+    }
+}

--- a/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
@@ -53,6 +53,8 @@ struct KeyboardAvoidingModifier: ViewModifier {
         }
     }
     
+    
+    
     private func removeKeyboardObservers() {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)

--- a/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
@@ -53,8 +53,6 @@ struct KeyboardAvoidingModifier: ViewModifier {
         }
     }
     
-    
-    
     private func removeKeyboardObservers() {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)

--- a/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
+++ b/Backpack-SwiftUI/BottomSheet/Classes/KeyboardAvoidingViewModifier.swift
@@ -34,13 +34,21 @@ struct KeyboardAvoidingModifier: ViewModifier {
     
     // MARK: - Keyboard Handling
     private func observeKeyboardChanges() {
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(
+            forName: UIResponder.keyboardWillShowNotification,
+            object: nil,
+            queue: .main
+        ) { notification in
             if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                 keyboardHeight = keyboardFrame.height
             }
         }
         
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
+        NotificationCenter.default.addObserver(
+            forName: UIResponder.keyboardWillHideNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
             keyboardHeight = 0
         }
     }


### PR DESCRIPTION
**Problem:**

When` bpkBottomSheet`'s content mode is `.fitMode`, the expectation is that the sheet will take the intrinsic height of its content, expanding and collapsing as the content changes, and to activate scrolling once the content exceed the maximum sheet height. But the `ContentFitBottomSheet`  implementation doesn't place its content in a scrollView, it's the consumer responsibility to do so. But when a consumer wraps their content in a scrollview, the sheet doesn't appear.

https://github.com/user-attachments/assets/60ae4bdb-95ae-4b65-abe7-a690ba5e6482


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
