### PR TITLE
[DON-3395] [DON-3396] [DON-3397] Standardise iOS BPKBadge API and documentation

### DIFF
--- a/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
+++ b/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
@@ -25,13 +25,13 @@ import Backpack_Common
 /// Use `badgeStyle(_ style: BPKBadge.Style)` to change the style of the badge
 ///
 public struct BPKBadge: View {
-    private let title: String
+    private let text: String
     private let icon: BPKIcon?
     private var style: BPKBadge.Style = .normal
     private let config: BpkConfiguration?
 
-    public init(_ title: String, icon: BPKIcon? = nil) {
-        self.title = title
+    public init(_ text: String, icon: BPKIcon? = nil) {
+        self.text = text
         self.icon = icon
         self.config = BpkConfiguration.shared
     }
@@ -46,7 +46,7 @@ public struct BPKBadge: View {
             .clipShape(RoundedRectangle(cornerRadius: .xs))
             .outline(style.borderColor(config), cornerRadius: .xs)
             .accessibilityElement()
-            .accessibilityLabel(title)
+            .accessibilityLabel(text)
             .if(!BPKFont.enableDynamicType, transform: {
                 $0.sizeCategory(.large)
             })
@@ -85,7 +85,7 @@ public struct BPKBadge: View {
             if let badgeIconView = createBadgeIconView(icon: icon) {
                 badgeIconView.foregroundColor(style.iconColor(config))
             }
-            BPKText(title, style: .footnote)
+            BPKText(text, style: .footnote)
                 .foregroundColor(style.foregroundColor(config))
         }
     }

--- a/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
+++ b/Backpack-SwiftUI/Badge/Classes/BPKBadge.swift
@@ -64,7 +64,7 @@ public struct BPKBadge: View {
         return result
     }
     
-    public func createBadgeIconView(icon: BPKIcon?) -> BPKIconView? {
+    private func createBadgeIconView(icon: BPKIcon?) -> BPKIconView? {
         guard let badgeIcon = icon else {
             switch style {
             case .success:

--- a/Backpack-SwiftUI/Badge/README.md
+++ b/Backpack-SwiftUI/Badge/README.md
@@ -1,6 +1,6 @@
 # Backpack-SwiftUI/Badge
 
-[![Cocoapods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](hhttps://cocoapods.org/pods/Backpack-SwiftUI)
+[![Cocoapods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](https://cocoapods.org/pods/Backpack-SwiftUI)
 [![class reference](https://img.shields.io/badge/Class%20reference-iOS-blue)](https://backpack.github.io/ios/versions/latest/swiftui/Structs/BPKBadge.html)
 [![view on Github](https://img.shields.io/badge/Source%20code-GitHub-lightgrey)](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack-SwiftUI/Badge)
 
@@ -13,7 +13,7 @@
 ## Usage
 
 ### Basic text badge
-If you don't specify a `.badgeStyle(<style>)` it will use the `.default` type
+If you don't specify a `.badgeStyle(<style>)` it will use the `.normal` style.
 
 ```swift
 import Backpack_SwiftUI
@@ -23,15 +23,37 @@ BPKBadge("Hello World")
 BPKBadge("Hello World")
     .badgeStyle(.destructive)
 ```
+
+### Available styles
+
+`BPKBadge` supports nine styles:
+
+- `.normal`
+- `.subtle`
+- `.strong`
+- `.success`
+- `.warning`
+- `.destructive`
+- `.inverse`
+- `.outline`
+- `.brand`
 
 ### Badge with icon
-If you don't specify a `.badgeStyle(<style>)` it will use the `.default` type
+If you don't specify a `.badgeStyle(<style>)` it will use the `.normal` style.
 
 ```swift
 import Backpack_SwiftUI
 
 BPKBadge("Hello World", icon: .tickCircle)
 
-BPKBadge("Hello World", icon: .tickCircle)
+BPKBadge("Hello World")
     .badgeStyle(.destructive)
 ```
+
+For `.success`, `.warning`, and `.destructive`, an icon is provided automatically when no `icon` is supplied:
+
+- `.success` uses `.tickCircle`
+- `.warning` uses `.informationCircle`
+- `.destructive` uses `.exclamation`
+
+Passing an explicit `icon` overrides the automatically selected icon.

--- a/Backpack-SwiftUI/Badge/README.md
+++ b/Backpack-SwiftUI/Badge/README.md
@@ -1,6 +1,6 @@
 # Backpack-SwiftUI/Badge
 
-[![Cocoapods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](hhttps://cocoapods.org/pods/Backpack-SwiftUI)
+[![Cocoapods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](https://cocoapods.org/pods/Backpack-SwiftUI)
 [![class reference](https://img.shields.io/badge/Class%20reference-iOS-blue)](https://backpack.github.io/ios/versions/latest/swiftui/Structs/BPKBadge.html)
 [![view on Github](https://img.shields.io/badge/Source%20code-GitHub-lightgrey)](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack-SwiftUI/Badge)
 
@@ -13,7 +13,7 @@
 ## Usage
 
 ### Basic text badge
-If you don't specify a `.badgeStyle(<style>)` it will use the `.default` type
+If you don't specify a `.badgeStyle(<style>)` it will use the `.normal` style.
 
 ```swift
 import Backpack_SwiftUI
@@ -21,17 +21,44 @@ import Backpack_SwiftUI
 BPKBadge("Hello World")
 
 BPKBadge("Hello World")
-    .badgeStyle(.destructive)
+    .badgeStyle(.strong)
 ```
 
-### Badge with icon
-If you don't specify a `.badgeStyle(<style>)` it will use the `.default` type
+### Available styles
+
+`BPKBadge` supports nine styles:
+
+- `.normal`
+- `.subtle`
+- `.strong`
+- `.success`
+- `.warning`
+- `.destructive`
+- `.inverse`
+- `.outline`
+- `.brand`
+
+### Badge with explicit icon
+
+Pass an icon using the `icon` parameter:
 
 ```swift
 import Backpack_SwiftUI
 
 BPKBadge("Hello World", icon: .tickCircle)
+```
 
-BPKBadge("Hello World", icon: .tickCircle)
+### Automatic icons
+
+For `.success`, `.warning`, and `.destructive`, an icon is provided automatically when no `icon` is supplied:
+
+```swift
+BPKBadge("Hello World")
     .badgeStyle(.destructive)
 ```
+
+- `.success` uses `.tickCircle`
+- `.warning` uses `.informationCircle`
+- `.destructive` uses `.exclamation`
+
+Passing an explicit `icon` overrides the automatically selected icon.


### PR DESCRIPTION
https://skyscanner.atlassian.net/browse/DON-3395
https://skyscanner.atlassian.net/browse/DON-3396
https://skyscanner.atlassian.net/browse/DON-3397

### Summary

This PR addresses three BPKBadge parity and documentation issues on iOS:
- Makes createBadgeIconView(icon:) private so it is no longer exposed as part of the public API.
- Renames the internal title parameter/property to text in BPKBadge.init for consistency with Android, while keeping the external initializer call unchanged.
- Updates the BPKBadge README so it reflects the current API and styling behaviour.

### Changes
Removed the public access modifier from createBadgeIconView(icon:).
Renamed internal references from title to text in BPKBadge.swift.
Updated the README to:
- use .normal instead of .default
- document all 9 styles, including subtle
- describe automatic icon injection for success, warning, and destructive
- fix the broken CocoaPods badge URL
- refresh stale screenshots

### Notes
These changes are internal/API documentation updates only and do not require any call site changes.



+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
