### PR TITLE
[MUON-1044] Preparation for Black weight font

### DIFF
--- a/Backpack-SwiftUI/Font/Classes/BPKFontDefinition.swift
+++ b/Backpack-SwiftUI/Font/Classes/BPKFontDefinition.swift
@@ -20,12 +20,14 @@ public protocol BPKFontDefinition {
     var fontFamily: String { get }
     var regularFontFace: String { get }
     var semiboldFontFace: String { get }
+    var blackFontFace: String { get }
 }
 
 public struct BPKRelativeFontDefinition: BPKFontDefinition {
     public var fontFamily = "SkyscannerRelativeiOS"
     public var regularFontFace = "SkyscannerRelativeiOS-Book"
     public var semiboldFontFace = "SkyscannerRelativeiOS-Bold"
+    public var blackFontFace = "SkyscannerRelativeiOS-Black"
     
     public init() {}
 }
@@ -34,6 +36,7 @@ public struct FallbackFontDefinition: BPKFontDefinition {
     public var fontFamily = "Helvetica Neue"
     public var regularFontFace = "HelveticaNeue"
     public var semiboldFontFace = "HelveticaNeue-Medium"
+    public var blackFontFace = "HelveticaNeue-Bold"
     
     public init() {}
 }

--- a/scripts/gulp/fonts.js
+++ b/scripts/gulp/fonts.js
@@ -54,7 +54,8 @@ const WEIGHT_MAP_OBJC = {
 
 const WEIGHT_MAP_SWIFTUI = {
     400: 'regular',
-    700: 'semibold'
+    700: 'semibold',
+    900: 'black'
 };
 
 const TEXT_STYLE_MAP_SWIFTUI = {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

# Preparation for Black weight on app

Adds required fields and parameters to add `black` weight (900 on css) on apps (following up from `bpk-foundations`: 
https://github.com/Skyscanner/backpack-foundations/pull/460


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
