### PR TITLE
[DON-2112] Remove `OCMock` dependency (non-SPM support) from test target

### DIFF
--- a/Backpack.podspec
+++ b/Backpack.podspec
@@ -51,7 +51,6 @@ Pod::Spec.new do |s|
   end  
 
   s.test_spec 'UnitTests' do |test_spec|
-    test_spec.dependency 'OCMock', '~> 3.8.1'
     test_spec.source_files = 'Backpack/Tests/UnitTests/**/*.{swift,h,m}'
     test_spec.ios.resource_bundle = {
     'UnitTestImages' => 'Backpack/Tests/UnitTests/Images*'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -17,9 +17,7 @@ PODS:
   - Backpack/UnitTests (1.0):
     - Backpack-Common
     - FloatingPanel (= 2.8.6)
-    - OCMock (~> 3.8.1)
   - FloatingPanel (2.8.6)
-  - OCMock (3.8.1)
   - SnapshotTesting (1.9.0)
   - SwiftLint (0.43.1)
 
@@ -37,7 +35,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - FloatingPanel
-    - OCMock
     - SnapshotTesting
     - SwiftLint
 
@@ -52,12 +49,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Backpack: db8f6ed74fd42b941ed26074f14afbd94259d3df
+  Backpack: 0f22ea0965fc8ad65ec5a515036e40fa8d71e1fc
   Backpack-Common: e8993f9fa4e7a79236ea16a4a06b5f73f3517d53
   Backpack-Fonts: 2ed96553a5325156a154d788defbdc6306dae5ef
   Backpack-SwiftUI: 68146835f8aa1cbfa4814e24dce4abbb0b8d0d84
   FloatingPanel: 11559d3700c39f1c2ee8dbb7a5415223b52fdce0
-  OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
   SnapshotTesting: 6141c48b6aa76ead61431ca665c14ab9a066c53b
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 


### PR DESCRIPTION
[DON-2112] 
**There's no support of  `OCMock` in SPM.**
Replaces usage of OCMock in BPKFontTest.m with a custom BPKFontManagerStub, and removes OCMock from Backpack.podspec and Podfile.lock. This simplifies test dependencies and avoids reliance on external mocking frameworks.

<img width="768" height="196" alt="Screenshot 2025-09-24 at 12 25 42" src="https://github.com/user-attachments/assets/6ee6e190-9946-468a-8402-abd641fd852d" />