### PR TITLE
Improve floating notification accessibility announcement timing

### DIFF
--- a/Backpack/FloatingNotification/Classes/FloatingNotificationAnimator.swift
+++ b/Backpack/FloatingNotification/Classes/FloatingNotificationAnimator.swift
@@ -33,6 +33,8 @@ final class FloatingNotificationAnimator {
             notification.alpha = 1
             notification.bottomConstraint.constant = displayedBottomConstraintConstant
             notification.superview?.layoutIfNeeded()
+        }
+        upAnimator.addCompletion { position in
             UIAccessibility.post(notification: .layoutChanged, argument: notification.messageLabel)
         }
         upAnimator.startAnimation()


### PR DESCRIPTION
Updates `FloatingNotificationAnimator` so the VoiceOver layout change notification is posted after the floating notification presentation animation completes.

This ensures the notification message label is announced once the notification has finished moving into its displayed position.

## Before 

https://github.com/user-attachments/assets/d596469e-3cbc-4862-99c5-a7485844f706


## After 

https://github.com/user-attachments/assets/5e08bfb5-fd12-4dc7-8464-b6de1db898a2


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md` - Not applicable; no documentation or API changes.
+ [ ] Tests - Not added; small UIKit animation completion timing change.
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift) - Not applicable; no visual change.
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h) - Not applicable; no new component.
