### PR TITLE
DON-1275: Fix bpkcalendar accessibility

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/CalendarHeader.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/CalendarHeader.swift
@@ -34,7 +34,7 @@ struct CalendarHeader: View {
             }
             Divider()
         }
-        .accessibilityHidden(true)
+        .accessibilityChildren { EmptyView().accessibilityHidden(true) }
     }
     
     private var weekdays: [String] {

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarMonthGrid.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarMonthGrid.swift
@@ -91,6 +91,8 @@ struct CalendarMonthGrid<
                     .modifier(ReadSizeModifier { accessoryViewHeight = max($0.height, accessoryViewHeight ?? 0) })
             }
             .frame(maxWidth: .infinity)
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isButton)
         }
     }
     

--- a/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
@@ -103,7 +103,6 @@ struct RangeCalendarMonthContainer<DayAccessoryView: View>: View {
                 rangeSelectionState: selectionState
             )
         ))
-//        .accessibility(addTraits: .isButton)
     }
     
     private func initialSelection(_ initialDateSelection: Date, matchesDate date: Date) -> Bool {

--- a/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Range/RangeCalendarContainer.swift
@@ -103,7 +103,7 @@ struct RangeCalendarMonthContainer<DayAccessoryView: View>: View {
                 rangeSelectionState: selectionState
             )
         ))
-        .accessibility(addTraits: .isButton)
+//        .accessibility(addTraits: .isButton)
     }
     
     private func initialSelection(_ initialDateSelection: Date, matchesDate date: Date) -> Bool {

--- a/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
@@ -55,7 +55,7 @@ struct SingleCalendarMonthContainer<DayAccessoryView: View>: View {
         } onSelection: {
             selection = selectionHandler.newSingleSelectionStateFor(selection: dayDate, currentSelection: selection)
         }
-        .accessibilityAddTraits(.isButton)
+//        .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(selection?.isSelected(dayDate) == true ? .isSelected : [])
         .accessibilityLabel(accessibilityProvider.accessibilityLabel(for: dayDate, selection: selection))
         .accessibilityHint(accessibilityProvider.accessibilityHint(for: dayDate, selection: selection))

--- a/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Single/SingleCalendarContainer.swift
@@ -55,7 +55,6 @@ struct SingleCalendarMonthContainer<DayAccessoryView: View>: View {
         } onSelection: {
             selection = selectionHandler.newSingleSelectionStateFor(selection: dayDate, currentSelection: selection)
         }
-//        .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(selection?.isSelected(dayDate) == true ? .isSelected : [])
         .accessibilityLabel(accessibilityProvider.accessibilityLabel(for: dayDate, selection: selection))
         .accessibilityHint(accessibilityProvider.accessibilityHint(for: dayDate, selection: selection))


### PR DESCRIPTION
There are two potential accessibility issues:

1. Apparently, if there is a higher level .accessibilityHidden() modifier, it would override everything for children
In the DateSelector case we added this for the Cheapest month, this harmless modifier affects everything inside. But this header always should be hidden for accessibility. The easiest workaround it to override its accessibility behaviour.

2. Because of the complex structure of the day and accessory view cells, there is a major accessibility issue when a day view is separately from an accessory view. It makes a lot of confusion for accessibility users. So, we had to combine its content. (small note about a button trait, it had to be placed into a different part as it affected accessibility view's structure).


https://github.com/user-attachments/assets/f5a761c6-8396-42a5-a23d-bca114d927de


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file


](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
