### PR TITLE
DON-1953 add warning label to BPKButton wrapper

### DIFF
--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -77,6 +77,7 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
 public extension UIView {
     
     /// Creates a SwiftUI BPKButton wrapped in a UIHostingController and returns both the view and its ViewModel
+    @available(*, deprecated, message: "Still in development not working perfectly with UIKit")
     static func makeReactiveSwiftUIBPKButton(
         title: String? = "",
         icon: BPKButton.Icon? = nil,

--- a/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
+++ b/Backpack-SwiftUI/Button/Classes/UIView+SwiftUIButton.swift
@@ -77,7 +77,8 @@ public struct ReactiveSwiftUIBPKButtonWrapper: View {
 public extension UIView {
     
     /// Creates a SwiftUI BPKButton wrapped in a UIHostingController and returns both the view and its ViewModel
-    @available(*, deprecated, message: "Still in development not working perfectly with UIKit")
+    /// This method is valid to use however be cautious with some usage in UIKit
+    /// Current known issue in StackViews with a hoziontal setting, more issues could occur.
     static func makeReactiveSwiftUIBPKButton(
         title: String? = "",
         icon: BPKButton.Icon? = nil,


### PR DESCRIPTION
Ticket: [DON-1953](https://skyscanner.atlassian.net/browse/DON-1953)

Add warning label to wrapper

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_


[DON-1953]: https://skyscanner.atlassian.net/browse/DON-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ