### PR TITLE
DON-1571: Date formatters fixing

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/MonthScroll.swift
@@ -39,7 +39,7 @@ public struct MonthScroll {
     public init(monthToScroll: Date, anchor: UnitPoint = .top, animated: Bool = false) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM"
-        dateFormatter.timeZone = .utc
+        dateFormatter.timeZone = .gmt
 
         self.scrollId = dateFormatter.string(from: monthToScroll)
         self.anchor = anchor


### PR DESCRIPTION
Fixing the month scroll object. For timezones earlier than UTC/GMT (like New York) there was a bug. Users could see the incorrect month when they opened the date selector.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
