### PR TITLE
[DON-3412] Add accessibility header control to BPKSectionHeader

### DIFF
--- a/Backpack-SwiftUI/SectionHeader/Classes/BPKSectionHeader.swift
+++ b/Backpack-SwiftUI/SectionHeader/Classes/BPKSectionHeader.swift
@@ -25,14 +25,6 @@ public struct BPKSectionHeader: View {
     let accessibilityHeaderEnabled: Bool
     let button: BPKButton?
 
-    /// Creates a Section Header without a trailing button.
-    ///
-    /// - Parameters:
-    ///   - title: The title of the section.
-    ///   - description: An optional description displayed below the title.
-    ///   - style: The visual style of the Section Header. Defaults to `.default`.
-    ///   - accessibilityHeaderEnabled: Whether the title has the accessibility
-    ///     header trait. Defaults to `true`.
     public init(
         title: String,
         description: String? = nil,
@@ -46,17 +38,6 @@ public struct BPKSectionHeader: View {
         self.button = nil
     }
 
-    /// Creates a Section Header with a trailing button.
-    ///
-    /// The button style is set automatically according to the Section Header style.
-    ///
-    /// - Parameters:
-    ///   - title: The title of the section.
-    ///   - description: An optional description displayed below the title.
-    ///   - style: The visual style of the Section Header. Defaults to `.default`.
-    ///   - accessibilityHeaderEnabled: Whether the title has the accessibility
-    ///     header trait. Defaults to `true`.
-    ///   - button: The button displayed after the title and description.
     public init(
         title: String,
         description: String? = nil,

--- a/Backpack-SwiftUI/SectionHeader/Classes/BPKSectionHeader.swift
+++ b/Backpack-SwiftUI/SectionHeader/Classes/BPKSectionHeader.swift
@@ -80,6 +80,9 @@ public struct BPKSectionHeader: View {
                     .accessibilityAddTraits(
                         accessibilityHeaderEnabled ? .isHeader : []
                     )
+                    .accessibilityRemoveTraits(
+                        accessibilityHeaderEnabled ? [] : .isHeader
+                    )
                 if let description = description {
                     BPKText(description, style: .bodyDefault)
                         .foregroundColor(style == .default ? .textPrimaryColor : .textOnDarkColor)

--- a/Backpack-SwiftUI/SectionHeader/Classes/BPKSectionHeader.swift
+++ b/Backpack-SwiftUI/SectionHeader/Classes/BPKSectionHeader.swift
@@ -22,28 +22,52 @@ public struct BPKSectionHeader: View {
     let title: String
     let description: String?
     let style: Style
+    let accessibilityHeaderEnabled: Bool
     let button: BPKButton?
 
-    public init(
-        title: String,
-        description: String? = nil,
-        style: Style = .default
-    ) {
-        self.title = title
-        self.description = description
-        self.style = style
-        self.button = nil
-    }
-
+    /// Creates a Section Header without a trailing button.
+    ///
+    /// - Parameters:
+    ///   - title: The title of the section.
+    ///   - description: An optional description displayed below the title.
+    ///   - style: The visual style of the Section Header. Defaults to `.default`.
+    ///   - accessibilityHeaderEnabled: Whether the title has the accessibility
+    ///     header trait. Defaults to `true`.
     public init(
         title: String,
         description: String? = nil,
         style: Style = .default,
+        accessibilityHeaderEnabled: Bool = true
+    ) {
+        self.title = title
+        self.description = description
+        self.style = style
+        self.accessibilityHeaderEnabled = accessibilityHeaderEnabled
+        self.button = nil
+    }
+
+    /// Creates a Section Header with a trailing button.
+    ///
+    /// The button style is set automatically according to the Section Header style.
+    ///
+    /// - Parameters:
+    ///   - title: The title of the section.
+    ///   - description: An optional description displayed below the title.
+    ///   - style: The visual style of the Section Header. Defaults to `.default`.
+    ///   - accessibilityHeaderEnabled: Whether the title has the accessibility
+    ///     header trait. Defaults to `true`.
+    ///   - button: The button displayed after the title and description.
+    public init(
+        title: String,
+        description: String? = nil,
+        style: Style = .default,
+        accessibilityHeaderEnabled: Bool = true,
         @ViewBuilder button: () -> BPKButton
     ) {
         self.title = title
         self.description = description
         self.style = style
+        self.accessibilityHeaderEnabled = accessibilityHeaderEnabled
         self.button = button()
     }
 
@@ -53,7 +77,9 @@ public struct BPKSectionHeader: View {
                 BPKText(title, style: .heading3)
                     .foregroundColor(style == .default ? .textPrimaryColor : .textOnDarkColor)
                     .lineLimit(nil)
-                    .accessibilityAddTraits(.isHeader)
+                    .accessibilityAddTraits(
+                        accessibilityHeaderEnabled ? .isHeader : []
+                    )
                 if let description = description {
                     BPKText(description, style: .bodyDefault)
                         .foregroundColor(style == .default ? .textPrimaryColor : .textOnDarkColor)

--- a/Backpack-SwiftUI/SectionHeader/README.md
+++ b/Backpack-SwiftUI/SectionHeader/README.md
@@ -98,3 +98,10 @@ BPKSectionHeader(
 ## Cross-platform naming
 
 The appearance parameter is named `style` on iOS and `type` on Android. iOS retains `style` to follow SwiftUI naming conventions and to avoid a breaking change to the existing public API.
+
+Android exposes the equivalent accessibility control as
+`accessibilityHeaderTagEnabled: Boolean?`. iOS uses the shorter
+`accessibilityHeaderEnabled: Bool` name and a non-optional Boolean because the
+component supports two behaviours: applying or suppressing the Header trait.
+This follows Swift naming and type conventions while preserving equivalent
+cross-platform behaviour.

--- a/Backpack-SwiftUI/SectionHeader/README.md
+++ b/Backpack-SwiftUI/SectionHeader/README.md
@@ -1,6 +1,6 @@
 # Section Header
 
-[![Cocoapods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](https://cocoapods.org/pods/Backpack-SwiftUI)
+[![CocoaPods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](https://cocoapods.org/pods/Backpack-SwiftUI)
 [![class reference](https://img.shields.io/badge/Class%20reference-iOS-blue)](https://backpack.github.io/ios/versions/latest/swiftui/Structs/BPKSectionHeader.html)
 [![view on Github](https://img.shields.io/badge/Source%20code-GitHub-lightgrey)](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack-SwiftUI/SectionHeader)
 

--- a/Backpack-SwiftUI/SectionHeader/README.md
+++ b/Backpack-SwiftUI/SectionHeader/README.md
@@ -35,7 +35,7 @@ struct SectionHeaderExampleView: View {
 }
 ```
 
-### Description
+### Section header with a title and description.
 
 ```swift
 BPKSectionHeader(

--- a/Backpack-SwiftUI/SectionHeader/README.md
+++ b/Backpack-SwiftUI/SectionHeader/README.md
@@ -23,9 +23,16 @@
 When `style` is omitted, the Default style is used.
 
 ```swift
-BPKSectionHeader(
-    title: "Section title"
-)
+import SwiftUI
+import Backpack_SwiftUI
+
+struct SectionHeaderExampleView: View {
+    var body: some View {
+        BPKSectionHeader(
+            title: "Section title"
+        )
+    }
+}
 ```
 
 ### Description

--- a/Backpack-SwiftUI/SectionHeader/README.md
+++ b/Backpack-SwiftUI/SectionHeader/README.md
@@ -1,6 +1,6 @@
 # Section Header
 
-[![Cocoapods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](hhttps://cocoapods.org/pods/Backpack-SwiftUI)
+[![Cocoapods](https://img.shields.io/cocoapods/v/Backpack-SwiftUI.svg?style=flat)](https://cocoapods.org/pods/Backpack-SwiftUI)
 [![class reference](https://img.shields.io/badge/Class%20reference-iOS-blue)](https://backpack.github.io/ios/versions/latest/swiftui/Structs/BPKSectionHeader.html)
 [![view on Github](https://img.shields.io/badge/Source%20code-GitHub-lightgrey)](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack-SwiftUI/SectionHeader)
 
@@ -8,53 +8,86 @@
 
 | Day | Night |
 | --- | --- |
-| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___default_lm.png" alt="" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___default_dm.png" alt="" width="375" /> |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___default_lm.png" alt="" width="375" /> | <img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___default_dm.png" alt="" width="375" /> |
 
 ## On Dark
 
 | Day | Night |
 | --- | --- |
-| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___on-dark_lm.png" alt="" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___on-dark_dm.png" alt="" width="375" /> |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___on-dark_lm.png" alt="" width="375" /> | <img src="https://raw.githubusercontent.com/Skyscanner/backpack-ios/main/screenshots/iPhone-swiftui_section-header___on-dark_dm.png" alt="" width="375" /> |
 
 ## Usage
 
-### Basic section header with a title. 
-If you don't specify a `style` parameter it will use the `.default` type
+### Basic Section Header
+
+When `style` is omitted, the Default style is used.
 
 ```swift
-BPKSectionHeader(title: "Section title")
+BPKSectionHeader(
+    title: "Section title"
+)
 ```
 
-### Section header with a title and description. 
+### Description
 
-```swift 
+```swift
 BPKSectionHeader(
     title: "Section title",
     description: "Description about this section"
 )
 ```
 
-### Section header with a title, description and trailing button. 
+### Accessibility header trait
 
-```swift 
+The title has the accessibility header trait by default. Set `accessibilityHeaderEnabled` to `false` when another view already provides the appropriate heading semantics.
+
+```swift
 BPKSectionHeader(
     title: "Section title",
-    description: "Description about this section") {
-        BPKButton(icon: .addCircle, accessibilityLabel: "Add item") {
-            print("Tap add button")
-        }
+    accessibilityHeaderEnabled: false
+)
+```
+
+### Trailing button
+
+```swift
+BPKSectionHeader(
+    title: "Section title",
+    description: "Description about this section"
+) {
+    BPKButton(
+        icon: .addCircle,
+        accessibilityLabel: "Add item"
+    ) {
+        print("Tap add button")
+    }
 }
 ```
 
-### Section header with a title, description, trailing button and onDark style. 
+SectionHeader automatically overrides the supplied button style:
 
-```swift 
+- Default SectionHeader uses `.primary`.
+- On Dark SectionHeader uses `.primaryOnDark`.
+
+Callers do not need to set the button style themselves.
+
+### On Dark
+
+```swift
 BPKSectionHeader(
     title: "Section title",
     description: "Description about this section",
-    style: .onDark) {
-        BPKButton(icon: .addCircle, accessibilityLabel: "Add item") {
-            print("Tap add button")
-        }
+    style: .onDark
+) {
+    BPKButton(
+        icon: .addCircle,
+        accessibilityLabel: "Add item"
+    ) {
+        print("Tap add button")
+    }
 }
 ```
+
+## Cross-platform naming
+
+The appearance parameter is named `style` on iOS and `type` on Android. iOS retains `style` to follow SwiftUI naming conventions and to avoid a breaking change to the existing public API.

--- a/Backpack-SwiftUI/SectionHeader/README.md
+++ b/Backpack-SwiftUI/SectionHeader/README.md
@@ -101,7 +101,8 @@ The appearance parameter is named `style` on iOS and `type` on Android. iOS reta
 
 Android exposes the equivalent accessibility control as
 `accessibilityHeaderTagEnabled: Boolean?`. iOS uses the shorter
-`accessibilityHeaderEnabled: Bool` name and a non-optional Boolean because the
-component supports two behaviours: applying or suppressing the Header trait.
-This follows Swift naming and type conventions while preserving equivalent
+`accessibilityHeaderEnabled: Bool` name with a default value of `true`. The iOS
+API does not need a nullable state because Backpack always supplies a concrete
+enabled or disabled default. A non-optional Boolean follows Swift API
+conventions for simple binary configuration while preserving equivalent
 cross-platform behaviour.

--- a/Backpack-SwiftUI/Tests/SectionHeader/BPKSectionHeaderViewTests.swift
+++ b/Backpack-SwiftUI/Tests/SectionHeader/BPKSectionHeaderViewTests.swift
@@ -76,4 +76,14 @@ class BPKSectionHeaderViewTests: XCTestCase {
             .padding()
         )
     }
+
+    func testSectionHeaderWithoutAccessibilityHeaderTrait() {
+        assertSnapshot(
+            BPKSectionHeader(
+                title: "Section title",
+                accessibilityHeaderEnabled: false
+            )
+            .padding()
+        )
+    }
 }

--- a/Backpack-SwiftUI/Tests/SectionHeader/BPKSectionHeaderViewTests.swift
+++ b/Backpack-SwiftUI/Tests/SectionHeader/BPKSectionHeaderViewTests.swift
@@ -18,7 +18,7 @@
 
 import XCTest
 import SnapshotTesting
-import Backpack_SwiftUI
+@testable import Backpack_SwiftUI
 
 class BPKSectionHeaderViewTests: XCTestCase {
     func testSectionHeaderDefault() {
@@ -77,13 +77,34 @@ class BPKSectionHeaderViewTests: XCTestCase {
         )
     }
 
-    func testSectionHeaderWithoutAccessibilityHeaderTrait() {
-        assertSnapshot(
-            BPKSectionHeader(
-                title: "Section title",
-                accessibilityHeaderEnabled: false
-            )
-            .padding()
+    func testSectionHeaderAccessibilityHeaderEnabledByDefault() {
+        let sectionHeader = BPKSectionHeader(
+            title: "Section title"
         )
+
+        XCTAssertTrue(sectionHeader.accessibilityHeaderEnabled)
+    }
+
+    func testSectionHeaderAccessibilityHeaderCanBeDisabled() {
+        let sectionHeader = BPKSectionHeader(
+            title: "Section title",
+            accessibilityHeaderEnabled: false
+        )
+
+        XCTAssertFalse(sectionHeader.accessibilityHeaderEnabled)
+    }
+
+    func testSectionHeaderWithButtonAccessibilityHeaderCanBeDisabled() {
+        let sectionHeader = BPKSectionHeader(
+            title: "Section title",
+            accessibilityHeaderEnabled: false
+        ) {
+            BPKButton(
+                icon: .addCircle,
+                accessibilityLabel: "Add item"
+            ) { }
+        }
+
+        XCTAssertFalse(sectionHeader.accessibilityHeaderEnabled)
     }
 }


### PR DESCRIPTION
## Summary

This PR adds accessibility header-trait control to the iOS SwiftUI `BPKSectionHeader` API.

Callers can now suppress the title’s `.isHeader` accessibility trait when another view already provides the appropriate heading semantics.

## Changes

- Added `accessibilityHeaderEnabled: Bool = true` to both public `BPKSectionHeader` initializers:
  - Section Header without a trailing button.
  - Section Header with a trailing button.
- Adds the `.isHeader` accessibility trait when enabled and explicitly removes it when disabled, ensuring the title’s Header trait is fully suppressed.
- Preserved existing behaviour by default, so current call sites remain unchanged.
- Added unit coverage for:
  - The default `accessibilityHeaderEnabled` value.
  - Explicitly disabling the accessibility header configuration.
  - Passing the disabled configuration through the trailing-button initializer.
- Updated the README to:
  - Document `accessibilityHeaderEnabled`.
  - Explain the iOS `style` versus Android `type` naming difference and rationale.
  - Document the difference between iOS `accessibilityHeaderEnabled: Bool` and Android `accessibilityHeaderTagEnabled: Boolean?`.
  - Explain why iOS uses a shorter name and a non-optional Boolean with a concrete default.
  - Document that Section Header automatically overrides the supplied button style.
  - Correct the CocoaPods badge URL.
  - Refresh and correct the usage examples.
  - Make the primary usage example standalone and compilable.

## Manual verification

Verified using Accessibility Inspector in the Backpack example app on an iPhone 17 Pro simulator running iOS 26.3.

- [x] Confirmed the default Section Header title exposes the accessibility Header trait:
  - Type: `heading`
  - Role: `AXHeading`
- [x] Confirmed `accessibilityHeaderEnabled: false` suppresses the Header trait:
  - Type: `text`
  - Role: `AXStaticText`
- [x] Confirmed there were no visual or layout differences.
- [x] Temporary example-app changes used for verification were reverted.

The local package test target did not finish loading in Xcode, so the complete automated test suite will be compiled and run by CI.

## Cross-platform behaviour

Android exposes the equivalent accessibility control as `accessibilityHeaderTagEnabled: Boolean?`. iOS uses the shorter `accessibilityHeaderEnabled: Bool` name with a default value of `true`.

The iOS API does not need a nullable state because Backpack always supplies a concrete enabled or disabled default. A non-optional Boolean follows Swift API conventions for simple binary configuration while preserving equivalent cross-platform behaviour.

The existing appearance parameter remains named `style` on iOS and `type` on Android. The difference is retained to follow SwiftUI naming conventions and avoid a breaking change to the existing iOS API.

## Notes

These changes are additive and do not require existing call sites to change. Existing Section Headers continue to expose the Header trait by default.

There are no visual changes, so no new snapshot baselines or screenshotting-code changes are expected.

Responsive typography and responsive button rendering are outside the scope of this PR. No Android or production `skyscanner-app` changes are included.

- [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:

- [x] `README.md`
- [x] Tests
- [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
- [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)._

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)