### PR TITLE
[DON-3516] Fix isButton accessibility trait and expose heading suppression for Snippet

### DIFF
--- a/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
+++ b/Backpack-SwiftUI/Snippet/Classes/BPKSnippet.swift
@@ -24,14 +24,16 @@ public struct BPKSnippet: View {
     let subheading: String?
     let bodyText: String?
     let imageOrientation: ImageOrientation
+    let accessibilityHeaderEnabled: Bool
     let onClick: (() -> Void)?
-    
+
     public init(
         image: Image,
         headline: String? = nil,
         subheading: String? = nil,
         bodyText: String? = nil,
         imageOrientation: ImageOrientation = .landscape,
+        accessibilityHeaderEnabled: Bool = true,
         onClick: (() -> Void)? = nil
     ) {
         self.image = image
@@ -39,6 +41,7 @@ public struct BPKSnippet: View {
         self.subheading = subheading
         self.bodyText = bodyText
         self.imageOrientation = imageOrientation
+        self.accessibilityHeaderEnabled = accessibilityHeaderEnabled
         self.onClick = onClick
     }
     
@@ -49,7 +52,7 @@ public struct BPKSnippet: View {
             if let headline {
                 BPKText(headline, style: .heading4)
                     .lineLimit(nil)
-                    .accessibilityAddTraits(.isHeader)
+                    .accessibilityAddTraits(accessibilityHeaderEnabled ? .isHeader : [])
                     .padding(.top, .base)
             }
             if let subheading {
@@ -70,9 +73,11 @@ public struct BPKSnippet: View {
         }
         .accessibilityElement(children: .combine)
         .fixedSize(horizontal: false, vertical: true)
-        .accessibilityAddTraits(.isButton)
-        .onTapGesture {
-            onClick?()
+        .accessibilityAddTraits(onClick != nil ? .isButton : [])
+        .if(onClick != nil) { view in
+            view.onTapGesture {
+                onClick?()
+            }
         }
     }
 

--- a/Backpack-SwiftUI/Snippet/README.md
+++ b/Backpack-SwiftUI/Snippet/README.md
@@ -56,3 +56,24 @@ BPKSnippet(
     }
 )
 ```
+
+The button accessibility trait is only applied when `onClick` is provided, so a
+Snippet without an action isn't announced as a button.
+
+### Accessibility header trait
+
+The headline has the accessibility header trait by default. Set `accessibilityHeaderEnabled` to `false` when another view already provides the appropriate heading semantics.
+
+```swift
+BPKSnippet(
+    image: Image("dialog_image", bundle: TestsBundle.bundle),
+    headline: "Headline Text",
+    accessibilityHeaderEnabled: false
+)
+```
+
+## Cross-platform naming
+
+Android exposes the equivalent accessibility control as `accessibilityHeaderTagEnabled: Boolean?`. iOS uses the shorter `accessibilityHeaderEnabled: Bool` name with a default value of `true`, following the same convention used on `BPKSectionHeader`.
+
+The subheading parameter is also named differently across platforms: `subheading` on iOS and `subHeading` on Android. This is a known, intentional discrepancy rather than a bug.

--- a/Backpack-SwiftUI/Tests/Snippet/BPKSnippetAccessibilityTests.swift
+++ b/Backpack-SwiftUI/Tests/Snippet/BPKSnippetAccessibilityTests.swift
@@ -1,0 +1,100 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import SwiftUI
+@testable import Backpack_SwiftUI
+
+class BPKSnippetAccessibilityTests: XCTestCase {
+    override class func setUp() {
+        // SwiftUI only materialises its UIKit accessibility tree when the
+        // accessibility runtime is active in-process, which it isn't by
+        // default in a test host. Without this, every trait assertion below
+        // would silently pass on an empty tree regardless of the code change.
+        guard let handle = dlopen("/usr/lib/libAccessibility.dylib", RTLD_NOW) else { return }
+        typealias SetterFn = @convention(c) (Bool) -> Void
+        if let sym = dlsym(handle, "_AXSSetAutomationEnabled") {
+            unsafeBitCast(sym, to: SetterFn.self)(true)
+        }
+    }
+
+    private func combinedElementTraits<V: View>(_ view: V) -> UIAccessibilityTraits? {
+        let host = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+
+        var found: UIAccessibilityTraits?
+        func walk(_ object: NSObject, depth: Int) {
+            if depth > 14 || found != nil { return }
+            let isElement = (object as? UIView)?.isAccessibilityElement ?? object.isAccessibilityElement
+            if isElement {
+                found = object.accessibilityTraits
+                return
+            }
+            if let elements = object.accessibilityElements as? [NSObject], !elements.isEmpty {
+                for element in elements { walk(element, depth: depth + 1) }
+            }
+            if let view = object as? UIView {
+                for subview in view.subviews { walk(subview, depth: depth + 1) }
+            }
+        }
+        walk(host.view, depth: 0)
+        return found
+    }
+
+    private func snippet(
+        accessibilityHeaderEnabled: Bool = true,
+        onClick: (() -> Void)? = nil
+    ) -> BPKSnippet {
+        BPKSnippet(
+            image: Image("dialog_image", bundle: TestsBundle.bundle),
+            headline: "Headline Text",
+            subheading: "Subheading",
+            bodyText: "Body Text",
+            accessibilityHeaderEnabled: accessibilityHeaderEnabled,
+            onClick: onClick
+        )
+    }
+
+    func test_defaultAccessibilityHeaderEnabledWithOnClick_matchesCurrentBehaviour() {
+        let traits = combinedElementTraits(snippet(onClick: {}))
+        XCTAssertEqual(traits?.contains(.header), true)
+        XCTAssertEqual(traits?.contains(.button), true)
+    }
+
+    func test_accessibilityHeaderEnabledFalse_removesHeaderTraitOnly() {
+        let traits = combinedElementTraits(snippet(accessibilityHeaderEnabled: false, onClick: {}))
+        XCTAssertEqual(traits?.contains(.header), false)
+        XCTAssertEqual(traits?.contains(.button), true)
+    }
+
+    func test_noOnClick_removesButtonTraitOnly() {
+        let traits = combinedElementTraits(snippet(accessibilityHeaderEnabled: true, onClick: nil))
+        XCTAssertEqual(traits?.contains(.header), true)
+        XCTAssertEqual(traits?.contains(.button), false)
+    }
+
+    func test_accessibilityHeaderEnabledFalseAndNoOnClick_removesBothTraits() {
+        let traits = combinedElementTraits(snippet(accessibilityHeaderEnabled: false, onClick: nil))
+        XCTAssertEqual(traits?.contains(.header), false)
+        XCTAssertEqual(traits?.contains(.button), false)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a confirmed accessibility bug in `BPKSnippet` and adds a heading-suppression parameter to match Android's existing capability.

## Changes

- **`.isButton` trait fix**: previously applied unconditionally regardless of whether `onClick` was provided. Now only applied when `onClick != nil`. A non-interactive `BPKSnippet` (e.g. a loading placeholder) is no longer announced as a button by VoiceOver.
- **`.onTapGesture` gating**: the tap gesture is now only attached when `onClick != nil`, using the existing `.if()` conditional-modifier helper. Without this, a non-interactive Snippet would still silently swallow taps intended for a parent view, even after the trait fix.
- **New `accessibilityHeaderEnabled: Bool = true` parameter**: lets callers suppress the `.isHeader` trait on the headline, mirroring Android's `accessibilityHeaderTagEnabled` and the pattern already used on `BPKSectionHeader` (DON-3412). Defaults to `true`, preserving current behaviour for all existing callers.
- **New tests** (`BPKSnippetAccessibilityTests.swift`): asserts the real accessibility traits on the hosted `UIView`, covering all four combinations of the two new conditionals, plus a check that the defaults reproduce today's exact trait output.
- **README updated** with usage examples and a cross-platform naming note (also documents the `subheading`/`subHeading` iOS/Android naming difference, left un-renamed to avoid an unrelated breaking change).

## Compatibility

Source-compatible: `accessibilityHeaderEnabled` is inserted before the existing `onClick` parameter with a default value; no real call site uses positional or trailing-closure syntax for `onClick`, so nothing breaks.

Behaviour change (intentional): any existing `BPKSnippet` without `onClick` will no longer be announced as "Button" by VoiceOver, and will no longer consume tap gestures. Two example/test call sites in this repo are affected; both are non-interactive by design.

## Verification

- `xcodebuild test` run locally against the real `Backpack-Package` scheme (iOS simulator): all existing `BPKSnippetViewTests` snapshot tests pass unchanged (zero visual difference, as expected since traits don't render).
- New `BPKSnippetAccessibilityTests` pass, confirming each flag independently controls its trait and that defaults match today's behaviour exactly.
- Ran the **full** `Backpack-SwiftUI` + `Backpack` test suite with and without this change on the same simulator: identical pass/fail outcome across all 78 test suites. The handful of pre-existing snapshot failures (device/OS reference-image mismatches, unrelated components) are present identically in both runs.
- Smoke-testing against `skyscanner-app` via a draft PR with the Podfile pointed at this branch (linked below) to confirm CI passes end-to-end.

Remember to include the following changes:
- [x] `README.md`
- [x] Tests
- [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
- [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)._