### PR TITLE
Fix BPKCellItem scroll interference from press-tracking DragGesture

### DIFF
--- a/Backpack-SwiftUI/CellItem/Classes/BPKCellItem.swift
+++ b/Backpack-SwiftUI/CellItem/Classes/BPKCellItem.swift
@@ -42,8 +42,6 @@ public struct BPKCellItem: View {
     private let slot: BPKCellItemSlot?
     private let onClick: (() -> Void)?
 
-    @State private var isPressed: Bool = false
-
     /// Creates a cell item with the specified content and configuration.
     /// - Parameters:
     ///   - title: The primary text displayed in the cell (required).
@@ -72,28 +70,23 @@ public struct BPKCellItem: View {
     }
 
     public var body: some View {
-        contentView
-            .padding(.base)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(backgroundColor)
-            .cornerRadius(cornerRadius)
-            .opacity(isPressed ? 0.7 : 1.0)
-            .contentShape(Rectangle())
-            .if(onClick != nil) { view in
-                view
-                    .onTapGesture {
-                        onClick?()
-                    }
-                    .simultaneousGesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged { _ in isPressed = true }
-                            .onEnded { _ in isPressed = false }
-                    )
+        if let onClick = onClick {
+            Button(action: onClick) {
+                contentView
             }
+            .buttonStyle(CellItemButtonStyle(
+                backgroundColor: backgroundColor,
+                cornerRadius: cornerRadius
+            ))
             .accessibilityElement(children: hasAccessibleSlot ? .contain : .combine)
-            .if(onClick != nil) { view in
-                view.accessibilityAddTraits(.isButton)
-            }
+            .accessibilityAddTraits(.isButton)
+        } else {
+            // Render without Button so non-clickable cells aren't focusable or exposed as buttons to a11y.
+            contentView
+                .background(backgroundColor)
+                .cornerRadius(cornerRadius)
+                .accessibilityElement(children: hasAccessibleSlot ? .contain : .combine)
+        }
     }
 
     @ViewBuilder
@@ -112,6 +105,8 @@ public struct BPKCellItem: View {
                 slotView(for: slot)
             }
         }
+        .padding(.base)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
@@ -180,6 +175,19 @@ public struct BPKCellItem: View {
         default:
             return false
         }
+    }
+}
+
+private struct CellItemButtonStyle: ButtonStyle {
+    let backgroundColor: BPKColor
+    let cornerRadius: CGFloat
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background(backgroundColor)
+            .cornerRadius(cornerRadius)
+            .opacity(configuration.isPressed ? 0.7 : 1.0)
+            .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
## Summary
- `BPKCellItem` used `DragGesture(minimumDistance: 0)` to drive its `isPressed` opacity feedback. With `minimumDistance: 0` the gesture wins ownership of touches as soon as a finger lands, which prevents a parent `ScrollView` / `List` from picking up the drag and scrolling.
- Replaced the gesture with a `Button` wrapped in a private `CellItemButtonStyle` that reads `configuration.isPressed`. Same visual feedback (0.7 opacity), but the button gesture cooperates with scroll gestures rather than blocking them. This matches the pattern already used in `BPKCard`.
- Non-clickable cells (no `onClick`) skip the `Button` entirely so they're not focusable or announced as buttons by VoiceOver.
- Accessibility ordering preserved: `accessibilityElement(children:)` runs before `accessibilityAddTraits(.isButton)` so the synthesised element keeps the button trait.

## Test plan
- [x] All 15 `BPKCellItemTests` snapshot tests pass on iPhone SE (3rd generation), iOS 18.6 — no diffs from the refactor.
- [x] Verify scroll behaviour by hand: place `BPKCellItem`s in a `List` / `ScrollView` and confirm a finger drag scrolls the parent instead of being trapped by the cell.
- [x] Verify VoiceOver: clickable cell announces as a button and is focusable; non-clickable cell is not focusable as a button.

| Before:  Scroll is not working  | After:  Scroll is now working  |
| -------- | ------- |
| <img width="554" height="1040" alt="before scroll fix" src="https://github.com/user-attachments/assets/48a34cd7-66aa-4394-90ce-8c8ffae90831" />  |  <img width="554" height="1040" alt="after scrolling fix" src="https://github.com/user-attachments/assets/f70721c7-7b8f-438c-a608-d44f0cd183b1" />  |

🤖 Generated with [Claude Code](https://claude.com/claude-code)