### PR TITLE
[DON-3416] Document gradient stop differences and shader parity for Blur

### DIFF
--- a/Backpack-SwiftUI/Blur/Classes/BPKProgressiveBlurFallback.swift
+++ b/Backpack-SwiftUI/Blur/Classes/BPKProgressiveBlurFallback.swift
@@ -20,6 +20,13 @@ import SwiftUI
 
 /// A ViewModifier that applies a progressive blur effect to a view
 /// The blur gradually increases from no blur at the top to full blur at the bottom
+///
+/// - Note: This is the < iOS 17 fallback for `bpkProgressiveBlur()` (see `VisualEffect+Blur.swift`).
+///   It intentionally differs from the Metal-based `bpkProgressiveBlur()` in both region and gradient:
+///   this fallback blurs the *full* height of the view (0%–100%) via a fixed 10pt blur revealed through
+///   a 5-stop alpha cross-fade, whereas `bpkProgressiveBlur()` only blurs the bottom half (50%–100%) with
+///   a continuously variable radius up to 24pt. As a result the two can look meaningfully different
+///   depending on OS version. See `Backpack-SwiftUI/Blur/README.md` for the full comparison.
 public struct BPKProgressiveBlurFallback: ViewModifier {
     /// The maximum blur radius to apply at the bottom of the view
     let radius: CGFloat

--- a/Backpack-SwiftUI/Blur/Classes/VisualEffect+Blur.swift
+++ b/Backpack-SwiftUI/Blur/Classes/VisualEffect+Blur.swift
@@ -98,6 +98,14 @@ public extension View {
     }
 
     /// Applies progressive blur effect from bottom to top.
+    ///
+    /// - Note: Only iOS 17+; use `bpkProgressiveBlurFallback()` on earlier versions. The two differ in both
+    ///   region and gradient: this Metal-based version only blurs the bottom half of the view (50%–100%),
+    ///   and its mask alpha caps at 0.5 at the bottom edge, so the effective peak blur is roughly half of
+    ///   the nominal `radius: 24` (~12pt). `bpkProgressiveBlurFallback()` blurs the full view height using a
+    ///   fixed 10pt blur revealed via alpha cross-fade, reaching full visibility at 75% down. This means the
+    ///   same call can look meaningfully different depending on OS version — see
+    ///   `Backpack-SwiftUI/Blur/README.md` for the full comparison against the Android AGSL shader too.
     func bpkProgressiveBlur() -> some View {
         self.variableBlur(
             radius: 24,

--- a/Backpack-SwiftUI/Blur/README.md
+++ b/Backpack-SwiftUI/Blur/README.md
@@ -96,6 +96,48 @@ Image("example-image")
 
 ---
 
+## Platform Parity & Gradient Notes
+
+### Shader parity: iOS Metal vs Android AGSL
+
+Both platforms apply progressive blur only to the bottom half of the view/composable, ramping intensity
+from the vertical midpoint (no blur) to the bottom edge (maximum blur). However, the two implementations
+scale intensity differently:
+
+- **iOS (`bpkProgressiveBlur`)**: the mask alpha driving the Metal shader's blur radius only reaches `0.5`
+  at the bottom edge (see gradient stops below), so the effective maximum blur is roughly half of the
+  nominal `radius: 24` passed to the shader (~12pt).
+- **Android AGSL**: `blurSigma` is interpolated linearly from `0` at the midpoint to the *full* `uMaxSigma`
+  (4dp) at the bottom edge, with no equivalent 0.5 cap.
+
+This is an accepted, documented difference rather than a defect: the two shaders use different units
+(points vs dp) and different intensity curves by design, but both produce the same qualitative effect
+(no blur at the midpoint, strongest blur at the bottom edge, confined to the bottom 50% of the view).
+Visual comparison of the recorded snapshots (`screenshots/iPhone-swiftui_blur-progessive___default_lm.png`
+on iOS vs `BpkBlurTest_progressiveBlur.png` on Android) confirms the falloff shape is perceptually similar,
+though iOS's effective peak intensity is lower relative to its nominal radius.
+
+### `bpkProgressiveBlurFallback` vs `bpkProgressiveBlur` gradient differences
+
+The two iOS implementations use different gradient distributions and affect different regions of the view,
+which can produce visibly different results depending on which one is selected for a given OS version:
+
+| | `bpkProgressiveBlurFallback` (< iOS 17) | `bpkProgressiveBlur` (iOS 17+) |
+| --- | --- | --- |
+| Region affected | Full height (0%–100%) | Bottom half only (50%–100%) |
+| Mechanism | Fixed 10pt blur, revealed via an alpha cross-fade mask | Continuously variable blur radius (0–24pt) driven directly by the shader mask |
+| Gradient stops | `0.0` clear, `0.25` clear, `0.5` @ 50% opacity, `0.75` @ 100% opacity, `1.0` @ 100% opacity | `0.0` @ 50% opacity, `0.5` @ 30% opacity, `1.0` clear |
+| Effective peak intensity | Full 10pt blur visible from 75% down to the bottom | ~12pt effective (24pt nominal × 0.5 mask cap), only right at the bottom edge |
+
+Because the fallback blurs the entire view while the Metal version only blurs the bottom half, and the
+fallback's blur becomes fully visible well before the bottom edge (at 75% down) while the Metal version's
+effective intensity is lower and concentrated at the very edge, the same call to `bpkProgressiveBlur()`
+can look meaningfully different depending on whether a device is running iOS 16 or iOS 17+. This is a
+known, accepted platform limitation rather than a bug — callers should not assume identical visual output
+across OS versions.
+
+---
+
 ## Accessibility
 
 These visual effects are non-interactive and should be combined with accessible labels or containers as appropriate.


### PR DESCRIPTION
## Summary

Validates and documents progressive blur shader parity between iOS and Android, and documents the gradient stop differences between `bpkProgressiveBlurFallback` and `bpkProgressiveBlur`, as required by the parity audit.

## Changes

- Added a "Platform Parity & Gradient Notes" section to `Backpack-SwiftUI/Blur/README.md` comparing the iOS Metal shader against the Android AGSL shader (region affected, intensity scaling, gradient stops).
- Documented in the same section that `bpkProgressiveBlurFallback` (< iOS 17) and `bpkProgressiveBlur` (iOS 17+) use different gradient distributions and affect different regions of the view, which can produce visibly different results depending on OS version.
- Added a doc comment on `BPKProgressiveBlurFallback` cross-referencing `bpkProgressiveBlur()` and summarizing the region/intensity divergence.
- Added a doc comment on `bpkProgressiveBlur()` cross-referencing `BPKProgressiveBlurFallback` and the Android AGSL comparison.

## Compatibility

This is a documentation-only change. No gradient stop values, radius constants, mask logic, or shader code were modified — no behavioural or API changes.

## Verification

- No shader or logic changed, so no snapshot re-recording was needed.
- Findings were derived by directly comparing the iOS Metal shader (`VisualEffect+Blur.swift`, `VariableBlur.metal`), the iOS fallback (`BPKProgressiveBlurFallback.swift`), and the Android AGSL shader (`BpkBlurImpl.kt`), and cross-checking against each platform's recorded snapshots (`iPhone-swiftui_blur-progessive___default_lm.png` vs `BpkBlurTest_progressiveBlur.png`).

Remember to include the following changes:
+ [x] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_