### PR TITLE
[DON-3510] Increase CardCarousel accessibility test coverage

### DIFF
--- a/Backpack-SwiftUI/CardCarousel/Classes/BPKCardCarousel.swift
+++ b/Backpack-SwiftUI/CardCarousel/Classes/BPKCardCarousel.swift
@@ -45,6 +45,38 @@ public struct BPKCardCarousel<Content: View>: View {
     }
 }
 
+/// Pure index arithmetic for `InternalCardCarousel`'s infinite-scroll wraparound, extracted so it can be
+/// unit tested directly - the surrounding view's `@State` cannot be exercised meaningfully without
+/// mounting it into a live view hierarchy.
+internal struct CardCarouselIndexCalculator {
+    let cardCount: Int
+    let totalContentCount: Int
+
+    func adjustedIndex(for internalIndex: Int) -> Int {
+        (internalIndex - 1) % cardCount
+    }
+
+    /// The index `currentInternalIndex` should be silently reset to (with no animation) before
+    /// advancing left, if it's about to run off the end of the duplicated content array.
+    func wrapResetBeforeAdvancingLeft(from internalIndex: Int) -> Int {
+        internalIndex == totalContentCount - 1 ? internalIndex % cardCount : internalIndex
+    }
+
+    /// The index `currentInternalIndex` should be silently reset to (with no animation) before
+    /// advancing right, if it's about to run off the start of the duplicated content array.
+    func wrapResetBeforeAdvancingRight(from internalIndex: Int) -> Int {
+        internalIndex == 2 ? internalIndex + cardCount : internalIndex
+    }
+
+    func advancingLeft(from internalIndex: Int) -> Int {
+        wrapResetBeforeAdvancingLeft(from: internalIndex) + 1
+    }
+
+    func advancingRight(from internalIndex: Int) -> Int {
+        wrapResetBeforeAdvancingRight(from: internalIndex) - 1
+    }
+}
+
 internal struct InternalCardCarousel<Content: View>: View {
     private let numberOfCardsForLandscape: CGFloat = 3.0
     @Binding private var currentIndex: Int
@@ -139,8 +171,12 @@ internal struct InternalCardCarousel<Content: View>: View {
         }
     }
     
+    private var indexCalculator: CardCarouselIndexCalculator {
+        CardCarouselIndexCalculator(cardCount: cardCount, totalContentCount: content.count)
+    }
+
     private var currentAdjustedIndex: Int {
-        (currentInternalIndex - 1) % (cardCount)
+        indexCalculator.adjustedIndex(for: currentInternalIndex)
     }
 
     private var dragGesture: some Gesture {
@@ -189,22 +225,21 @@ internal struct InternalCardCarousel<Content: View>: View {
         focusOnCard = currentInternalIndex
     }
     
-    // Internal (not private) so tests can exercise the increment/decrement
-    // logic behind .accessibilityAdjustableAction directly.
-    func handleLeftSwipe() {
-        if currentInternalIndex == content.count - 1 {
+    private func handleLeftSwipe() {
+        let wrapped = indexCalculator.wrapResetBeforeAdvancingLeft(from: currentInternalIndex)
+        if wrapped != currentInternalIndex {
             withAnimation(.none) {
-                currentInternalIndex = currentInternalIndex % cardCount
+                currentInternalIndex = wrapped
             }
         }
-        
         updateIndices(with: currentInternalIndex + 1)
     }
 
-    func handleRightSwipe() {
-        if currentInternalIndex == 2 {
+    private func handleRightSwipe() {
+        let wrapped = indexCalculator.wrapResetBeforeAdvancingRight(from: currentInternalIndex)
+        if wrapped != currentInternalIndex {
             withAnimation(.none) {
-                currentInternalIndex += cardCount
+                currentInternalIndex = wrapped
             }
         }
         updateIndices(with: currentInternalIndex - 1)

--- a/Backpack-SwiftUI/CardCarousel/Classes/BPKCardCarousel.swift
+++ b/Backpack-SwiftUI/CardCarousel/Classes/BPKCardCarousel.swift
@@ -189,7 +189,9 @@ internal struct InternalCardCarousel<Content: View>: View {
         focusOnCard = currentInternalIndex
     }
     
-    private func handleLeftSwipe() {
+    // Internal (not private) so tests can exercise the increment/decrement
+    // logic behind .accessibilityAdjustableAction directly.
+    func handleLeftSwipe() {
         if currentInternalIndex == content.count - 1 {
             withAnimation(.none) {
                 currentInternalIndex = currentInternalIndex % cardCount
@@ -199,7 +201,7 @@ internal struct InternalCardCarousel<Content: View>: View {
         updateIndices(with: currentInternalIndex + 1)
     }
 
-    private func handleRightSwipe() {
+    func handleRightSwipe() {
         if currentInternalIndex == 2 {
             withAnimation(.none) {
                 currentInternalIndex += cardCount

--- a/Backpack-SwiftUI/CardCarousel/README.md
+++ b/Backpack-SwiftUI/CardCarousel/README.md
@@ -18,10 +18,8 @@ BPKCardCarousel(
     cards: [
         BPKCarouselCard(
             content: {
-                AnyView(
-                    Rectangle()
-                        .foregroundColor(BPKColor.skyBlue)
-                )
+                Rectangle()
+                    .foregroundColor(BPKColor.skyBlue)
             },
             title: "Test Title",
             description: "Test description",
@@ -29,10 +27,8 @@ BPKCardCarousel(
         ),
         BPKCarouselCard(
             content: {
-                AnyView(
-                    Rectangle()
-                        .foregroundColor(BPKColor.skyBlue)
-                )
+                Rectangle()
+                    .foregroundColor(BPKColor.skyBlue)
             },
             title: "Test Title",
             description: "Test description",
@@ -40,16 +36,14 @@ BPKCardCarousel(
         ),
         BPKCarouselCard(
             content: {
-                AnyView(
-                    Rectangle()
-                        .foregroundColor(BPKColor.skyBlue)
-                )
+                Rectangle()
+                    .foregroundColor(BPKColor.skyBlue)
             },
             title: "Test Title",
             description: "Test description",
             contentAccessibilityLabel: "Blue rectangle"
         )
     ],
-    curentIndex: .constant(0)
+    currentIndex: .constant(0)
 )
 ```

--- a/Backpack-SwiftUI/Tests/CardCarousel/BPKCardCarouselTests.swift
+++ b/Backpack-SwiftUI/Tests/CardCarousel/BPKCardCarouselTests.swift
@@ -145,7 +145,48 @@ class BPKCardCarouselTests: XCTestCase {
         
         assertA11ySnapshot(cardCarousel)
     }
-    
+
+    // BPKPageIndicator's .accessibilityAdjustableAction closure forwards
+    // VoiceOver's increment/decrement directly to handleLeftSwipe/
+    // handleRightSwipe, so these tests exercise that navigation logic
+    // directly since there's no infra in this test suite (or elsewhere in
+    // Backpack-SwiftUI) to simulate an accessibility adjustable action.
+    func test_accessibilityAdjustableAction_incrementNavigatesForwardWithWraparound() {
+        var currentIndex = 0
+        let carousel = InternalCardCarousel(
+            size: CGSize(width: 300, height: 530),
+            content: [createCard(), createCard(), createCard()],
+            currentIndex: Binding(get: { currentIndex }, set: { currentIndex = $0 })
+        )
+
+        carousel.handleLeftSwipe()
+        XCTAssertEqual(currentIndex, 1)
+
+        carousel.handleLeftSwipe()
+        XCTAssertEqual(currentIndex, 2)
+
+        carousel.handleLeftSwipe()
+        XCTAssertEqual(currentIndex, 0)
+    }
+
+    func test_accessibilityAdjustableAction_decrementNavigatesBackwardWithWraparound() {
+        var currentIndex = 0
+        let carousel = InternalCardCarousel(
+            size: CGSize(width: 300, height: 530),
+            content: [createCard(), createCard(), createCard()],
+            currentIndex: Binding(get: { currentIndex }, set: { currentIndex = $0 })
+        )
+
+        carousel.handleRightSwipe()
+        XCTAssertEqual(currentIndex, 2)
+
+        carousel.handleRightSwipe()
+        XCTAssertEqual(currentIndex, 1)
+
+        carousel.handleRightSwipe()
+        XCTAssertEqual(currentIndex, 0)
+    }
+
     private func createCard() -> BPKCarouselCard<AnyView> {
         return BPKCarouselCard(
             content: {

--- a/Backpack-SwiftUI/Tests/CardCarousel/BPKCardCarouselTests.swift
+++ b/Backpack-SwiftUI/Tests/CardCarousel/BPKCardCarouselTests.swift
@@ -146,45 +146,35 @@ class BPKCardCarouselTests: XCTestCase {
         assertA11ySnapshot(cardCarousel)
     }
 
-    // BPKPageIndicator's .accessibilityAdjustableAction closure forwards
-    // VoiceOver's increment/decrement directly to handleLeftSwipe/
-    // handleRightSwipe, so these tests exercise that navigation logic
-    // directly since there's no infra in this test suite (or elsewhere in
-    // Backpack-SwiftUI) to simulate an accessibility adjustable action.
+    // BPKPageIndicator's .accessibilityAdjustableAction closure forwards VoiceOver's increment/decrement
+    // directly to handleLeftSwipe/handleRightSwipe, which delegate their wraparound arithmetic to
+    // CardCarouselIndexCalculator. That calculator is tested directly here (rather than driving
+    // InternalCardCarousel itself) because InternalCardCarousel's @State never propagates writes unless
+    // it's mounted into a live view hierarchy, which this test suite has no infrastructure to do.
     func test_accessibilityAdjustableAction_incrementNavigatesForwardWithWraparound() {
-        var currentIndex = 0
-        let carousel = InternalCardCarousel(
-            size: CGSize(width: 300, height: 530),
-            content: [createCard(), createCard(), createCard()],
-            currentIndex: Binding(get: { currentIndex }, set: { currentIndex = $0 })
-        )
+        let calculator = CardCarouselIndexCalculator(cardCount: 3, totalContentCount: 6)
 
-        carousel.handleLeftSwipe()
-        XCTAssertEqual(currentIndex, 1)
+        let afterFirst = calculator.advancingLeft(from: 4)
+        XCTAssertEqual(calculator.adjustedIndex(for: afterFirst), 1)
 
-        carousel.handleLeftSwipe()
-        XCTAssertEqual(currentIndex, 2)
+        let afterSecond = calculator.advancingLeft(from: afterFirst)
+        XCTAssertEqual(calculator.adjustedIndex(for: afterSecond), 2)
 
-        carousel.handleLeftSwipe()
-        XCTAssertEqual(currentIndex, 0)
+        let afterThird = calculator.advancingLeft(from: afterSecond)
+        XCTAssertEqual(calculator.adjustedIndex(for: afterThird), 0)
     }
 
     func test_accessibilityAdjustableAction_decrementNavigatesBackwardWithWraparound() {
-        var currentIndex = 0
-        let carousel = InternalCardCarousel(
-            size: CGSize(width: 300, height: 530),
-            content: [createCard(), createCard(), createCard()],
-            currentIndex: Binding(get: { currentIndex }, set: { currentIndex = $0 })
-        )
+        let calculator = CardCarouselIndexCalculator(cardCount: 3, totalContentCount: 6)
 
-        carousel.handleRightSwipe()
-        XCTAssertEqual(currentIndex, 2)
+        let afterFirst = calculator.advancingRight(from: 4)
+        XCTAssertEqual(calculator.adjustedIndex(for: afterFirst), 2)
 
-        carousel.handleRightSwipe()
-        XCTAssertEqual(currentIndex, 1)
+        let afterSecond = calculator.advancingRight(from: afterFirst)
+        XCTAssertEqual(calculator.adjustedIndex(for: afterSecond), 1)
 
-        carousel.handleRightSwipe()
-        XCTAssertEqual(currentIndex, 0)
+        let afterThird = calculator.advancingRight(from: afterSecond)
+        XCTAssertEqual(calculator.adjustedIndex(for: afterThird), 0)
     }
 
     private func createCard() -> BPKCarouselCard<AnyView> {


### PR DESCRIPTION
## Summary

- Add test coverage for the increment/decrement navigation logic that backs `.accessibilityAdjustableAction` on `BPKCardCarousel`'s page indicator (previously untested since the modifier was added in the component's original 2024 contribution, before DON-3510).
- Fix `CardCarousel/README.md`: `curentIndex` → `currentIndex` typo, and remove unnecessary `AnyView(...)` wrapping from the usage example.

`.accessibilityAdjustableAction` itself, the structured card data model, and a `cardStyle` parameter were all evaluated per DON-3510 — see the Jira comment on the ticket for why the latter two are out of scope for this PR (not breaking if added later, but no concrete consumer need identified today).

### Test approach

The first version of the new tests constructed `InternalCardCarousel` directly (bypassing `BPKCardCarousel`, never mounted into a view hierarchy) and called its swipe handlers, widening them from `private` to `internal` to do so. That failed in CI: writes to `@State` on an unmounted SwiftUI view struct never propagate, so every assertion silently checked against the frozen initial value.

Fixed by extracting the wraparound index arithmetic into a plain, state-free `CardCarouselIndexCalculator` that's tested directly — no `@State`, no view mounting needed. `InternalCardCarousel`'s swipe handlers are back to `private` and just delegate to the calculator, with the exact original animation sequencing (the separate no-animation wrap-reset step) preserved.

## Test plan

- [x] Verified locally: `test_accessibilityAdjustableAction_incrementNavigatesForwardWithWraparound` and `test_accessibilityAdjustableAction_decrementNavigatesBackwardWithWraparound` pass
- [ ] Confirm existing snapshot tests (`testCardCarousel`, `testCardCarouselIPad`, `test_accessibility`) are unaffected
- [ ] Confirm the README code sample still compiles as valid SwiftUI
