### PR TITLE
[DON-3491] Remove nonexistent accessibilityIdentifier param from BannerAlert README

### DIFF
--- a/Backpack-SwiftUI/BannerAlert/README.md
+++ b/Backpack-SwiftUI/BannerAlert/README.md
@@ -28,8 +28,7 @@ Supported `Style`s:
 BPKBannerAlert(
     type: .warning(accessibilityLabel: "Warning"),
     style: .onContrast,
-    message: "Hello World!",
-    accessibilityIdentifier: "BannerAlertAccessibilityIdentifier"
+    message: "Hello World!"
 )
 ```
 


### PR DESCRIPTION
## Summary

Fixes a doc bug in the `BannerAlert` README: the usage example passed an `accessibilityIdentifier:` argument to `BPKBannerAlert.init`, but the initializer has never had that parameter (`type`, `style`, `message`, `icon` are the only ones). The example would not compile as written.

## Changes

- Remove the nonexistent `accessibilityIdentifier:` line from the "How to initialize" example in `Backpack-SwiftUI/BannerAlert/README.md`

## Context

Found while working DON-3491 (BannerAlert iOS/Android parity audit).

## Test plan

- [x] Docs-only change, no code touched
- [x] Confirmed `BPKBannerAlert.init` signature has no `accessibilityIdentifier` param