### PR TITLE
[DON-1248] Update BPKCloseButton for fix accessibility issue in iOS 16

### DIFF
--- a/Backpack-SwiftUI/Button/Classes/BPKCloseButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/BPKCloseButton.swift
@@ -26,7 +26,7 @@ struct BPKCloseButton: View {
     
     var body: some View {
         Button(action: action) {
-            BPKIconView(.close, size: .large)
+            BPKIconView(.close, size: .large, accessibilityLabel: "icon_\(accessibilityLabel)")
         }
         .foregroundColor(.textPrimaryColor)
         .contentShape(Rectangle())


### PR DESCRIPTION
Fix the issue where the close button is not accessible in `BPKAppSearchModal` on iOS 16.

<img width="1348" alt="Screenshot 2025-05-01 at 09 39 03" src="https://github.com/user-attachments/assets/246cfcc7-2eff-487a-abe9-4dbf8d4fe0c1" />

## 🧵 Discussions

### 🔍 Main Issue
The core issue stems from the following SwiftUI initializer:
[Image.init(decorative:bundle:)](https://developer.apple.com/documentation/swiftui/image/init(decorative:bundle:))
And its usage in the codebase:
[BPKIconView.swift#L89](https://github.com/Skyscanner/backpack-ios/blob/main/Backpack-SwiftUI/Icons/Classes/BPKIconView.swift#L89)

### 📱 iOS 16-Specific?
Yes — the issue appears to affect only iOS 16. You can verify this using the Accessibility Inspector on the Close Button in the `BPKAppSearchModal`:
On iOS 16, the close button is not visible to assistive technologies.
On iOS 18, it behaves as expected.

### ❓ Why Only iOS 16?
While there’s no official documentation, it seems due to enhancements in the SwiftUI accessibility tree in iOS 17+. When using a hierarchy of views where the lowest element is marked as `accessibility(hidden: true)` (via `.init(decorative:))`, iOS 16 mistakenly treats parent views as ignored too, breaking the entire chain.
View Hierarchy:
BPKCloseButton
  └── Button
...         └── BPKIconView
......               └── Image (⚠️ accessibility-ignored via decorative initializer)

### ✅ Alternative Approach
To fix the accessibility issue across all iOS versions, especially iOS 16, we can explicitly ignore the children’s accessibility and provide your own label at the button level using `.accessibilityElement(children: .ignore)`.
```swift
struct BPKCloseButton: View {
    var accessibilityLabel: String
    var action: () -> Void

    var body: some View {
        Button(action: action) {
            BPKIconView(.close, size: .large)
        }
        .foregroundColor(.textPrimaryColor)
        .contentShape(Rectangle())
        .accessibilityElement(children: .ignore) // 👈 Fix applied here
        .accessibilityLabel(accessibilityLabel)
    }
}
```
This ensures the button is announced properly by VoiceOver even when its child image is decorative.

