### PR TITLE
Donburi/don 1622 dyanmic colour helper

### DIFF
--- a/Backpack/CardButton/Classes/CardButtonBackgroundView.swift
+++ b/Backpack/CardButton/Classes/CardButtonBackgroundView.swift
@@ -21,10 +21,7 @@ internal class CardButtonBackgroundView: UIView {
     init() {
         super.init(frame: .zero)
 
-        backgroundColor = BPKColor.dynamicColor(
-            withLightVariant: BPKColor.white.withAlphaComponent(0.5),
-            darkVariant: BPKColor.black.withAlphaComponent(0.5)
-        )
+        backgroundColor = BPKColor.canvasColor.withAlphaComponent(0.5)
         isUserInteractionEnabled = false
         translatesAutoresizingMaskIntoConstraints = false
     }

--- a/Backpack/Color/Classes/Generated/BPKColor.h
+++ b/Backpack/Color/Classes/Generated/BPKColor.h
@@ -856,6 +856,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (UIColor *)blend:(UIColor*)firstColor with:(UIColor*)secondColor weight:(double)weight;
 
+@end
+
+@interface BPKColor ()
+
 /**
  * Generates a dynamic color given a light and dark variant.
  *
@@ -864,6 +868,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @deprecated Please use only available BPKColors.
  */
 + (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant __deprecated_msg("Please use only available BPKColors");
+
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Backpack/Color/Classes/Generated/BPKColor.h
+++ b/Backpack/Color/Classes/Generated/BPKColor.h
@@ -857,19 +857,5 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIColor *)blend:(UIColor*)firstColor with:(UIColor*)secondColor weight:(double)weight;
 
 @end
-
-@interface BPKColor ()
-
-/**
- * Generates a dynamic color given a light and dark variant.
- *
- * @param lightVariant The color used in light mode, or on systems that don't support dark-mode.
- * @param darkVariant The color used in dark mode.
- * @deprecated Please use only available BPKColors.
- */
-+ (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant __deprecated_msg("Please use only available BPKColors");
-
-
-@end
 NS_ASSUME_NONNULL_END
 // clang-format on

--- a/Backpack/Color/Classes/Generated/BPKColor.m
+++ b/Backpack/Color/Classes/Generated/BPKColor.m
@@ -564,6 +564,7 @@
     return _dynamicColorsCache;
 }
 
+
 + (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant {
 #if __BPK_DARK_MODE_SUPPORTED
     if (@available(iOS 13.0, *)) {

--- a/Backpack/Color/Classes/Generated/BPKColor.m
+++ b/Backpack/Color/Classes/Generated/BPKColor.m
@@ -22,6 +22,16 @@
 
 @interface BPKColor()
 @property(nonatomic, strong, readonly) NSCache<NSString *, UIColor *> *dynamicColorsCache;
+
+/**
+ * Generates a dynamic color given a light and dark variant.
+ *
+ * @param lightVariant The color used in light mode, or on systems that don't support dark-mode.
+ * @param darkVariant The color used in dark mode.
+ * @deprecated Please use only available BPKColors.
+ */
++ (UIColor *)dynamicColorWithLightVariant:(UIColor *)lightVariant darkVariant:(UIColor *)darkVariant __deprecated_msg("Please use only available BPKColors");
+
 @end
 
 @implementation BPKColor

--- a/Backpack/Color/Classes/Generated/BPKInternalColors.swift
+++ b/Backpack/Color/Classes/Generated/BPKInternalColors.swift
@@ -25,328 +25,371 @@ import UIKit
 // swiftlint:disable bpk_use_colour_token
 // swiftlint:disable identifier_name
 internal extension BPKColor {
+    
+    private static var dynamicColorsCache = NSCache<NSString, UIColor>()
+    
+    static func dynamicColor(lightVariant: UIColor, darkVariant: UIColor) -> UIColor {
+        // Only on iOS 13+ can we do trait-based dynamic coloring
+        if #available(iOS 13.0, *) {
+            // 1. Build a cache key
+            let key = "\(lightVariant.cacheKey)_\(darkVariant.cacheKey)" as NSString
+            
+            // 2. Return cached if we have it
+            if let cached = dynamicColorsCache.object(forKey: key) {
+                return cached
+            }
+            
+            // 3. Create the dynamic provider
+            let dynamic = UIColor { traitCollection in
+                traitCollection.userInterfaceStyle == .dark ? darkVariant : lightVariant
+            }
+            
+            // 4. Cache & return
+            dynamicColorsCache.setObject(dynamic, forKey: key)
+            return dynamic
+        }
+        
+        // 5. Fallback pre-iOS 13
+        return lightVariant
+    }
 
     /// The `badgeBackgroundNormalColor` internal color.
     
     static let badgeBackgroundNormalColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
+        lightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
         darkVariant: UIColor(red: 0.141, green: 0.200, blue: 0.275, alpha: 1))
 
     /// The `infoBannerDefaultColor` internal color.
     
     static let infoBannerDefaultColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
+        lightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
         darkVariant: UIColor(red: 0.075, green: 0.114, blue: 0.169, alpha: 1))
 
     /// The `infoBannerOnContrastColor` internal color.
     
     static let infoBannerOnContrastColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 0.075, green: 0.114, blue: 0.169, alpha: 1))
 
     /// The `infoBannerSuccessColor` internal color.
     
     static let infoBannerSuccessColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.047, green: 0.514, blue: 0.541, alpha: 1),
+        lightVariant: UIColor(red: 0.047, green: 0.514, blue: 0.541, alpha: 1),
         darkVariant: UIColor(red: 0.384, green: 0.945, blue: 0.776, alpha: 1))
 
     /// The `infoBannerErrorColor` internal color.
     
     static let infoBannerErrorColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.906, green: 0.031, blue: 0.400, alpha: 1),
+        lightVariant: UIColor(red: 0.906, green: 0.031, blue: 0.400, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 0.392, blue: 0.612, alpha: 1))
 
     /// The `infoBannerInfoColor` internal color.
     
     static let infoBannerInfoColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.384, green: 0.412, blue: 0.443, alpha: 1),
+        lightVariant: UIColor(red: 0.384, green: 0.412, blue: 0.443, alpha: 1),
         darkVariant: UIColor(red: 0.741, green: 0.769, blue: 0.796, alpha: 1))
 
     /// The `infoBannerWarningColor` internal color.
     
     static let infoBannerWarningColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.961, green: 0.365, blue: 0.259, alpha: 1),
+        lightVariant: UIColor(red: 0.961, green: 0.365, blue: 0.259, alpha: 1),
         darkVariant: UIColor(red: 0.996, green: 0.922, blue: 0.529, alpha: 1))
 
     /// The `chipOnDarkPressedStrokeColor` internal color.
     
     static let chipOnDarkPressedStrokeColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 0.020, green: 0.255, blue: 0.518, alpha: 1))
 
     /// The `chipOnDarkOnBackgroundColor` internal color.
     
     static let chipOnDarkOnBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 0.020, green: 0.255, blue: 0.518, alpha: 1))
 
     /// The `chipDisabledBackgroundColor` internal color.
     
     static let chipDisabledBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
+        lightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
         darkVariant: UIColor(red: 0.043, green: 0.071, blue: 0.114, alpha: 1))
 
     /// The `chipOnDarkOnDismissIconColor` internal color.
     
     static let chipOnDarkOnDismissIconColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.384, green: 0.412, blue: 0.443, alpha: 1),
+        lightVariant: UIColor(red: 0.384, green: 0.412, blue: 0.443, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.5019607843137255))
 
     /// The `mapPreviousSelectionColor` internal color.
     
     static let mapPreviousSelectionColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.812, green: 0.894, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 0.812, green: 0.894, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 0.812, green: 0.894, blue: 1.000, alpha: 1))
 
     /// The `mapClusterPinColor` internal color.
     
     static let mapClusterPinColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.020, green: 0.125, blue: 0.235, alpha: 1),
+        lightVariant: UIColor(red: 0.020, green: 0.125, blue: 0.235, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1))
 
     /// The `mapClusterPinPreviousSelectionColor` internal color.
     
     static let mapClusterPinPreviousSelectionColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.580, green: 0.765, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 0.580, green: 0.765, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 0.580, green: 0.765, blue: 1.000, alpha: 1))
 
     /// The `mapMarkerViewedForegroundColor` internal color.
     
     static let mapMarkerViewedForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.8),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.8),
         darkVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0.8))
 
     /// The `mapPoiPinColor` internal color.
     
     static let mapPoiPinColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.557, green: 0.278, blue: 0.729, alpha: 1),
+        lightVariant: UIColor(red: 0.557, green: 0.278, blue: 0.729, alpha: 1),
         darkVariant: UIColor(red: 0.557, green: 0.278, blue: 0.729, alpha: 1))
 
     /// The `buttonSecondaryPressedBackgroundColor` internal color.
     
     static let buttonSecondaryPressedBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.757, green: 0.780, blue: 0.812, alpha: 1),
+        lightVariant: UIColor(red: 0.757, green: 0.780, blue: 0.812, alpha: 1),
         darkVariant: UIColor(red: 0.004, green: 0.035, blue: 0.075, alpha: 1))
 
     /// The `buttonLinkNormalForegroundColor` internal color.
     
     static let buttonLinkNormalForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.000, green: 0.384, blue: 0.890, alpha: 1),
+        lightVariant: UIColor(red: 0.000, green: 0.384, blue: 0.890, alpha: 1),
         darkVariant: UIColor(red: 0.518, green: 0.914, blue: 1.000, alpha: 1))
 
     /// The `buttonLinkOnDarkDisabledForegroundColor` internal color.
     
     static let buttonLinkOnDarkDisabledForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2))
 
     /// The `buttonSecondaryNormalBackgroundColor` internal color.
     
     static let buttonSecondaryNormalBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
+        lightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
         darkVariant: UIColor(red: 0.141, green: 0.200, blue: 0.275, alpha: 1))
 
     /// The `buttonPrimaryOnLightPressedBackgroundColor` internal color.
     
     static let buttonPrimaryOnLightPressedBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.082, green: 0.275, blue: 0.475, alpha: 1),
+        lightVariant: UIColor(red: 0.082, green: 0.275, blue: 0.475, alpha: 1),
         darkVariant: UIColor(red: 0.020, green: 0.255, blue: 0.518, alpha: 1))
 
     /// The `buttonFeaturedNormalBackgroundColor` internal color.
     
     static let buttonFeaturedNormalBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.000, green: 0.384, blue: 0.890, alpha: 1),
+        lightVariant: UIColor(red: 0.000, green: 0.384, blue: 0.890, alpha: 1),
         darkVariant: UIColor(red: 0.518, green: 0.914, blue: 1.000, alpha: 1))
 
     /// The `buttonFeaturedPressedBackgroundColor` internal color.
     
     static let buttonFeaturedPressedBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1),
+        lightVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1),
         darkVariant: UIColor(red: 0.820, green: 0.969, blue: 1.000, alpha: 1))
 
     /// The `buttonPrimaryOnLightNormalBackgroundColor` internal color.
     
     static let buttonPrimaryOnLightNormalBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.020, green: 0.125, blue: 0.235, alpha: 1),
+        lightVariant: UIColor(red: 0.020, green: 0.125, blue: 0.235, alpha: 1),
         darkVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1))
 
     /// The `buttonPrimaryOnLightDisabledForegroundColor` internal color.
     
     static let buttonPrimaryOnLightDisabledForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0.2),
+        lightVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0.2),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2))
 
     /// The `buttonSecondaryOnDarkDisabledBackgroundColor` internal color.
     
     static let buttonSecondaryOnDarkDisabledBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.043, green: 0.071, blue: 0.114, alpha: 1),
+        lightVariant: UIColor(red: 0.043, green: 0.071, blue: 0.114, alpha: 1),
         darkVariant: UIColor(red: 0.043, green: 0.071, blue: 0.114, alpha: 1))
 
     /// The `buttonDestructiveNormalForegroundColor` internal color.
     
     static let buttonDestructiveNormalForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.906, green: 0.031, blue: 0.400, alpha: 1),
+        lightVariant: UIColor(red: 0.906, green: 0.031, blue: 0.400, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 0.392, blue: 0.612, alpha: 1))
 
     /// The `buttonPrimaryOnDarkNormalBackgroundColor` internal color.
     
     static let buttonPrimaryOnDarkNormalBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1))
 
     /// The `buttonPrimaryOnDarkDisabledForegroundColor` internal color.
     
     static let buttonPrimaryOnDarkDisabledForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0.2),
+        lightVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0.2),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2))
 
     /// The `buttonSecondaryOnDarkPressedBackgroundColor` internal color.
     
     static let buttonSecondaryOnDarkPressedBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.004, green: 0.035, blue: 0.075, alpha: 1),
+        lightVariant: UIColor(red: 0.004, green: 0.035, blue: 0.075, alpha: 1),
         darkVariant: UIColor(red: 0.004, green: 0.035, blue: 0.075, alpha: 1))
 
     /// The `buttonLinkPressedForegroundColor` internal color.
     
     static let buttonLinkPressedForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1),
+        lightVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1),
         darkVariant: UIColor(red: 0.820, green: 0.969, blue: 1.000, alpha: 1))
 
     /// The `buttonPrimaryOnLightDisabledBackgroundColor` internal color.
     
     static let buttonPrimaryOnLightDisabledBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
+        lightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
         darkVariant: UIColor(red: 0.043, green: 0.071, blue: 0.114, alpha: 1))
 
     /// The `buttonDestructiveNormalBackgroundColor` internal color.
     
     static let buttonDestructiveNormalBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
+        lightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
         darkVariant: UIColor(red: 0.141, green: 0.200, blue: 0.275, alpha: 1))
 
     /// The `buttonPrimaryNormalBackgroundColor` internal color.
     
     static let buttonPrimaryNormalBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.020, green: 0.125, blue: 0.235, alpha: 1),
+        lightVariant: UIColor(red: 0.020, green: 0.125, blue: 0.235, alpha: 1),
         darkVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1))
 
     /// The `buttonDestructivePressedBackgroundColor` internal color.
     
     static let buttonDestructivePressedBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.906, green: 0.031, blue: 0.400, alpha: 1),
+        lightVariant: UIColor(red: 0.906, green: 0.031, blue: 0.400, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 0.392, blue: 0.612, alpha: 1))
 
     /// The `buttonPrimaryPressedBackgroundColor` internal color.
     
     static let buttonPrimaryPressedBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.082, green: 0.275, blue: 0.475, alpha: 1),
+        lightVariant: UIColor(red: 0.082, green: 0.275, blue: 0.475, alpha: 1),
         darkVariant: UIColor(red: 0.020, green: 0.255, blue: 0.518, alpha: 1))
 
     /// The `buttonPrimaryOnDarkDisabledBackgroundColor` internal color.
     
     static let buttonPrimaryOnDarkDisabledBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
+        lightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
         darkVariant: UIColor(red: 0.043, green: 0.071, blue: 0.114, alpha: 1))
 
     /// The `buttonLinkOnDarkPressedForegroundColor` internal color.
     
     static let buttonLinkOnDarkPressedForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.5019607843137255),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.5019607843137255),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.5019607843137255))
 
     /// The `buttonLinkOnDarkNormalForegroundColor` internal color.
     
     static let buttonLinkOnDarkNormalForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1))
 
     /// The `buttonDisabledBackgroundColor` internal color.
     
     static let buttonDisabledBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
+        lightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
         darkVariant: UIColor(red: 0.043, green: 0.071, blue: 0.114, alpha: 1))
 
     /// The `buttonSecondaryOnDarkNormalBackgroundColor` internal color.
     
     static let buttonSecondaryOnDarkNormalBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.10196078431372549),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.10196078431372549),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.10196078431372549))
 
     /// The `buttonSecondaryOnDarkDisabledForegroundColor` internal color.
     
     static let buttonSecondaryOnDarkDisabledForegroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.2))
 
     /// The `buttonPrimaryOnDarkPressedBackgroundColor` internal color.
     
     static let buttonPrimaryOnDarkPressedBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.757, green: 0.780, blue: 0.812, alpha: 1),
+        lightVariant: UIColor(red: 0.757, green: 0.780, blue: 0.812, alpha: 1),
         darkVariant: UIColor(red: 0.757, green: 0.780, blue: 0.812, alpha: 1))
 
     /// The `barTrackDefaultColor` internal color.
     
     static let barTrackDefaultColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
+        lightVariant: UIColor(red: 0.878, green: 0.894, blue: 0.914, alpha: 1),
         darkVariant: UIColor(red: 0.141, green: 0.200, blue: 0.275, alpha: 1))
 
     /// The `barTrackOnContrastColor` internal color.
     
     static let barTrackOnContrastColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1),
         darkVariant: UIColor(red: 0.141, green: 0.200, blue: 0.275, alpha: 1))
 
     /// The `skeletonShimmerStartEndColor` internal color.
     
     static let skeletonShimmerStartEndColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0),
         darkVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0))
 
     /// The `skeletonShimmerCenterColor` internal color.
     
     static let skeletonShimmerCenterColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.6),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.6),
         darkVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0.2))
 
     /// The `sponsoredBannerBackgroundColor` internal color.
     
     static let sponsoredBannerBackgroundColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
+        lightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
         darkVariant: UIColor(red: 0.141, green: 0.200, blue: 0.275, alpha: 1))
 
     /// The `navigationTabHoverColor` internal color.
     
     static let navigationTabHoverColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.082, green: 0.275, blue: 0.475, alpha: 1),
+        lightVariant: UIColor(red: 0.082, green: 0.275, blue: 0.475, alpha: 1),
         darkVariant: UIColor(red: 0.820, green: 0.969, blue: 1.000, alpha: 1))
 
     /// The `navigationTabOutlineColor` internal color.
     
     static let navigationTabOutlineColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.757, green: 0.780, blue: 0.812, alpha: 1),
+        lightVariant: UIColor(red: 0.757, green: 0.780, blue: 0.812, alpha: 1),
         darkVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 1))
 
     /// The `cardButtonContainedFillColor` internal color.
     
     static let cardButtonContainedFillColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.8),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.8),
         darkVariant: UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 0.8))
 
     /// The `segmentedControlCanvasDefaultColor` internal color.
     
     static let segmentedControlCanvasDefaultColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
+        lightVariant: UIColor(red: 0.937, green: 0.953, blue: 0.973, alpha: 1),
         darkVariant: UIColor(red: 0.075, green: 0.114, blue: 0.169, alpha: 1))
 
     /// The `segmentedControlSurfaceContrastColor` internal color.
     
     static let segmentedControlSurfaceContrastColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.10196078431372549),
+        lightVariant: UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha: 0.10196078431372549),
         darkVariant: UIColor(red: 0.075, green: 0.114, blue: 0.169, alpha: 1))
 
     /// The `segmentedControlSurfaceContrastOnColor` internal color.
     
     static let segmentedControlSurfaceContrastOnColor = BPKColor.dynamicColor(
-        withLightVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1),
+        lightVariant: UIColor(red: 0.008, green: 0.302, blue: 0.686, alpha: 1),
         darkVariant: UIColor(red: 0.020, green: 0.255, blue: 0.518, alpha: 1))
+}
+
+private extension UIColor {
+    /// A crude cache-key generator: e.g. “#RRGGBBAA”
+    var cacheKey: String {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return String(format: "#%02X%02X%02X%02X",
+            Int(red * 255),
+            Int(green * 255),
+            Int(blue * 255),
+            Int(alpha * 255))
+    }
 }

--- a/Backpack/Dialog/Classes/BPKDialogContentView.m
+++ b/Backpack/Dialog/Classes/BPKDialogContentView.m
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Dynamic colors
 - (UIColor *)dialogContentViewBackgroundColor {
-    return [BPKColor dynamicColorWithLightVariant:BPKColor.white darkVariant:BPKColor.backgroundSecondaryDarkColor];
+    return BPKColor.surfaceDefaultColor;
 }
 
 @end

--- a/Backpack/Spinner/Classes/BPKSpinner.m
+++ b/Backpack/Spinner/Classes/BPKSpinner.m
@@ -127,7 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIColor *)colorForSpinnerStyle:(BPKSpinnerStyle)style {
     switch (style) {
     case BPKSpinnerStylePrimary:
-        return [BPKColor dynamicColorWithLightVariant:BPKColor.skyBlue darkVariant:BPKColor.white];
+        return BPKColor.textPrimaryColor;
     case BPKSpinnerStyleSecondary:
         return BPKColor.textPrimaryColor;
     case BPKSpinnerStyleDark:

--- a/Backpack/Toast/Classes/BPKToast.m
+++ b/Backpack/Toast/Classes/BPKToast.m
@@ -144,8 +144,7 @@ NSString *const ToastAccessibilityIdentifier = @"toastView";
 
 - (void)setupHUD {
     self.hud.bezelView.style = MBProgressHUDBackgroundStyleSolidColor;
-    self.hud.bezelView.backgroundColor = [[BPKColor dynamicColorWithLightVariant:BPKColor.corePrimaryColor
-                                                                     darkVariant:BPKColor.textPrimaryColor] colorWithAlphaComponent:0.85];
+    self.hud.bezelView.backgroundColor = [BPKColor.corePrimaryColor colorWithAlphaComponent:0.8];
     self.hud.contentColor = BPKColor.white;
     self.hud.delegate = self;
     self.hud.accessibilityIdentifier = ToastAccessibilityIdentifier;

--- a/Example/Backpack/UIKit/Components/Bottom Sheet/BottomSheetPersistentViewController.swift
+++ b/Example/Backpack/UIKit/Components/Bottom Sheet/BottomSheetPersistentViewController.swift
@@ -28,14 +28,8 @@ final class BottomSheetPersistentViewController: UIViewController {
         let closeButton = BPKButton(size: .default, style: .secondary)
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         closeButton.setImage(BPKIcon.makeLargeTemplateIcon(name: .close))
-        closeButton.secondaryBackgroundColor = BPKColor.dynamicColor(
-            withLightVariant: BPKColor.white,
-            darkVariant: BPKColor.blackTint06
-        )
-        closeButton.secondaryContentColor = BPKColor.dynamicColor(
-            withLightVariant: BPKColor.skyGray,
-            darkVariant: BPKColor.blackTint01
-        )
+        closeButton.secondaryBackgroundColor = BPKColor.canvasColor
+        closeButton.secondaryContentColor = BPKColor.corePrimaryColor
         closeButton.secondaryBorderColor = BPKColor.clear
         return closeButton
     }()


### PR DESCRIPTION
Ticket: [DON-1622](https://skyscanner.atlassian.net/browse/DON-1622)

Removing deprecated dynamicColor being used in backpack components
Make dynamicColor helper method private so that it can't be called in the main app anymore.

<img width="588" alt="Screenshot 2025-05-23 at 15 30 20" src="https://github.com/user-attachments/assets/c5192f76-3772-4a39-b06d-9046f1133b14" />


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
