### PR TITLE
fix(BpkConfiguration): Remove sync dispatch to prevent main thread deadlocks

### DIFF
--- a/Backpack-Common/Configuration/Classes/BPKConfiguration.swift
+++ b/Backpack-Common/Configuration/Classes/BPKConfiguration.swift
@@ -166,8 +166,8 @@ public final class BpkConfiguration: NSObject {
     }
 
     private func emitSignalIfNeeded() {
-        guard !configIsAccessed else { return }
-
+        // Use async with barrier - this doesn't block the calling thread
+        // The barrier ensures thread-safe access to configIsAccessed
         configurationAccessQueue.async(flags: .barrier) {
             if !self.configIsAccessed {
                 self.configIsAccessed = true

--- a/Backpack-Common/Configuration/Classes/BPKConfiguration.swift
+++ b/Backpack-Common/Configuration/Classes/BPKConfiguration.swift
@@ -162,12 +162,12 @@ public final class BpkConfiguration: NSObject {
     
     private func getConfig<T>(getter: () -> T) -> T {
         emitSignalIfNeeded()
-        return configurationAccessQueue.sync {
-            getter()
-        }
+        return getter()
     }
-    
+
     private func emitSignalIfNeeded() {
+        guard !configIsAccessed else { return }
+
         configurationAccessQueue.async(flags: .barrier) {
             if !self.configIsAccessed {
                 self.configIsAccessed = true

--- a/Backpack-Common/Tests/BPKConfigurationTests.swift
+++ b/Backpack-Common/Tests/BPKConfigurationTests.swift
@@ -101,4 +101,39 @@ final class BpkConfigurationTests: XCTestCase {
         // Then
         XCTAssertNil(config.badgeConfig)
     }
+
+    func testOnConfigurationAccessedCallbackFiresExactlyOnceUnderConcurrentAccess() {
+        // Given
+        let config = BpkConfiguration.shared
+        var callCount = 0
+        let callCountLock = NSLock()
+        let expectation = self.expectation(description: "Callback fires")
+
+        config.onConfigurationAccessed = {
+            callCountLock.lock()
+            callCount += 1
+            callCountLock.unlock()
+            expectation.fulfill()
+        }
+
+        // When - Access config from multiple threads simultaneously
+        let group = DispatchGroup()
+        for _ in 0..<20 {
+            group.enter()
+            DispatchQueue.global().async {
+                _ = config.chipConfig
+                _ = config.iconConfig
+                group.leave()
+            }
+        }
+
+        // Then - Callback should fire exactly once
+        waitForExpectations(timeout: 2)
+        group.wait()
+
+        // Small delay to catch any late duplicate callbacks
+        usleep(100000) // 100ms
+
+        XCTAssertEqual(callCount, 1, "Callback fired \(callCount) times, expected exactly 1")
+    }
 }


### PR DESCRIPTION
## Summary

  Removes the synchronous dispatch queue wrapper from `BpkConfiguration` property getters to prevent main thread deadlocks under thread pool saturation conditions.

  ## Problem

  The `getConfig` method uses `configurationAccessQueue.sync {}` to wrap all property reads:

  ```swift
  private func getConfig<T>(getter: () -> T) -> T {
      emitSignalIfNeeded()
      return configurationAccessQueue.sync {
          getter()
      }
  }
  ```

  This causes main thread hangs when:
  1. The GCD thread pool becomes saturated (e.g., by analytics SDKs spawning many threads)
  2. Main thread calls .sync on a queue that needs a worker thread
  3. No worker threads are available → main thread blocks indefinitely

## Solution

  Remove the sync dispatch wrapper. Configuration values are set once at app bootstrap and only read thereafter - synchronous dispatch is unnecessary for immutable-after-init values.

  ```swift
  private func getConfig<T>(getter: () -> T) -> T {
      emitSignalIfNeeded()
      return getter()
  }
  ```

### Why This Is Safe

  - `BpkConfiguration` follows a "write-once, read-many" pattern
  - All `set(configs:)` calls happen during app initialisation, before any UI renders
  - The `hasSet` guard prevents configuration from being modified after initial setup
  - Property reads after bootstrap are effectively reading immutable values
  - The `onConfigurationAccessed` callback mechanism is preserved via the existing async barrier dispatch