### PR TITLE
[PAN-5983] Expose slideshow image change event

### DIFF
--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
@@ -57,8 +57,8 @@ public extension View {
         categories: [BPKImageGalleryImageCategory<CategoryView, GridImage, SlideshowImage>],
         closeAccessibilityLabel: String,
         onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
-        onCloseTapped: @escaping () -> Void,
-        onSlideshowImageChanged: @escaping (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _, _ in }
+        onSlideshowImageChanged: @escaping (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _, _ in },
+        onCloseTapped: @escaping () -> Void
     ) -> some View {
         modifier(
             ImageGalleryGrid(
@@ -93,8 +93,8 @@ public extension View {
         categories: [BPKImageGalleryChipCategory<GridImage, SlideshowImage>],
         closeAccessibilityLabel: String,
         onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
-        onCloseTapped: @escaping () -> Void,
-        onSlideshowImageChanged: @escaping (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _, _ in }
+        onSlideshowImageChanged: @escaping (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _, _ in },
+        onCloseTapped: @escaping () -> Void
     ) -> some View {
         modifier(
             ImageGalleryGrid(

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/BPKImageGalleryGrid.swift
@@ -24,10 +24,11 @@ struct ImageGalleryGrid<Categories: View, GridImageView: View, SlideshowImageVie
     let slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>]
     let closeAccessibilityLabel: String
     let onImageTapped: (_ category: Int, _ image: Int) -> Void
+    let onSlideshowImageChanged: (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void
     let onCloseTapped: () -> Void
     @Binding var selectedCategoryIndex: Int
     @Binding var isPresented: Bool
-    
+
     func body(content: Content) -> some View {
         content
             .fullScreenCover(isPresented: $isPresented) {
@@ -39,6 +40,7 @@ struct ImageGalleryGrid<Categories: View, GridImageView: View, SlideshowImageVie
                     imageTapped: { selectedCategory, image in
                         onImageTapped(selectedCategory, image)
                     },
+                    onSlideshowImageChanged: onSlideshowImageChanged,
                     onCloseTapped: onCloseTapped,
                     selectedCategoryIndex: selectedCategoryIndex
                 )
@@ -55,7 +57,8 @@ public extension View {
         categories: [BPKImageGalleryImageCategory<CategoryView, GridImage, SlideshowImage>],
         closeAccessibilityLabel: String,
         onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
-        onCloseTapped: @escaping () -> Void
+        onCloseTapped: @escaping () -> Void,
+        onSlideshowImageChanged: @escaping (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _, _ in }
     ) -> some View {
         modifier(
             ImageGalleryGrid(
@@ -74,13 +77,14 @@ public extension View {
                 slideshowImages: categories[selectedCategory.wrappedValue].slideshowImages,
                 closeAccessibilityLabel: closeAccessibilityLabel,
                 onImageTapped: onImageTapped,
+                onSlideshowImageChanged: onSlideshowImageChanged,
                 onCloseTapped: onCloseTapped,
                 selectedCategoryIndex: selectedCategory,
                 isPresented: isPresented
             )
         )
     }
-    
+
     // swiftlint:disable function_parameter_count
     @ViewBuilder
     func bpkImageGalleryGrid<GridImage, SlideshowImage>(
@@ -89,7 +93,8 @@ public extension View {
         categories: [BPKImageGalleryChipCategory<GridImage, SlideshowImage>],
         closeAccessibilityLabel: String,
         onImageTapped: @escaping (_ category: Int, _ image: Int) -> Void,
-        onCloseTapped: @escaping () -> Void
+        onCloseTapped: @escaping () -> Void,
+        onSlideshowImageChanged: @escaping (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _, _ in }
     ) -> some View {
         modifier(
             ImageGalleryGrid(
@@ -103,6 +108,7 @@ public extension View {
                 slideshowImages: categories[selectedCategory.wrappedValue].slideshowImages,
                 closeAccessibilityLabel: closeAccessibilityLabel,
                 onImageTapped: onImageTapped,
+                onSlideshowImageChanged: onSlideshowImageChanged,
                 onCloseTapped: onCloseTapped,
                 selectedCategoryIndex: selectedCategory,
                 isPresented: isPresented
@@ -112,7 +118,7 @@ public extension View {
 }
 
 struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
-    
+
     static var previews: some View {
         Color.clear
             .bpkImageGalleryGrid(
@@ -124,7 +130,7 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
                 onCloseTapped: {}
             )
             .previewDisplayName("Images")
-        
+
         Color.clear
             .bpkImageGalleryGrid(
                 isPresented: .constant(true),
@@ -136,7 +142,7 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             )
             .previewDisplayName("Chips")
     }
-    
+
     private static var testChipCategories: [BPKImageGalleryChipCategory<Color, Color>] {
         [
             .init(
@@ -156,7 +162,7 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             )
         ]
     }
-    
+
     private static var testImageCategories: [BPKImageGalleryImageCategory<Color, Color, Color>] {
         [
             .init(
@@ -179,7 +185,7 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             )
         ]
     }
-    
+
     private static func testSlideshowImages(_ amount: Int, color: Color) -> [BPKSlideshowGalleryImage<Color>] {
         return (0..<amount).map { _ in
             BPKSlideshowGalleryImage(title: "image \(amount)") {
@@ -187,7 +193,7 @@ struct BPKImageGalleryImageGrid_Previews: PreviewProvider {
             }
         }
     }
-    
+
     private static func testGridImages(_ amount: Int, color: Color) -> [BPKGridGalleryImage<Color>] {
         return (0..<amount).map { _ in
             BPKGridGalleryImage { color }

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
@@ -66,8 +66,8 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
             images: slideshowImages,
             closeAccessibilityLabel: closeAccessibilityLabel,
             currentIndex: $imageIndexInCategory,
-            onCloseTapped: { isSlideshowPresented = false },
-            onSlideshowImageChanged: slideshowImageChanged
+            onSlideshowImageChanged: slideshowImageChanged,
+            onCloseTapped: { isSlideshowPresented = false }
         )
     }
 

--- a/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
+++ b/Backpack-SwiftUI/ImageGalleryGrid/Classes/ImageGalleryGridContentView.swift
@@ -25,12 +25,13 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
     let slideshowImages: [BPKSlideshowGalleryImage<SlideshowImageView>]
     let closeAccessibilityLabel: String
     let imageTapped: (_ category: Int, _ image: Int) -> Void
+    let onSlideshowImageChanged: (_ categoryIndex: Int, _ fromImageIndex: Int, _ toImageIndex: Int) -> Void
     let onCloseTapped: () -> Void
-    
+
     let selectedCategoryIndex: Int
     @State var isSlideshowPresented: Bool = false
     @State var imageIndexInCategory: Int = 0
-    
+
     var body: some View {
         VStack(spacing: .base) {
             header
@@ -65,10 +66,11 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
             images: slideshowImages,
             closeAccessibilityLabel: closeAccessibilityLabel,
             currentIndex: $imageIndexInCategory,
-            onCloseTapped: { isSlideshowPresented = false }
+            onCloseTapped: { isSlideshowPresented = false },
+            onSlideshowImageChanged: slideshowImageChanged
         )
     }
-    
+
     var header: some View {
         ImageGalleryHeader(
             closeAccessibilityLabel: closeAccessibilityLabel,
@@ -76,6 +78,12 @@ struct ImageGalleryGridContentView<Categories: View, GridImageView: View, Slides
         )
         .padding(.horizontal, .base)
         .padding(.top, .md)
+    }
+
+    var slideshowImageChanged: (_ fromImageIndex: Int, _ toImageIndex: Int) -> Void {
+        { fromImageIndex, toImageIndex in
+            onSlideshowImageChanged(selectedCategoryIndex, fromImageIndex, toImageIndex)
+        }
     }
 }
 
@@ -99,6 +107,7 @@ struct ImageGalleryGridContentView_Previews: PreviewProvider {
             ],
             closeAccessibilityLabel: "Close",
             imageTapped: { _, _ in },
+            onSlideshowImageChanged: { _, _, _ in },
             onCloseTapped: {},
             selectedCategoryIndex: 0,
             isSlideshowPresented: false,

--- a/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
+++ b/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
@@ -178,8 +178,8 @@ public extension View {
         images: [BPKSlideshowGalleryImage<Content>],
         closeAccessibilityLabel: String,
         currentIndex: Binding<Int>,
-        onCloseTapped: @escaping () -> Void,
-        onSlideshowImageChanged: @escaping (_ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _ in }
+        onSlideshowImageChanged: @escaping (_ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _ in },
+        onCloseTapped: @escaping () -> Void
     ) -> some View {
         modifier(
             ImageGallerySlideshow(

--- a/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
+++ b/Backpack-SwiftUI/ImageGallerySlideshow/Classes/BPKImageGallerySlideshow.swift
@@ -22,9 +22,10 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
     let images: [BPKSlideshowGalleryImage<ImageView>]
     let closeAccessibilityLabel: String
     let onCloseTapped: () -> Void
+    let onSlideshowImageChanged: (_ fromImageIndex: Int, _ toImageIndex: Int) -> Void
     @Binding var currentIndex: Int
     @Binding var isPresented: Bool
-    
+
     func body(content: Content) -> some View {
         content
             .fullScreenCover(isPresented: $isPresented, content: {
@@ -32,17 +33,37 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
                     images: images,
                     closeAccessibilityLabel: closeAccessibilityLabel,
                     onCloseTapped: onCloseTapped,
-                    currentIndex: $currentIndex
+                    currentIndex: $currentIndex,
+                    onSlideshowImageChanged: onSlideshowImageChanged
                 )
             })
     }
-    
+
     struct ContentView: View {
         let images: [BPKSlideshowGalleryImage<ImageView>]
         let closeAccessibilityLabel: String
         let onCloseTapped: () -> Void
+        let onSlideshowImageChanged: (_ fromImageIndex: Int, _ toImageIndex: Int) -> Void
         @Binding var currentIndex: Int
-        
+        @State private var indexChangeTracker: ImageGallerySlideshowIndexChangeTracker
+
+        init(
+            images: [BPKSlideshowGalleryImage<ImageView>],
+            closeAccessibilityLabel: String,
+            onCloseTapped: @escaping () -> Void,
+            currentIndex: Binding<Int>,
+            onSlideshowImageChanged: @escaping (_ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _ in }
+        ) {
+            self.images = images
+            self.closeAccessibilityLabel = closeAccessibilityLabel
+            self.onCloseTapped = onCloseTapped
+            self._currentIndex = currentIndex
+            self.onSlideshowImageChanged = onSlideshowImageChanged
+            self._indexChangeTracker = State(
+                initialValue: ImageGallerySlideshowIndexChangeTracker(initialIndex: currentIndex.wrappedValue)
+            )
+        }
+
         var body: some View {
             VStack(spacing: .xl) {
                 ImageGalleryHeader(
@@ -50,7 +71,7 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
                     onCloseTapped: onCloseTapped
                 )
                 .padding([.leading, .top], .base)
-                
+
                 ZStack(alignment: .bottom) {
                     InternalCarouselWrapper(
                         images: images.map { $0.content() },
@@ -64,12 +85,17 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
                 .aspectRatio(1.0, contentMode: .fill)
                 .accessibilityElement(children: .ignore)
                 .accessibilityHidden(true)
-                
+
                 footer
             }
             .background(Color(.canvasContrastColor))
+            .onChange(of: currentIndex) { newIndex in
+                if let change = indexChangeTracker.change(to: newIndex) {
+                    onSlideshowImageChanged(change.from, change.to)
+                }
+            }
         }
-        
+
         private var footer: some View {
             VStack(spacing: .xl) {
                 BPKPageIndicator(
@@ -88,7 +114,7 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
                     VStack(spacing: .md) {
                         BPKText(descriptionText, style: .caption)
                             .lineLimit(nil)
-                        
+
                         if let credit = images[currentIndex].credit {
                             HStack(spacing: .sm) {
                                 BPKIconView(.camera)
@@ -101,7 +127,7 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
                 }
             }
         }
-        
+
         private var descriptionText: String {
             let currentImage = images[currentIndex]
             let titleText = "**\(currentImage.title)**"
@@ -110,7 +136,7 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
             }
             return currentImage.title
         }
-        
+
         private func accessibilityPageIncrement() {
             if currentIndex == images.count - 1 {
                 currentIndex = 0
@@ -118,7 +144,7 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
                 currentIndex += 1
             }
         }
-        
+
         private func accessibilityPageDecrement() {
             if currentIndex == 0 {
                 currentIndex = images.count - 1
@@ -129,19 +155,38 @@ struct ImageGallerySlideshow<ImageView: View>: ViewModifier {
     }
 }
 
+struct ImageGallerySlideshowIndexChangeTracker {
+    private(set) var currentIndex: Int
+
+    init(initialIndex: Int) {
+        currentIndex = initialIndex
+    }
+
+    mutating func change(to newIndex: Int) -> (from: Int, to: Int)? {
+        guard newIndex != currentIndex else {
+            return nil
+        }
+
+        defer { currentIndex = newIndex }
+        return (from: currentIndex, to: newIndex)
+    }
+}
+
 public extension View {
     func bpkImageGallerySlideshow<Content>(
         isPresented: Binding<Bool>,
         images: [BPKSlideshowGalleryImage<Content>],
         closeAccessibilityLabel: String,
         currentIndex: Binding<Int>,
-        onCloseTapped: @escaping () -> Void
+        onCloseTapped: @escaping () -> Void,
+        onSlideshowImageChanged: @escaping (_ fromImageIndex: Int, _ toImageIndex: Int) -> Void = { _, _ in }
     ) -> some View {
         modifier(
             ImageGallerySlideshow(
                 images: images,
                 closeAccessibilityLabel: closeAccessibilityLabel,
                 onCloseTapped: onCloseTapped,
+                onSlideshowImageChanged: onSlideshowImageChanged,
                 currentIndex: currentIndex,
                 isPresented: isPresented
             )

--- a/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
+++ b/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
@@ -91,8 +91,8 @@ class ImageGalleryGridTests: XCTestCase {
         var receivedChange: (category: Int, from: Int, to: Int)?
         let view = ImageGalleryGridContentView(
             categories: { EmptyView() },
-            gridImages: [],
-            slideshowImages: [],
+            gridImages: [] as [BPKGridGalleryImage<Color>],
+            slideshowImages: [] as [BPKSlideshowGalleryImage<Color>],
             closeAccessibilityLabel: "close",
             imageTapped: { _, _ in },
             onSlideshowImageChanged: { category, from, to in

--- a/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
+++ b/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
@@ -123,8 +123,7 @@ class ImageGalleryGridTests: XCTestCase {
             selectedCategory: .constant(0),
             categories: categories,
             closeAccessibilityLabel: "close",
-            onImageTapped: { _, _ in },
-            onCloseTapped: {}
-        )
+            onImageTapped: { _, _ in }
+        ) {}
     }
 }

--- a/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
+++ b/Backpack-SwiftUI/Tests/ImageGalleryGrid/ImageGalleryGridTests.swift
@@ -25,7 +25,7 @@ class ImageGalleryGridTests: XCTestCase {
         Image("dialog_image", bundle: TestsBundle.bundle)
             .resizable()
     }
-    
+
     func test_imageGalleryChipGrid() {
         assertSnapshot(
             ImageGalleryGridContentView(
@@ -46,13 +46,14 @@ class ImageGalleryGridTests: XCTestCase {
                 },
                 closeAccessibilityLabel: "close",
                 imageTapped: { _, _ in },
+                onSlideshowImageChanged: { _, _, _ in },
                 onCloseTapped: {},
                 selectedCategoryIndex: 1
             )
             .frame(width: 400, height: 600)
         )
     }
-    
+
     func test_imageGalleryImagesGrid() {
         assertSnapshot(
             ImageGalleryGridContentView(
@@ -78,10 +79,52 @@ class ImageGalleryGridTests: XCTestCase {
                 },
                 closeAccessibilityLabel: "close",
                 imageTapped: { _, _ in },
+                onSlideshowImageChanged: { _, _, _ in },
                 onCloseTapped: {},
                 selectedCategoryIndex: 1
             )
             .frame(width: 400, height: 600)
+        )
+    }
+
+    func test_slideshowImageChanged_forwardsSelectedCategoryAndIndices() {
+        var receivedChange: (category: Int, from: Int, to: Int)?
+        let view = ImageGalleryGridContentView(
+            categories: { EmptyView() },
+            gridImages: [],
+            slideshowImages: [],
+            closeAccessibilityLabel: "close",
+            imageTapped: { _, _ in },
+            onSlideshowImageChanged: { category, from, to in
+                receivedChange = (category, from, to)
+            },
+            onCloseTapped: {},
+            selectedCategoryIndex: 2
+        )
+
+        view.slideshowImageChanged(1, 3)
+
+        XCTAssertEqual(receivedChange?.category, 2)
+        XCTAssertEqual(receivedChange?.from, 1)
+        XCTAssertEqual(receivedChange?.to, 3)
+    }
+
+    func test_imageGalleryGrid_withoutSlideshowImageChangedCallback_remainsSourceCompatible() {
+        let categories: [BPKImageGalleryChipCategory<Color, Color>] = [
+            .init(
+                title: "Category",
+                gridImages: [.init(content: { Color.red })],
+                slideshowImages: [.init(title: "Image", content: { Color.red })]
+            )
+        ]
+
+        _ = Color.clear.bpkImageGalleryGrid(
+            isPresented: .constant(false),
+            selectedCategory: .constant(0),
+            categories: categories,
+            closeAccessibilityLabel: "close",
+            onImageTapped: { _, _ in },
+            onCloseTapped: {}
         )
     }
 }

--- a/Backpack-SwiftUI/Tests/ImageGallerySlideshow/BPKImageGallerySlideshowTests.swift
+++ b/Backpack-SwiftUI/Tests/ImageGallerySlideshow/BPKImageGallerySlideshowTests.swift
@@ -63,4 +63,13 @@ class BPKImageGallerySlideshowTests: XCTestCase {
         XCTAssertEqual(secondChange?.from, 2)
         XCTAssertEqual(secondChange?.to, 0)
     }
+
+    func test_imageGallerySlideshow_withTrailingCloseCallback_remainsSourceCompatible() {
+        _ = Color.clear.bpkImageGallerySlideshow(
+            isPresented: .constant(false),
+            images: [.init(title: "Image", content: { Color.red })],
+            closeAccessibilityLabel: "close",
+            currentIndex: .constant(0)
+        ) {}
+    }
 }

--- a/Backpack-SwiftUI/Tests/ImageGallerySlideshow/BPKImageGallerySlideshowTests.swift
+++ b/Backpack-SwiftUI/Tests/ImageGallerySlideshow/BPKImageGallerySlideshowTests.swift
@@ -26,7 +26,7 @@ class BPKImageGallerySlideshowTests: XCTestCase {
             .resizable()
             .aspectRatio(contentMode: .fill)
     }
-    
+
     func test_imageGalleryPreview() {
         assertSnapshot(
             ImageGallerySlideshow.ContentView(
@@ -45,5 +45,22 @@ class BPKImageGallerySlideshowTests: XCTestCase {
             )
             .frame(width: 300, height: 600)
         )
+    }
+
+    func test_indexChangeTracker_doesNotReportInitialSlideshowIndex() {
+        var tracker = ImageGallerySlideshowIndexChangeTracker(initialIndex: 1)
+
+        XCTAssertNil(tracker.change(to: 1))
+    }
+
+    func test_indexChangeTracker_reportsPreviousAndNewIndicesAfterNavigation() {
+        var tracker = ImageGallerySlideshowIndexChangeTracker(initialIndex: 1)
+        let firstChange = tracker.change(to: 2)
+        let secondChange = tracker.change(to: 0)
+
+        XCTAssertEqual(firstChange?.from, 1)
+        XCTAssertEqual(firstChange?.to, 2)
+        XCTAssertEqual(secondChange?.from, 2)
+        XCTAssertEqual(secondChange?.to, 0)
     }
 }


### PR DESCRIPTION
PAN-5983

Expose a slideshow image-change event from BPKImageGalleryGrid for hotel image-swipe analytics. The gallery did not expose image changes after the slideshow opened.

Validation: manually verified in the example app.