### PR TITLE
DON-1949 Accessibility Identifier on BPKButton not Hosting view

### DIFF
--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -30,7 +30,6 @@ public final class SwiftUIButtonViewModel: ObservableObject {
     public var action: () -> Void
     public var accessibilityIdentifier: String
     
-    
     public init(isEnabled: Bool,
                 isLoading: Bool,
                 title: String? = nil,

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -49,6 +49,7 @@ public final class SwiftUIButtonViewModel: ObservableObject {
         self.size = size
         self.action = action
         self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityLabel = accessibilityLabel
     }
 }
 

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -28,8 +28,7 @@ public final class SwiftUIButtonViewModel: ObservableObject {
     public var style: BPKButton.Style
     public var size: BPKButton.Size
     public var action: () -> Void
-    public var accessibilityLabel: String?
-    public var accessibilityIdentifier: String?
+    public var accessibilityIdentifier: String
     
     
     public init(isEnabled: Bool,
@@ -39,8 +38,7 @@ public final class SwiftUIButtonViewModel: ObservableObject {
                 style: BPKButton.Style,
                 size: BPKButton.Size = .default,
                 action: @escaping () -> Void,
-                accessibilityLabel: String? = nil,
-                accessibilityIdentifier: String? = nil) {
+                accessibilityIdentifier: String) {
         
         self.isEnabled = isEnabled
         self.isLoading = isLoading
@@ -49,7 +47,6 @@ public final class SwiftUIButtonViewModel: ObservableObject {
         self.style = style
         self.size = size
         self.action = action
-        self.accessibilityLabel = accessibilityLabel
         self.accessibilityIdentifier = accessibilityIdentifier
     }
 }
@@ -66,10 +63,7 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
             action: viewModel.action)
         .buttonStyle(viewModel.style)
         .stretchable()
-        if let identifier = viewModel.accessibilityIdentifier {
-            button = button.accessibilityIdentifier(identifier)
-        }
-        return button.accessibilityLabel(viewModel.accessibilityLabel ?? "")
+        .accessibilityIdentifier(viewModel.accessibilityIdentifier)
     }
 }
 
@@ -79,8 +73,7 @@ public extension UIView {
     static func makeReactiveSwiftUIBPKButton(
         title: String? = "",
         icon: BPKButton.Icon? = nil,
-        accessibilityIdentifier: String? = nil,
-        accessibilityLabel: String? = nil,
+        accessibilityIdentifier: String,
         style: BPKButton.Style,
         size: BPKButton.Size = .default,
         isEnabled: Bool = true,
@@ -94,7 +87,6 @@ public extension UIView {
                                                style: style,
                                                size: size,
                                                action: action,
-                                               accessibilityLabel: accessibilityLabel,
                                                accessibilityIdentifier: accessibilityIdentifier)
         
         let wrapperView = ReactiveSwiftUIBPKButtonWrapper(

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -66,8 +66,10 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
             action: viewModel.action)
         .buttonStyle(viewModel.style)
         .stretchable()
-        .accessibilityIdentifier(viewModel.accessibilityIdentifier ?? "")
-        .accessibilityLabel(viewModel.accessibilityLabel ?? "")
+        if let identifier = viewModel.accessibilityIdentifier {
+            button = button.accessibilityIdentifier(identifier)
+        }
+        return button.accessibilityLabel(viewModel.accessibilityLabel ?? "")
     }
 }
 

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -28,6 +28,9 @@ public final class SwiftUIButtonViewModel: ObservableObject {
     public var style: BPKButton.Style
     public var size: BPKButton.Size
     public var action: () -> Void
+    public var accessibilityLabel: String?
+    public var accessibilityIdentifier: String?
+    
     
     public init(isEnabled: Bool,
                 isLoading: Bool,
@@ -35,7 +38,9 @@ public final class SwiftUIButtonViewModel: ObservableObject {
                 icon: BPKButton.Icon? = nil,
                 style: BPKButton.Style,
                 size: BPKButton.Size = .default,
-                action: @escaping () -> Void) {
+                action: @escaping () -> Void,
+                accessibilityLabel: String? = nil,
+                accessibilityIdentifier: String? = nil) {
         
         self.isEnabled = isEnabled
         self.isLoading = isLoading
@@ -44,6 +49,8 @@ public final class SwiftUIButtonViewModel: ObservableObject {
         self.style = style
         self.size = size
         self.action = action
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 }
 
@@ -59,6 +66,8 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
             action: viewModel.action)
         .buttonStyle(viewModel.style)
         .stretchable()
+        .accessibilityIdentifier(viewModel.accessibilityIdentifier ?? "")
+        .accessibilityLabel(viewModel.accessibilityLabel ?? "")
     }
 }
 
@@ -82,7 +91,9 @@ public extension UIView {
                                                icon: icon,
                                                style: style,
                                                size: size,
-                                               action: action)
+                                               action: action,
+                                               accessibilityLabel: accessibilityLabel,
+                                               accessibilityIdentifier: accessibilityIdentifier)
         
         let wrapperView = ReactiveSwiftUIBPKButtonWrapper(
             viewModel: viewModel
@@ -91,8 +102,6 @@ public extension UIView {
         let hostingController = UIHostingController(rootView: wrapperView)
         hostingController.view.backgroundColor = .clear
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        hostingController.view.accessibilityIdentifier = accessibilityIdentifier
-        hostingController.view.accessibilityLabel = accessibilityLabel
         
         return (hostingController.view, viewModel)
     }

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -38,8 +38,8 @@ public final class SwiftUIButtonViewModel: ObservableObject {
                 style: BPKButton.Style,
                 size: BPKButton.Size = .default,
                 action: @escaping () -> Void,
-                accessibilityIdentifier: String?,
-                accessibilityLabel: String?) {
+                accessibilityIdentifier: String? = nil,
+                accessibilityLabel: String? = nil) {
         
         self.isEnabled = isEnabled
         self.isLoading = isLoading
@@ -80,8 +80,8 @@ public extension UIView {
     static func makeReactiveSwiftUIBPKButton(
         title: String? = "",
         icon: BPKButton.Icon? = nil,
-        accessibilityIdentifier: String?,
-        accessibilityLabel: String?,
+        accessibilityIdentifier: String? = nil,
+        accessibilityLabel: String? = nil,
         style: BPKButton.Style,
         size: BPKButton.Size = .default,
         isEnabled: Bool = true,

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -65,10 +65,10 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
             action: viewModel.action)
         .buttonStyle(viewModel.style)
         .stretchable()
-        .if(!(viewModel.accessibilityLabel?.isEmpty ?? false)) { button in
+        .if((viewModel.accessibilityLabel?.isEmpty ?? false)) { button in
             button.accessibilityLabel(viewModel.accessibilityLabel!)
         }
-        .if(!(viewModel.accessibilityIdentifier?.isEmpty ?? false)) { button in
+        .if((viewModel.accessibilityIdentifier?.isEmpty ?? false)) { button in
             button.accessibilityIdentifier(viewModel.accessibilityIdentifier!)
         }
     }

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -65,10 +65,10 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
             action: viewModel.action)
         .buttonStyle(viewModel.style)
         .stretchable()
-        .if((viewModel.accessibilityLabel?.isEmpty ?? false)) { button in
+        .if((viewModel.accessibilityLabel?.isEmpty == false)) { button in
             button.accessibilityLabel(viewModel.accessibilityLabel!)
         }
-        .if((viewModel.accessibilityIdentifier?.isEmpty ?? false)) { button in
+        .if((viewModel.accessibilityIdentifier?.isEmpty == false)) { button in
             button.accessibilityIdentifier(viewModel.accessibilityIdentifier!)
         }
     }

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -28,7 +28,8 @@ public final class SwiftUIButtonViewModel: ObservableObject {
     public var style: BPKButton.Style
     public var size: BPKButton.Size
     public var action: () -> Void
-    public var accessibilityIdentifier: String
+    public var accessibilityIdentifier: String?
+    public var accessibilityLabel: String?
     
     public init(isEnabled: Bool,
                 isLoading: Bool,
@@ -37,7 +38,8 @@ public final class SwiftUIButtonViewModel: ObservableObject {
                 style: BPKButton.Style,
                 size: BPKButton.Size = .default,
                 action: @escaping () -> Void,
-                accessibilityIdentifier: String) {
+                accessibilityIdentifier: String?,
+                accessibilityLabel: String?) {
         
         self.isEnabled = isEnabled
         self.isLoading = isLoading
@@ -52,7 +54,7 @@ public final class SwiftUIButtonViewModel: ObservableObject {
 
 public struct ReactiveSwiftUIBPKButtonWrapper: View {
     @ObservedObject var viewModel: SwiftUIButtonViewModel
-
+    
     public var body: some View {
         BPKButton(viewModel.title ?? "",
                   icon: viewModel.icon,
@@ -62,7 +64,12 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
             action: viewModel.action)
         .buttonStyle(viewModel.style)
         .stretchable()
-        .accessibilityIdentifier(viewModel.accessibilityIdentifier)
+        .if(!(viewModel.accessibilityLabel?.isEmpty ?? false)) { button in
+            button.accessibilityLabel(viewModel.accessibilityLabel!)
+        }
+        .if(!(viewModel.accessibilityIdentifier?.isEmpty ?? false)) { button in
+            button.accessibilityIdentifier(viewModel.accessibilityIdentifier!)
+        }
     }
 }
 
@@ -72,7 +79,8 @@ public extension UIView {
     static func makeReactiveSwiftUIBPKButton(
         title: String? = "",
         icon: BPKButton.Icon? = nil,
-        accessibilityIdentifier: String,
+        accessibilityIdentifier: String?,
+        accessibilityLabel: String?,
         style: BPKButton.Style,
         size: BPKButton.Size = .default,
         isEnabled: Bool = true,
@@ -86,7 +94,8 @@ public extension UIView {
                                                style: style,
                                                size: size,
                                                action: action,
-                                               accessibilityIdentifier: accessibilityIdentifier)
+                                               accessibilityIdentifier: accessibilityIdentifier,
+                                               accessibilityLabel: accessibilityLabel)
         
         let wrapperView = ReactiveSwiftUIBPKButtonWrapper(
             viewModel: viewModel


### PR DESCRIPTION
Ticket: [DON-1949](https://skyscanner.atlassian.net/browse/DON-1949)

Move identifier to actual BPKButton not the hosting view

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_


[DON-1949]: https://skyscanner.atlassian.net/browse/DON-1949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ