### PR TITLE
Make BPKGraphicPromo generic to support custom sponsored backgrounds

### DIFF
--- a/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
+++ b/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
@@ -24,6 +24,22 @@ private enum BPKGraphicPromoConstants {
     static let aspectRatioDesktop: CGFloat = 2.66
 }
 
+public enum BPKGraphicPromoLayoutType {
+    case mobile
+    case tablet
+    case desktop
+}
+
+public struct BPKGraphicPromoCallToAction {
+    public let accessibilityLabel: String
+    public let onClick: () -> Void
+
+    public init(accessibilityLabel: String, onClick: @escaping () -> Void) {
+        self.accessibilityLabel = accessibilityLabel
+        self.onClick = onClick
+    }
+}
+
 public struct BPKGraphicPromo<Background: View>: View {
     @Environment(\.sizeCategory) var sizeCategory
     
@@ -55,12 +71,8 @@ public struct BPKGraphicPromo<Background: View>: View {
     private let padding = BPKSpacing.lg
     private let cornerRadius = BPKCornerRadius.md
     
-    public enum LayoutType {
-        case mobile
-        case tablet
-        case desktop
-    }
-    
+    public typealias LayoutType = BPKGraphicPromoLayoutType
+
     public init(
         kicker: String? = nil,
         headline: String,
@@ -321,15 +333,7 @@ public extension BPKGraphicPromo where Background == AnyView {
 }
 
 public extension BPKGraphicPromo {
-    struct CallToAction {
-        public let accessibilityLabel: String
-        public let onClick: () -> Void
-
-        public init(accessibilityLabel: String, onClick: @escaping () -> Void) {
-            self.accessibilityLabel = accessibilityLabel
-            self.onClick = onClick
-        }
-    }
+    typealias CallToAction = BPKGraphicPromoCallToAction
 }
 
 private struct GraphicPromoButtonStyle<Background: View>: ButtonStyle {

--- a/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
+++ b/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
@@ -18,7 +18,13 @@
 
 import SwiftUI
 
-public struct BPKGraphicPromo: View {
+private enum BPKGraphicPromoConstants {
+    static let aspectRatioMobile: CGFloat = 3/4
+    static let aspectRatioTablet: CGFloat = 1.96
+    static let aspectRatioDesktop: CGFloat = 2.66
+}
+
+public struct BPKGraphicPromo<Background: View>: View {
     @Environment(\.sizeCategory) var sizeCategory
     
     private struct Sponsor {
@@ -28,16 +34,10 @@ public struct BPKGraphicPromo: View {
         let callToAction: CallToAction
     }
 
-    private struct Constants {
-        static let aspectRatioMobile: CGFloat = 3/4
-        static let aspectRatioTablet: CGFloat = 1.96
-        static let aspectRatioDesktop: CGFloat = 2.66
-    }
-    
     private let kicker: String?
     private let headline: String
     private let subheadline: String?
-    private let image: Image
+    private let backgroundContent: Background
     
     private let type: `Type`
     private let layoutType: LayoutType
@@ -62,32 +62,8 @@ public struct BPKGraphicPromo: View {
     }
     
     public init(
-        kicker: String? = nil,
         headline: String,
-        subheadline: String? = nil,
-        image: Image,
-        type: `Type` = .button,
-        layoutType: LayoutType = .mobile,
-        overlay: BPKOverlayType = .solid(.off),
-        variant: Variant = .onDark,
-        verticalAlignment: BPKGraphicPromo.VerticalAlignment = .top
-    ) {
-        self.kicker = kicker
-        self.headline = headline
-        self.subheadline = subheadline
-        self.image = image
-            
-        self.type = type
-        self.layoutType = layoutType
-        self.overlay = overlay
-        self.variant = variant
-            
-        self.verticalAlignment = verticalAlignment
-    }
-    
-    public init(
-        headline: String,
-        image: Image,
+        @ViewBuilder background: () -> Background,
         type: `Type` = .button,
         layoutType: LayoutType = .mobile,
         overlay: BPKOverlayType = .linear(.high, .bottom),
@@ -101,7 +77,7 @@ public struct BPKGraphicPromo: View {
         self.headline = headline
         self.kicker = nil
         self.subheadline = nil
-        self.image = image
+        self.backgroundContent = background()
         self.type = type
         self.layoutType = layoutType
         self.overlay = overlay
@@ -121,7 +97,7 @@ public struct BPKGraphicPromo: View {
                 .padding(padding)
         }
         .buttonStyle(GraphicPromoButtonStyle(
-            image: image,
+            backgroundContent: backgroundContent,
             overlay: overlay,
             backgroundColor: backgroundColor,
             cornerRadius: cornerRadius
@@ -240,13 +216,13 @@ public struct BPKGraphicPromo: View {
     }
     
     // MARK: - Public modifiers
-    public func fallbackColor(_ color: Color) -> BPKGraphicPromo {
+    public func fallbackColor(_ color: Color) -> BPKGraphicPromo<Background> {
         var view = self
         view.backgroundColor = color
         return view
     }
     
-    public func onTapGesture(perform: @escaping () -> Void) -> BPKGraphicPromo {
+    public func onTapGesture(perform: @escaping () -> Void) -> BPKGraphicPromo<Background> {
         var result = self
         result.tapAction = {
             let hapticFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
@@ -259,12 +235,66 @@ public struct BPKGraphicPromo: View {
     private func aspectRatio() -> CGFloat {
         switch layoutType {
         case .mobile:
-            return Constants.aspectRatioMobile
+            return BPKGraphicPromoConstants.aspectRatioMobile
         case .tablet:
-            return Constants.aspectRatioTablet
+            return BPKGraphicPromoConstants.aspectRatioTablet
         case .desktop:
-            return Constants.aspectRatioDesktop
+            return BPKGraphicPromoConstants.aspectRatioDesktop
         }
+    }
+}
+
+// MARK: - Image convenience inits (backward compatible)
+public extension BPKGraphicPromo where Background == AnyView {
+    init(
+        kicker: String? = nil,
+        headline: String,
+        subheadline: String? = nil,
+        image: Image,
+        type: `Type` = .button,
+        layoutType: LayoutType = .mobile,
+        overlay: BPKOverlayType = .solid(.off),
+        variant: Variant = .onDark,
+        verticalAlignment: BPKGraphicPromo.VerticalAlignment = .top
+    ) {
+        self.kicker = kicker
+        self.headline = headline
+        self.subheadline = subheadline
+        self.backgroundContent = AnyView(image.resizable().aspectRatio(contentMode: .fill))
+        self.type = type
+        self.layoutType = layoutType
+        self.overlay = overlay
+        self.variant = variant
+        self.verticalAlignment = verticalAlignment
+    }
+
+    init(
+        headline: String,
+        image: Image,
+        type: `Type` = .button,
+        layoutType: LayoutType = .mobile,
+        overlay: BPKOverlayType = .linear(.high, .bottom),
+        variant: Variant = .onDark,
+        sponsorTitle: String,
+        partnerLogo: Image?,
+        sponsoredAccessibilityLabel: String,
+        callToAction: CallToAction
+    ) {
+        self.verticalAlignment = .bottom
+        self.headline = headline
+        self.kicker = nil
+        self.subheadline = nil
+        self.backgroundContent = AnyView(image.resizable().aspectRatio(contentMode: .fill))
+        self.type = type
+        self.layoutType = layoutType
+        self.overlay = overlay
+        self.variant = variant
+
+        self.sponsor = .init(
+            title: sponsorTitle,
+            logo: partnerLogo,
+            accessibilityLabel: sponsoredAccessibilityLabel,
+            callToAction: callToAction)
     }
 }
 
@@ -280,10 +310,10 @@ public extension BPKGraphicPromo {
     }
 }
 
-private struct GraphicPromoButtonStyle: ButtonStyle {
+private struct GraphicPromoButtonStyle<Background: View>: ButtonStyle {
     @Environment(\.accessibilityReduceMotion) var reduceMotion
 
-    let image: Image
+    let backgroundContent: Background
     let overlay: BPKOverlayType
     let backgroundColor: Color
     let cornerRadius: BPKCornerRadius
@@ -294,9 +324,7 @@ private struct GraphicPromoButtonStyle: ButtonStyle {
                 .fill(.clear)
                 .background(backgroundColor)
                 .overlay(
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
+                    backgroundContent
                         .clipped()
                         .bpkOverlay(overlay)
                         .overlay(

--- a/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
+++ b/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromo.swift
@@ -62,6 +62,28 @@ public struct BPKGraphicPromo<Background: View>: View {
     }
     
     public init(
+        kicker: String? = nil,
+        headline: String,
+        subheadline: String? = nil,
+        @ViewBuilder background: () -> Background,
+        type: `Type` = .button,
+        layoutType: LayoutType = .mobile,
+        overlay: BPKOverlayType = .solid(.off),
+        variant: Variant = .onDark,
+        verticalAlignment: VerticalAlignment = .top
+    ) {
+        self.kicker = kicker
+        self.headline = headline
+        self.subheadline = subheadline
+        self.backgroundContent = background()
+        self.type = type
+        self.layoutType = layoutType
+        self.overlay = overlay
+        self.variant = variant
+        self.verticalAlignment = verticalAlignment
+    }
+
+    public init(
         headline: String,
         @ViewBuilder background: () -> Background,
         type: `Type` = .button,

--- a/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromoAlignment.swift
+++ b/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromoAlignment.swift
@@ -17,16 +17,18 @@
  */
 import SwiftUI
 
-public extension BPKGraphicPromo {
-    enum VerticalAlignment {
-        case top, bottom
-        
-        var contentAlignment: Alignment {
-            self == .top ? .topLeading : .bottomLeading
-        }
-        
-        var sponsorAlignment: Alignment {
-            self == .top ? .bottomLeading : .topLeading
-        }
+public enum BPKGraphicPromoVerticalAlignment {
+    case top, bottom
+
+    var contentAlignment: Alignment {
+        self == .top ? .topLeading : .bottomLeading
     }
+
+    var sponsorAlignment: Alignment {
+        self == .top ? .bottomLeading : .topLeading
+    }
+}
+
+public extension BPKGraphicPromo {
+    typealias VerticalAlignment = BPKGraphicPromoVerticalAlignment
 }

--- a/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromoType.swift
+++ b/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromoType.swift
@@ -17,12 +17,14 @@
  */
 import SwiftUI
 
-public extension BPKGraphicPromo {
-    enum `Type` {
-        case button, link
-        
-        var accessibilityTraits: AccessibilityTraits {
-            self == .button ? .isButton : .isLink
-        }
+public enum BPKGraphicPromoType {
+    case button, link
+
+    var accessibilityTraits: AccessibilityTraits {
+        self == .button ? .isButton : .isLink
     }
+}
+
+public extension BPKGraphicPromo {
+    typealias `Type` = BPKGraphicPromoType
 }

--- a/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromoVariant.swift
+++ b/Backpack-SwiftUI/GraphicPromo/Classes/BPKGraphicPromoVariant.swift
@@ -17,12 +17,14 @@
  */
 import SwiftUI
 
-public extension BPKGraphicPromo {
-    enum Variant {
-        case onDark, onLight
-        
-        var foregroundColor: BPKColor {
-            self == .onDark ? .textOnDarkColor : .textOnLightColor
-        }
+public enum BPKGraphicPromoVariant {
+    case onDark, onLight
+
+    var foregroundColor: BPKColor {
+        self == .onDark ? .textOnDarkColor : .textOnLightColor
     }
+}
+
+public extension BPKGraphicPromo {
+    typealias Variant = BPKGraphicPromoVariant
 }

--- a/Backpack-SwiftUI/GraphicPromo/README.md
+++ b/Backpack-SwiftUI/GraphicPromo/README.md
@@ -72,3 +72,32 @@ BPKGraphicPromo(
 )
 .fallbackColor(Color(.surfaceHighlightColor))
 ```
+
+### Sponsored with a custom background
+
+The sponsored variant accepts any SwiftUI view as its background via the `@ViewBuilder background` parameter. This allows using remote image loaders (e.g. `AsyncImage`, `KFImage`) or any other view in place of a local `Image`:
+
+```swift
+BPKGraphicPromo(
+    headline: "Three peaks challenge",
+    background: {
+        AsyncImage(url: URL(string: "https://example.com/image.jpg")) { image in
+            image.resizable().scaledToFill()
+        } placeholder: {
+            Color(.surfaceContrastColor)
+        }
+    },
+    sponsorTitle: "Sponsored",
+    partnerLogo: Image(decorative: "skyland"),
+    sponsoredAccessibilityLabel: "Sponsored by Skyland",
+    callToAction: .init(
+        accessibilityLabel: "Learn more about our sponsor",
+        onClick: {
+            // Open sponsor info modal
+        }
+    )
+)
+.fallbackColor(Color(.surfaceHighlightColor))
+```
+
+> The background view is responsible for its own sizing modifiers (e.g. `.resizable().scaledToFill()`). The component clips and applies the overlay on top of whatever view is provided.

--- a/Example/Backpack/SwiftUI/Components/GraphicPromo/GraphicPromoExampleView.swift
+++ b/Example/Backpack/SwiftUI/Components/GraphicPromo/GraphicPromoExampleView.swift
@@ -21,10 +21,10 @@ import SwiftUI
 import Backpack_SwiftUI
 
 struct GraphicPromoExampleView: View {
-    let verticalAlignment: BPKGraphicPromo.VerticalAlignment
+    let verticalAlignment: BPKGraphicPromo<AnyView>.VerticalAlignment
     let sponsored: Bool
 
-    init(verticalAlignment: BPKGraphicPromo.VerticalAlignment = .top, sponsored: Bool = false) {
+    init(verticalAlignment: BPKGraphicPromo<AnyView>.VerticalAlignment = .top, sponsored: Bool = false) {
         self.verticalAlignment = verticalAlignment
         self.sponsored = sponsored
     }


### PR DESCRIPTION
## What's changing

`BPKGraphicPromo` now accepts any SwiftUI view as the background for the sponsored variant, not just `SwiftUI.Image`. This is in preparation for integration of **Video Player** and Graphic Promo

### How

- The struct is now `BPKGraphicPromo<Background: View>` — generic over its background content, following the same pattern used by `BPKCard`, `BPKSponsoredInsetBanner`, `BPKRating`, and other components in the library.
- A new primary `init` for the sponsored variant takes a `@ViewBuilder background` closure, allowing consumers to pass `AsyncImage`, `KFImage`, video layers, gradients, or any custom view.
- `GraphicPromoButtonStyle` is also made generic so the background type flows through the render path without type erasure.
- `AnyView` is confined to a `where Background == AnyView` convenience extension that preserves the existing `image: Image` signatures verbatim — **zero migration required for existing callsites**.

### Non-breaking

All existing `init(image:)` and `init(headline:image:sponsorTitle:...)` callsites continue to compile and behave identically. The new `@ViewBuilder` init is additive.

### New callsite example

```swift
BPKGraphicPromo(
    headline: "Explore Britain",
    background: {
        AsyncImage(url: imageURL) { $0.resizable().scaledToFill() }
            placeholder: { Color(.surfaceContrastColor) }
    },
    sponsorTitle: "In partnership with Skyland",
    partnerLogo: Image("skyland"),
    sponsoredAccessibilityLabel: "Sponsored by Skyland",
    callToAction: .init(accessibilityLabel: "Learn more", onClick: {})
)
```