### PR TITLE
DON-2866 update script to handle full value, add full corner radius

### DIFF
--- a/Backpack-SwiftUI/Radii/Classes/Generated/BPKRadii.swift
+++ b/Backpack-SwiftUI/Radii/Classes/Generated/BPKRadii.swift
@@ -35,6 +35,9 @@ public extension RoundedRectangle {
 
 public extension BPKCornerRadius {
     
+    /// The Skyscanner full radius.
+    static let full = BPKCornerRadius(value: 100)
+
     /// The Skyscanner medium radius.
     static let md = BPKCornerRadius(value: 12)
 

--- a/Backpack-SwiftUI/Tests/Radii/RadiiTests.swift
+++ b/Backpack-SwiftUI/Tests/Radii/RadiiTests.swift
@@ -21,6 +21,7 @@ import XCTest
 
 class RadiiTests: XCTestCase {
     func testSpacingsHaveCorrectValues() {
+        XCTAssertEqual(BPKCornerRadius.full.value, 100)
         XCTAssertEqual(BPKCornerRadius.lg.value, 24)
         XCTAssertEqual(BPKCornerRadius.md.value, 12)
         XCTAssertEqual(BPKCornerRadius.sm.value, 8)

--- a/Backpack/Radii/Classes/Generated/BPKRadii.h
+++ b/Backpack/Radii/Classes/Generated/BPKRadii.h
@@ -25,6 +25,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ * The Skyscanner full radius.
+ */
+extern CGFloat const BPKCornerRadiusFull;
+
+/**
  * The Skyscanner medium radius.
  */
 extern CGFloat const BPKCornerRadiusMd;

--- a/Backpack/Radii/Classes/Generated/BPKRadii.m
+++ b/Backpack/Radii/Classes/Generated/BPKRadii.m
@@ -18,6 +18,8 @@
  */
 #import "BPKRadii.h"
 
+CGFloat const BPKCornerRadiusFull = 100;
+
 CGFloat const BPKCornerRadiusMd = 12;
 
 CGFloat const BPKCornerRadiusSm = 8;

--- a/Example/Backpack/SwiftUI/Tokens/RadiusTokensView.swift
+++ b/Example/Backpack/SwiftUI/Tokens/RadiusTokensView.swift
@@ -27,7 +27,8 @@ struct RadiusTokensView: View {
         ("BPKCornerRadiusXs", .xs),
         ("BPKCornerRadiusSm", .sm),
         ("BPKCornerRadiusMd", .md),
-        ("BPKCornerRadiusLg", .lg)
+        ("BPKCornerRadiusLg", .lg),
+        ("BPKCornerRadiusFull", .full)
     ]
     
     var body: some View {

--- a/scripts/gulp/radii.js
+++ b/scripts/gulp/radii.js
@@ -20,7 +20,7 @@ const _ = require('lodash');
 const { formatPrefixedConstName, lowercaseFirstLetter } = require('./utils/formatUtils');
 const getLegibleName = require('./utils/legibleName');
 
-const VALID_RADII = new Set(['xs', 'sm', 'md', 'lg', 'pill']);
+const VALID_RADII = new Set(['xs', 'sm', 'md', 'lg', 'pill', 'full']);
 
 const radii = (properties, formatName) => _.chain(properties)
   .filter(({ category }) => category === 'radii')

--- a/scripts/gulp/utils/legibleName.js
+++ b/scripts/gulp/utils/legibleName.js
@@ -30,6 +30,7 @@ const LEGIBLE_NAMES = [
   { identifier: 'Pill', legibleName: 'pill' },
   { identifier: 'None', legibleName: 'none' },
   { identifier: 'IconText', legibleName: 'icon text' },
+  { identifier: 'Full', legibleName: 'full' },
 ];
 
 const getLegibleName = (name) => {


### PR DESCRIPTION
Ticket: [DON-2866](https://skyscanner.atlassian.net/browse/DON-2866)

- Update scripts to handle `full` size on Radii
- Add `BPKCornerRadiusFull = 100`

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_


[DON-2866]: https://skyscanner.atlassian.net/browse/DON-2866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ