### PR TITLE
[MUON-1148] `BPKCardList` Make single rail element fill full width

### DIFF
--- a/Backpack-SwiftUI/CardList/Classes/BPKCardList.swift
+++ b/Backpack-SwiftUI/CardList/Classes/BPKCardList.swift
@@ -50,23 +50,36 @@ public struct BPKCardList<Element: Identifiable, Content: View>: View {
 
     public var body: some View {
         switch layout {
-        case .rail(let sectionHeaderAction):
-            railLayout(with: sectionHeaderAction)
+        case .rail(let sectionHeaderAction, let cardWidth):
+            railLayout(with: sectionHeaderAction, cardWidth: cardWidth)
         case .stack(let accessory):
             stackLayout(with: accessory)
         }
     }
 
-    private func railLayout(with sectionHeaderAction: BPKCardListLayout.SectionHeaderAction?) -> some View {
+    private func railLayout(
+        with sectionHeaderAction: BPKCardListLayout.SectionHeaderAction?,
+        cardWidth: CGFloat?
+    ) -> some View {
         cardListSkeleton(with: sectionHeaderAction) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: .base) {
-                    ForEach(elements) { index in
-                        cardForElement(index)
-                    }
+            if elements.count == 1, let only = elements.first {
+                VStack {
+                    cardForElement(only)
+                        .frame(maxWidth: .infinity)
                 }
                 .padding(.horizontal, .base)
                 .padding(.vertical, .sm)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .top, spacing: .base) {
+                        ForEach(elements) { element in
+                            cardForElement(element)
+                                .applyCardWidth(cardWidth)
+                        }
+                    }
+                    .padding(.horizontal, .base)
+                    .padding(.vertical, .sm)
+                }
             }
         }
     }
@@ -140,6 +153,17 @@ public struct BPKCardList<Element: Identifiable, Content: View>: View {
             .buttonStyle(.link)
             .stretchable()
             .accessibilityIdentifier("BPKCardListExpandButton")
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func applyCardWidth(_ width: CGFloat?) -> some View {
+        if let width {
+            self.frame(width: width)
+        } else {
+            self
         }
     }
 }

--- a/Backpack-SwiftUI/CardList/Classes/BPKCardListLayout.swift
+++ b/Backpack-SwiftUI/CardList/Classes/BPKCardListLayout.swift
@@ -19,6 +19,6 @@
 import SwiftUI
 
 public enum BPKCardListLayout {
-    case rail(sectionHeaderAction: SectionHeaderAction? = nil)
+    case rail(sectionHeaderAction: SectionHeaderAction? = nil, cardWidth: CGFloat? = nil)
     case stack(accessory: Accessory? = nil)
 }


### PR DESCRIPTION
[MUON-1148](https://skyscanner.atlassian.net/browse/MUON-1148?atlOrigin=eyJpIjoiYmIzM2IxMDM4NTk0NDRmNzg4NmIzM2U3NjIwZTY4ODgiLCJwIjoiaiJ9)



Rail layout now expands a single element to occupy available horizontal space instead of using a horizontal scroll container.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
