### PR TITLE
OGM-3592: Add custom BPKCardList padding

### DIFF
--- a/Backpack-SwiftUI/CardList/Classes/BPKCardList.swift
+++ b/Backpack-SwiftUI/CardList/Classes/BPKCardList.swift
@@ -25,6 +25,7 @@ public struct BPKCardList<Element: Identifiable, Content: View>: View {
     private let initiallyShownCardsCount: Int
     private let elements: [Element]
     private let cardForElement: (_ element: Element) -> Content
+    private let headerPadding: (Edge.Set, BPKSpacing)
     @State private var showingAllCards = false
 
     public init(
@@ -33,6 +34,7 @@ public struct BPKCardList<Element: Identifiable, Content: View>: View {
         layout: BPKCardListLayout,
         initiallyShownCardsCount: Int = 3,
         elements: [Element],
+        headerPadding: (Edge.Set, BPKSpacing) = (.all, .base),
         @ViewBuilder cardForElement: @escaping (_: Element) -> Content
     ) {
         self.title = title
@@ -40,6 +42,7 @@ public struct BPKCardList<Element: Identifiable, Content: View>: View {
         self.layout = layout
         self.initiallyShownCardsCount = initiallyShownCardsCount
         self.elements = elements
+        self.headerPadding = headerPadding
         self.cardForElement = cardForElement
     }
 
@@ -91,10 +94,10 @@ public struct BPKCardList<Element: Identifiable, Content: View>: View {
                     action: sectionHeaderAction.action)
                 .buttonStyle(.primary)
             }
-            .padding(.base)
+            .padding(headerPadding.0, headerPadding.1)
         } else {
             return BPKSectionHeader(title: title, description: description)
-                .padding(.base)
+                .padding(headerPadding.0, headerPadding.1)
         }
     }
     


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
[OGM-3592](https://skyscanner.atlassian.net/jira/software/c/projects/OGM/boards/485?selectedIssue=OGM-3592)
Adding custom padding for the header in BPKCardList. This gives us the option to remove the top padding.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
