### PR TITLE
[DON-1257] Revert the additive identifier in `BPKSearchInputSummary`

### DIFF
--- a/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
+++ b/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
@@ -102,7 +102,6 @@ public struct BPKSearchInputSummary: View {
         .if(!BPKFont.enableDynamicType, transform: {
             $0.sizeCategory(.large)
         })
-        .id("\(accessibilityIdentifier)_accessory_\(text.isEmpty ? "hidden" : "visible")")
     }
     
     @ViewBuilder


### PR DESCRIPTION
[DON-1257]
This is the revert the additive identifier in `BPKSearchInputSummary` made here:
https://github.com/Skyscanner/backpack-ios/pull/2243/files

The reason for revert: This change makes the user loose focus on the input.


[DON-1257]: https://skyscanner.atlassian.net/browse/DON-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ