### PR TITLE
[INC-2367] Static methods for fonts on iOS

### DIFF
--- a/Backpack-SwiftUI/Font/Classes/BPKFont.swift
+++ b/Backpack-SwiftUI/Font/Classes/BPKFont.swift
@@ -87,4 +87,23 @@ extension Font {
                 Font.custom(name, fixedSize: size)
         }
     }
+    
+    static func black(size: CGFloat, textStyle: TextStyle) -> Font {
+        return customOrDefault(
+            BPKFont.fontDefinition?.blackFontFace,
+            size: size,
+            weight: .black,
+            textStyle: textStyle
+        )
+    }
+    
+    static func blackFixed(size: CGFloat) -> Font {
+        return customOrDefault(
+            BPKFont.fontDefinition?.blackFontFace,
+            size: size,
+            weight: .black,
+            textStyle: .body) { name, size, _ in
+                Font.custom(name, fixedSize: size)
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

- Adds static methods for `black` weight font creation


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
