### PR TITLE
[MUON-1147] BPKSnippet changes

### DIFF
--- a/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
+++ b/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
@@ -59,9 +59,9 @@ public struct BPKSnippet: View {
             }
             if let bodyText {
                 let topPadding: CGFloat = {
-                    if subheading != nil { return .xl }
-                    if headline != nil { return .sm }
-                    return .base
+                    if subheading != nil { return BPKSpacing.xl.value }
+                    if headline != nil { return BPKSpacing.sm.value }
+                    return BPKSpacing.base.value
                 }()
                 BPKText(bodyText, style: .bodyDefault)
                     .lineLimit(nil)

--- a/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
+++ b/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
@@ -50,17 +50,22 @@ public struct BPKSnippet: View {
                 BPKText(headline, style: .heading5)
                     .lineLimit(nil)
                     .accessibilityAddTraits(.isHeader)
-                    .padding(.bottom, .sm)
+                    .padding(.top, .base)
             }
             if let subheading {
                 BPKText(subheading, style: .subheading)
                     .lineLimit(nil)
-                    .padding(.bottom, .xl)
+                    .padding(.top, headline != nil ? .sm : .base)
             }
             if let bodyText {
+                let topPadding: CGFloat = {
+                    if subheading != nil { return .xl }
+                    if headline != nil { return .sm }
+                    return .base
+                }()
                 BPKText(bodyText, style: .bodyDefault)
                     .lineLimit(nil)
-                    .padding(.bottom, .base)
+                    .padding(.top, topPadding)
             }
         }
         .accessibilityElement(children: .combine)
@@ -80,7 +85,6 @@ public struct BPKSnippet: View {
         }
         .aspectRatio(aspectRatio(for: imageOrientation), contentMode: .fit)
         .clipShape(RoundedRectangle(cornerRadius: .md, style: .continuous))
-        .padding(.bottom, .md)
     }
     
     private func aspectRatio(for imageOrientation: ImageOrientation) -> CGFloat {

--- a/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
+++ b/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
@@ -69,6 +69,7 @@ public struct BPKSnippet: View {
             }
         }
         .accessibilityElement(children: .combine)
+        .fixedSize(horizontal: false, vertical: true)
         .accessibilityAddTraits(.isButton)
         .onTapGesture {
             onClick?()

--- a/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
+++ b/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
@@ -47,7 +47,7 @@ public struct BPKSnippet: View {
             imageView
 
             if let headline {
-                BPKText(headline, style: .heading5)
+                BPKText(headline, style: .heading4)
                     .lineLimit(nil)
                     .accessibilityAddTraits(.isHeader)
                     .padding(.top, .base)


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
[MUON-1147](https://skyscanner.atlassian.net/browse/MUON-1147?atlOrigin=eyJpIjoiNTU4MzZjZmI2MzI1NDc4ZGJjM2QyZmNkNTI3ZmMxMmQiLCJwIjoiaiJ9)

- Removes bottom padding to better adjust in implementations
- Changes Headline to be `heading4`
- Updates snapshots accordingly


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_


[MUON-1147]: https://skyscanner.atlassian.net/browse/MUON-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ