### PR TITLE
[DON-1250] Add prefix to accessibility label when available in `BPKSearchInputSummary`

### DIFF
--- a/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
+++ b/Backpack-SwiftUI/SearchInputSummary/Classes/BPKSearchInputSummary.swift
@@ -83,7 +83,7 @@ public struct BPKSearchInputSummary: View {
                     view.accessibilityElement()
                 })
                 .accessibilityValue(customAccessibilityValue ?? text)
-                .accessibilityLabel(placeholder)
+                .accessibilityLabel(accessibilityLabel)
                 .accessibilityAddTraits(readOnly ? [] : .isSearchField)
                 .accessibilityIdentifier(accessibilityIdentifier)
                 .focused($focused)
@@ -103,7 +103,14 @@ public struct BPKSearchInputSummary: View {
             $0.sizeCategory(.large)
         })
     }
-    
+
+    private var accessibilityLabel: String {
+        if case let .text(prefixText)? = inputPrefix {
+            return "\(prefixText), \(placeholder)"
+        }
+        return placeholder
+    }
+
     @ViewBuilder
     private var accessory: some View {
         Button(action: clearAction.action) {


### PR DESCRIPTION
[DON-1250]
Add prefix to accessibility label when available in `BPKSearchInputSummary`

# Detail
The aim of this change is to include prefix in accessibility label (when available) to improve the accessibility experience.

Review the following document to understand other possible options, and why this approach has been chosen:
https://skyscanner.atlassian.net/browse/DON-1250?focusedCommentId=4109718

[DON-1250]: https://skyscanner.atlassian.net/browse/DON-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ