### PR TITLE
DON-2091 Fix accessibility 

### DIFF
--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
@@ -29,7 +29,7 @@ struct CalendarContainer<MonthContent: View>: View {
 
     @State private var hasScrolledToItem = false
     @StateObject private var visibilityObserver: ItemVisibilityObserver
-    @Environment(\.accessibilityVoiceOverEnabled) var vo
+    @Environment(\.accessibilityVoiceOverEnabled) var voiceOverEnabled
 
     init(
         calendar: Calendar,
@@ -85,7 +85,7 @@ struct CalendarContainer<MonthContent: View>: View {
                 .onChange(of: visibilityObserver.visibleItems) { newVisibleItems in
                     updateOnScrollToMonthHandler(newVisibleItems: newVisibleItems)
                 }
-                .padding(.horizontal, vo ? BPKSpacing.md.value : 0)
+                .padding(.horizontal, voiceOverEnabled ? BPKSpacing.md.value : 0)
             }
         }
     }

--- a/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
+++ b/Backpack-SwiftUI/Calendar/Classes/Core/CalendarContainer.swift
@@ -29,6 +29,7 @@ struct CalendarContainer<MonthContent: View>: View {
 
     @State private var hasScrolledToItem = false
     @StateObject private var visibilityObserver: ItemVisibilityObserver
+    @Environment(\.accessibilityVoiceOverEnabled) var vo
 
     init(
         calendar: Calendar,
@@ -84,6 +85,7 @@ struct CalendarContainer<MonthContent: View>: View {
                 .onChange(of: visibilityObserver.visibleItems) { newVisibleItems in
                     updateOnScrollToMonthHandler(newVisibleItems: newVisibleItems)
                 }
+                .padding(.horizontal, vo ? BPKSpacing.md.value : 0)
             }
         }
     }


### PR DESCRIPTION
Fix accessibility where last day of the week can't be selected in calendar

Following this conversation with designers it has been decided to add a padding around the calendar when voice over is activated to prevent the scroll bar to cover the activation point of the right side dates: https://skyscanner.slack.com/archives/C07LH0LRCAK/p1758121883831479

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
