### PR TITLE
Donburi/don 1635 cleanup old month selection gc

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/BPKCalendar.swift
@@ -140,13 +140,6 @@ public struct BPKCalendar<DayAccessoryView: View>: View {
         }
     }
 
-    /// Sets the accessory action for the calendar to be applied to each month, based on the give month `Date`.
-    public func monthAccessoryAction(_ action: ((Date) -> CalendarMonthAccessoryAction?)?) -> BPKCalendar {
-        var result = self
-        result.accessoryAction = action
-        return result
-    }
-
     /// Sets CTA call for when scrolling landed in the calendar,
     /// returning the first day of landed month inside the action.
     public func onScrollToMonthAction(_ action: @escaping (([Date]) -> Void)) -> BPKCalendar {
@@ -184,8 +177,5 @@ struct BPKCalendar_Previews: PreviewProvider {
                 BPKText("20", style: .caption)
             }
         )
-        .monthAccessoryAction { _ in
-            return CalendarMonthAccessoryAction(title: "Select whole month", action: .custom({ _ in }))
-        }
     }
 }

--- a/Backpack-SwiftUI/Calendar/Classes/CalendarMonthAccessoryAction.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/CalendarMonthAccessoryAction.swift
@@ -38,8 +38,5 @@ public struct CalendarMonthAccessoryAction {
         /// - Parameter: The `Date` representing the month interacted with by the user.
         case custom((Date) -> Void)
 
-        /// An action triggered for a whole month selection.
-        /// - Parameter: A `ClosedRange<Date>` for the start and end of the selected month (calendar range considered).
-        case wholeMonthSelection((ClosedRange<Date>) -> Void)
     }
 }

--- a/Backpack-SwiftUI/Calendar/Classes/CalendarMonthHeader.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/CalendarMonthHeader.swift
@@ -47,9 +47,6 @@ struct CalendarMonthHeader: View {
                     switch accessory.action {
                     case .custom(let action):
                         action(monthDate)
-                    case .wholeMonthSelection(let action):
-                        guard let range = monthRangeFor(date: monthDate) else { return }
-                        action(range)
                     }
                 }
                 .buttonStyle(.link)

--- a/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
+++ b/Backpack/Calendar/Classes/BPKCalendarStickyHeader.m
@@ -37,8 +37,6 @@
 
 @interface BPKCalendarStickyHeader ()
 
-@property(weak, nonatomic, readonly) BPKButton *selectMonthButton;
-
 @end
 
 @implementation BPKCalendarStickyHeader
@@ -51,11 +49,6 @@ CGFloat const BPKBaselineOffset = 2.0;
     if (self) {
         [self.weekdayView removeFromSuperview];
         [self.bottomBorder removeFromSuperview];
-
-        BPKButton *button = [[BPKButton alloc] initWithSize:BPKButtonSizeDefault style:BPKButtonStyleLink];
-        [button addTarget:self action:@selector(didTapSelectMonth:) forControlEvents:UIControlEventTouchUpInside];
-        [self.contentView addSubview:button];
-        _selectMonthButton = button;
     }
 
     return self;
@@ -84,15 +77,12 @@ CGFloat const BPKBaselineOffset = 2.0;
     self.titleLabel.frame = CGRectZero;
 
     self.titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    self.selectMonthButton.translatesAutoresizingMaskIntoConstraints = NO;
 
     [NSLayoutConstraint activateConstraints:@[
         [self.titleLabel.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
         [self.titleLabel.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor],
         [self.titleLabel.heightAnchor constraintEqualToConstant:BPKSpacingLg * 2],
         [self.titleLabel.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
-        [self.selectMonthButton.centerYAnchor constraintEqualToAnchor:self.titleLabel.centerYAnchor constant:BPKBaselineOffset],
-        [self.selectMonthButton.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
     ]];
 }
 
@@ -111,13 +101,6 @@ CGFloat const BPKBaselineOffset = 2.0;
     if (!calendar) {
         return;
     }
-
-    BPKCalendarWholeMonthConfiguration *configuration = calendar.wholeMonthSelectionConfiguration;
-    self.selectMonthButton.hidden = configuration == nil;
-
-    BPKSimpleDate *simpleMonth = [BPKSimpleDate simpleDatesFromDates:@[month] forCalendar:calendar.gregorian].firstObject;
-    self.selectMonthButton.enabled = [configuration isWholeMonthSelectionEnabledWithMonth:simpleMonth];
-    [self.selectMonthButton setTitle:configuration.title];
 }
 
 #pragma mark - Actions

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleSingleView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleSingleView.swift
@@ -76,14 +76,6 @@ struct CalendarExampleSingleView: View {
                 initialMonthScroll: monthScroll,
                 highlightedDates: highlightedDates
             )
-            .monthAccessoryAction { _ in
-                return CalendarMonthAccessoryAction(
-                    title: "Select whole month",
-                    action: .wholeMonthSelection({ monthRange in
-                        selection = .wholeMonth(monthRange, accessibilityConfig: wholeMonthAccessibilityConfig())
-                    })
-                )
-            }
         }
     }
 

--- a/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleWholeMonthView.swift
+++ b/Example/Backpack/SwiftUI/Components/Calendar/CalendarExampleWholeMonthView.swift
@@ -84,14 +84,6 @@ struct CalendarExampleWholeMonthView: View {
             calendar: calendar,
             validRange: validRange
         )
-        .monthAccessoryAction { _ in
-            return CalendarMonthAccessoryAction(
-                title: "Select whole month",
-                action: .wholeMonthSelection({ monthRange in
-                    selection = .wholeMonth(monthRange)
-                })
-            )
-        }
     }
 }
 

--- a/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
+++ b/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
@@ -75,7 +75,6 @@ struct CalendarGroupsProvider {
                     "With No Float Year Labelst",
                     view: CalendarExampleRangeView(showAccessoryViews: false, showFloatYearLabel: false)
                 ),
-                presentableCalendar("With Whole Month Selection", view: CalendarExampleWholeMonthView()),
                 presentableCalendar(
                     "Single Selection with highlighted dates",
                     view: CalendarExampleSingleView(includeHighlightedDates: true)

--- a/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
+++ b/Example/Backpack/Utils/FeatureStories/Groups/CalendarGroups.swift
@@ -60,15 +60,6 @@ struct CalendarGroupsProvider {
                         BPKSimpleDate(year: startingDate.year, month: startingDate.month + 2, day: 20)
                     )
                     vController.minDate = startingDate
-                },
-                presentable("With select whole month button") {
-                    $0.wholeMonthTitle = "Select whole month"
-                    let startingDate = BPKSimpleDate(year: 2020, month: 1, day: 1)
-                    $0.preselectedDates = (
-                        BPKSimpleDate(year: startingDate.year, month: startingDate.month + 1, day: 12),
-                        BPKSimpleDate(year: startingDate.year, month: startingDate.month + 1, day: 20)
-                    )
-                    $0.minDate = startingDate
                 }
             ]
         ).groups()


### PR DESCRIPTION
Ticket: [DON-1635](https://skyscanner.atlassian.net/browse/DON-1635)

Removing select whole month from calendar

| Before  | After |
| ------------- | ------------- |
|  
![Simulator Screenshot - iPhone 16 Pro - 2025-06-18 at 10 18 40](https://github.com/user-attachments/assets/004b5134-eb8e-4732-8a04-ba4eeb96956e)
 | Content Cell  |
| Content Cell  | Content Cell  |


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
