### PR TITLE
DON-1516 Added config for scroll debounce threshold

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
@@ -43,6 +43,7 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
     let validRange: ClosedRange<Date>
     private var accessoryAction: ((Date) -> CalendarMonthAccessoryAction?)?
     private var onScrollToMonthAction: ((Date) -> Void)?
+    private var scrollDebounceThreshold: Int
     private var initialMonthScroll: MonthScroll?
     private let monthHeaderDateFormatter: DateFormatter
     private let singleCalendarSelectionHandler: SingleCalendarSelectionHandler
@@ -57,11 +58,12 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
         calendar: Calendar,
         validRange: ClosedRange<Date>,
         initialMonthScroll: MonthScroll? = nil,
+        scrollDebounceThreshold: Int = 200,
         singleCalendarSelectionHandler: SingleCalendarSelectionHandler? = nil,
         rangeCalendarSelectionHandler: RangeCalendarSelectionHandler? = nil,
         showFloatYearLabel: Bool = true,
         highlightedDates: Set<Date>? = nil,
-        dayAccessoryView: @escaping (Date) -> DayAccessoryView = { _ in EmptyView() }
+        dayAccessoryView: @escaping (Date) -> DayAccessoryView = { _ in EmptyView()}
     ) {
         self.dayAccessoryView = dayAccessoryView
         _currentlyShownMonth = State(initialValue: validRange.lowerBound)
@@ -69,6 +71,7 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
         self.calendar = calendar
         self.selectionType = selectionType
         self.initialMonthScroll = initialMonthScroll
+        self.scrollDebounceThreshold = scrollDebounceThreshold
         self.showFloatYearLabel = showFloatYearLabel
         self.highlightedDates = highlightedDates
         self.singleCalendarSelectionHandler = singleCalendarSelectionHandler ?? DefaultSingleCalendarSelectionHandler()
@@ -98,6 +101,7 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
                         onScrollToMonth: { date in
                             onScrollToMonthAction?(date)
                         },
+                        scrollDebounceThreshold: scrollDebounceThreshold,
                         calculator: InMemoryCacheCalendarGridCalculator(
                             decoratee: DefaultCalendarGridCalculator(calendar: calendar)
                         ),

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
@@ -36,9 +36,10 @@ struct CalendarContainer<MonthContent: View>: View {
         parentProxy: GeometryProxy,
         monthScroll: MonthScroll?,
         onScrollToMonth: ((Date) -> Void)?,
+        scrollDebounceThreshold: Int,
         monthContent: @escaping (_ month: Date) -> MonthContent
     ) {
-        _visibilityObserver = StateObject(wrappedValue: ItemVisibilityObserver(parentProxy: parentProxy))
+        _visibilityObserver = StateObject(wrappedValue: ItemVisibilityObserver(parentProxy: parentProxy, debounceThreshold: scrollDebounceThreshold))
         self.calendar = calendar
         self.validRange = validRange
         self.parentProxy = parentProxy
@@ -143,6 +144,7 @@ struct CalendarContainer_Previews: PreviewProvider {
                 parentProxy: proxy,
                 monthScroll: monthScroll,
                 onScrollToMonth: nil,
+                scrollDebounceThreshold: 200,
                 monthContent: { monthNumber in
                     VStack {
                         BPKText("Calendar Grid \(monthNumber)")

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarTypeContainerFactory.swift
@@ -26,6 +26,7 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
     let validRange: ClosedRange<Date>
     let monthScroll: MonthScroll?
     let onScrollToMonth: ((Date) -> Void)?
+    let scrollDebounceThreshold: Int
     let calculator: CalendarGridCalculator
     let parentProxy: GeometryProxy
     let highlightedDates: Set<Date>?
@@ -46,7 +47,8 @@ struct CalendarTypeContainerFactory<MonthHeader: View, DayAccessoryView: View>: 
             validRange: adjustedValidRange,
             parentProxy: parentProxy,
             monthScroll: monthScroll,
-            onScrollToMonth: onScrollToMonth
+            onScrollToMonth: onScrollToMonth,
+            scrollDebounceThreshold: scrollDebounceThreshold
         ) { month in
             VStack(spacing: BPKSpacing.none) {
                 monthHeader(month)

--- a/Backpack-SwiftUI/Calendar/Classes/Core/ItemVisibilityObserver.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/ItemVisibilityObserver.swift
@@ -36,7 +36,7 @@ class ItemVisibilityObserver: ObservableObject {
 
     private var lastEmittedVisibleItems: [Int] = []
 
-    init(parentProxy: GeometryProxy) {
+    init(parentProxy: GeometryProxy, debounceThreshold: Int) {
         preferencePublisher
             .map { preferences in
                 let parentFrame = parentProxy.frame(in: .global)
@@ -45,7 +45,7 @@ class ItemVisibilityObserver: ObservableObject {
                 }.map { $0.key }
             }
             .removeDuplicates() // Ensures we don't debounce if the list hasn't changed
-            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
+            .debounce(for: .milliseconds(debounceThreshold), scheduler: DispatchQueue.main)
             .sink { [weak self] newVisibleItems in
                 guard let self = self else { return }
 


### PR DESCRIPTION
We need to make the debounce threshold for the calendar scroll action configurable

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
