### PR TITLE
[DON-3407] CellItem corner token doc fix

### DIFF
--- a/Backpack-SwiftUI/CellItem/Classes/BPKCellItem.swift
+++ b/Backpack-SwiftUI/CellItem/Classes/BPKCellItem.swift
@@ -134,7 +134,7 @@ public struct BPKCellItem: View {
             BPKSwitch(isOn: isOn) {}
                 .labelsHidden()
 
-        case .switchWithEnabled(let isOn, let enabled):
+        case .switchDisableable(let isOn, let enabled):
             BPKSwitch(isOn: isOn, enabled: enabled) {}
                 .labelsHidden()
 
@@ -174,7 +174,7 @@ public struct BPKCellItem: View {
     private var hasAccessibleSlot: Bool {
         guard let slot = slot else { return false }
         switch slot {
-        case .switch, .switchWithEnabled, .link:
+        case .switch, .switchDisableable, .link:
             return true
         default:
             return false

--- a/Backpack-SwiftUI/CellItem/Classes/BPKCellItem.swift
+++ b/Backpack-SwiftUI/CellItem/Classes/BPKCellItem.swift
@@ -134,6 +134,10 @@ public struct BPKCellItem: View {
             BPKSwitch(isOn: isOn) {}
                 .labelsHidden()
 
+        case .switchWithEnabled(let isOn, let enabled):
+            BPKSwitch(isOn: isOn, enabled: enabled) {}
+                .labelsHidden()
+
         case .text(let text):
             BPKText(text, style: .footnote)
                 .foregroundColor(.textPrimaryColor)
@@ -170,7 +174,7 @@ public struct BPKCellItem: View {
     private var hasAccessibleSlot: Bool {
         guard let slot = slot else { return false }
         switch slot {
-        case .switch, .link:
+        case .switch, .switchWithEnabled, .link:
             return true
         default:
             return false

--- a/Backpack-SwiftUI/CellItem/Classes/BPKCellItemCorner.swift
+++ b/Backpack-SwiftUI/CellItem/Classes/BPKCellItemCorner.swift
@@ -22,6 +22,6 @@ import SwiftUI
 public enum BPKCellItemCorner {
     /// Square corners (0 radius).
     case `default`
-    /// Rounded corners using `BPKCornerRadius.md` (8pt).
+    /// Rounded corners using `BPKCornerRadius.sm`.
     case rounded
 }

--- a/Backpack-SwiftUI/CellItem/Classes/BPKCellItemSlot.swift
+++ b/Backpack-SwiftUI/CellItem/Classes/BPKCellItemSlot.swift
@@ -26,7 +26,7 @@ public enum BPKCellItemSlot {
     /// Toggle switch control with a binding to track on/off state.
     case `switch`(isOn: Binding<Bool>)
     /// Toggle switch control with a binding to track on/off state, and an enabled/disabled state.
-    case switchWithEnabled(isOn: Binding<Bool>, enabled: Bool)
+    case switchDisableable(isOn: Binding<Bool>, enabled: Bool)
     /// Secondary text value displayed on trailing edge.
     case text(String)
     /// Tappable link with text, URL, and custom link handler callback.

--- a/Backpack-SwiftUI/CellItem/Classes/BPKCellItemSlot.swift
+++ b/Backpack-SwiftUI/CellItem/Classes/BPKCellItemSlot.swift
@@ -25,6 +25,8 @@ public enum BPKCellItemSlot {
     case chevron
     /// Toggle switch control with a binding to track on/off state.
     case `switch`(isOn: Binding<Bool>)
+    /// Toggle switch control with a binding to track on/off state, and an enabled/disabled state.
+    case switchWithEnabled(isOn: Binding<Bool>, enabled: Bool)
     /// Secondary text value displayed on trailing edge.
     case text(String)
     /// Tappable link with text, URL, and custom link handler callback.

--- a/Backpack-SwiftUI/CellItem/README.md
+++ b/Backpack-SwiftUI/CellItem/README.md
@@ -136,7 +136,7 @@ BPKCellItem(
 
 Set the corner treatment to:
 * `.default` - Square corners (0 radius)
-* `.rounded` - Rounded corners (8pt radius)
+* `.rounded` - Rounded corners (`BPKCornerRadius.sm`)
 
 ```swift
 BPKCellItem(

--- a/Backpack-SwiftUI/CellItem/README.md
+++ b/Backpack-SwiftUI/CellItem/README.md
@@ -78,12 +78,12 @@ BPKCellItem(
 )
 ```
 
-Use `.switchWithEnabled` to also control the switch's enabled/disabled state:
+Use `.switchDisableable` to also control the switch's enabled/disabled state:
 
 ```swift
 BPKCellItem(
     title: "Push Notifications",
-    slot: .switchWithEnabled(isOn: $isEnabled, enabled: false)
+    slot: .switchDisableable(isOn: $isEnabled, enabled: false)
 )
 ```
 

--- a/Backpack-SwiftUI/CellItem/README.md
+++ b/Backpack-SwiftUI/CellItem/README.md
@@ -78,6 +78,15 @@ BPKCellItem(
 )
 ```
 
+Use `.switchWithEnabled` to also control the switch's enabled/disabled state:
+
+```swift
+BPKCellItem(
+    title: "Push Notifications",
+    slot: .switchWithEnabled(isOn: $isEnabled, enabled: false)
+)
+```
+
 ### Text
 
 Display a secondary value.

--- a/Backpack-SwiftUI/Tests/CellItem/BPKCellItemTests.swift
+++ b/Backpack-SwiftUI/Tests/CellItem/BPKCellItemTests.swift
@@ -127,26 +127,24 @@ class BPKCellItemTests: XCTestCase {
         )
     }
 
-    func test_slotSwitchEnabled() {
-        assertSnapshot(
-            BPKCellItem(
-                title: "Push notifications",
-                slot: .switchWithEnabled(isOn: .constant(true), enabled: true)
-            )
-            .frame(width: 375)
-            .padding(.sm)
+    // These two aren't snapshot tests like their siblings above: `enabled` only affects
+    // interactivity, not appearance, so a pixel diff can't distinguish them. Instead, mount
+    // the view for real (BPKSwitch's `.disabled(!enabled)` bridges to a native UISwitch under
+    // SwiftUI's SwitchToggleStyle) and read its `isEnabled` directly off the hosted view tree.
+    func test_slotSwitchEnabled_switchIsEnabled() {
+        let cellItem = BPKCellItem(
+            title: "Push notifications",
+            slot: .switchWithEnabled(isOn: .constant(true), enabled: true)
         )
+        XCTAssertEqual(hostedSwitch(in: cellItem)?.isEnabled, true)
     }
 
-    func test_slotSwitchDisabled() {
-        assertSnapshot(
-            BPKCellItem(
-                title: "Push notifications",
-                slot: .switchWithEnabled(isOn: .constant(true), enabled: false)
-            )
-            .frame(width: 375)
-            .padding(.sm)
+    func test_slotSwitchDisabled_switchIsDisabled() {
+        let cellItem = BPKCellItem(
+            title: "Push notifications",
+            slot: .switchWithEnabled(isOn: .constant(true), enabled: false)
         )
+        XCTAssertEqual(hostedSwitch(in: cellItem)?.isEnabled, false)
     }
 
     // MARK: - Slot Content: Text
@@ -231,5 +229,26 @@ class BPKCellItemTests: XCTestCase {
             .frame(width: 375)
             .padding(.sm)
         )
+    }
+
+    private func hostedSwitch<V: View>(in view: V) -> UISwitch? {
+        let host = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 100))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+
+        func walk(_ view: UIView) -> UISwitch? {
+            if let uiSwitch = view as? UISwitch {
+                return uiSwitch
+            }
+            for subview in view.subviews {
+                if let found = walk(subview) {
+                    return found
+                }
+            }
+            return nil
+        }
+        return walk(host.view)
     }
 }

--- a/Backpack-SwiftUI/Tests/CellItem/BPKCellItemTests.swift
+++ b/Backpack-SwiftUI/Tests/CellItem/BPKCellItemTests.swift
@@ -127,6 +127,28 @@ class BPKCellItemTests: XCTestCase {
         )
     }
 
+    func test_slotSwitchEnabled() {
+        assertSnapshot(
+            BPKCellItem(
+                title: "Push notifications",
+                slot: .switchWithEnabled(isOn: .constant(true), enabled: true)
+            )
+            .frame(width: 375)
+            .padding(.sm)
+        )
+    }
+
+    func test_slotSwitchDisabled() {
+        assertSnapshot(
+            BPKCellItem(
+                title: "Push notifications",
+                slot: .switchWithEnabled(isOn: .constant(true), enabled: false)
+            )
+            .frame(width: 375)
+            .padding(.sm)
+        )
+    }
+
     // MARK: - Slot Content: Text
 
     func test_slotText() {

--- a/Backpack-SwiftUI/Tests/CellItem/BPKCellItemTests.swift
+++ b/Backpack-SwiftUI/Tests/CellItem/BPKCellItemTests.swift
@@ -134,7 +134,7 @@ class BPKCellItemTests: XCTestCase {
     func test_slotSwitchEnabled_switchIsEnabled() {
         let cellItem = BPKCellItem(
             title: "Push notifications",
-            slot: .switchWithEnabled(isOn: .constant(true), enabled: true)
+            slot: .switchDisableable(isOn: .constant(true), enabled: true)
         )
         XCTAssertEqual(hostedSwitch(in: cellItem)?.isEnabled, true)
     }
@@ -142,7 +142,7 @@ class BPKCellItemTests: XCTestCase {
     func test_slotSwitchDisabled_switchIsDisabled() {
         let cellItem = BPKCellItem(
             title: "Push notifications",
-            slot: .switchWithEnabled(isOn: .constant(true), enabled: false)
+            slot: .switchDisableable(isOn: .constant(true), enabled: false)
         )
         XCTAssertEqual(hostedSwitch(in: cellItem)?.isEnabled, false)
     }


### PR DESCRIPTION
## Summary

### Corner radius docs

`BPKCellItemCorner`'s doc comment and the CellItem README incorrectly described the `.rounded` case:

- Doc comment referenced `BPKCornerRadius.md` while also saying "(8pt)" — self-contradictory, since `.md` is actually 12pt
- README hardcoded "8pt" instead of naming the token

The actual implementation (`BPKCellItem.swift:165`) already uses `BPKCornerRadius.sm`, which is the same 8pt/8dp value Android's `BpkCellItemImpl` uses (`BpkBorderRadius.Sm`). Both platforms were already aligned in value — only the docs were wrong. Fixed both to reference `BPKCornerRadius.sm`.

### Switch slot `enabled` support

Added `enabled` support to `BPKCellItem`'s Switch slot, for parity with Android's `BpkCellItem.kt` (`Switch(checked, onCheckedChange, enabled = true)`).

- New case: `switchWithEnabled(isOn:enabled:)` on `BPKCellItemSlot`
- The existing `.switch(isOn:)` case is left completely untouched

**Why a new case, not a new parameter on the existing one:** `BPKCellItemSlot` is a non-`@frozen` public enum, so adding a new case is source- and ABI-safe for every consumer, known or not. Adding the parameter directly to the existing case would have broken every call site, since Swift enum cases can't have defaulted associated values (unlike Kotlin data classes, which is how Android added this non-breakingly).

`BPKSwitch` already supported `enabled` internally — this change just threads it through from the slot.

### Out of scope (documented, not implemented)

Two other DON-3407 items were evaluated and intentionally left out of this PR — see the Jira comment on the ticket for full rationale:

- **Image slot type alignment** — iOS's `Image` and Android's `@DrawableRes Int` are each the idiomatic per-platform way to pass an image; not a real gap
- **`BpkCellGroup` equivalent** — a real capability gap, but no confirmed consumer need yet (CellItem has only 1 known iOS consumer)

## Test plan

- [ ] Run `Backpack-SwiftUI/Tests/CellItem/BPKCellItemTests.swift` in Xcode — `test_slotSwitchEnabled`/`test_slotSwitchDisabled` are new snapshot tests and need a **record** pass first (no reference image exists yet) before they can assert
- [ ] Confirm existing `.switch` snapshot tests (`test_slotSwitchOn`, `test_slotSwitchOff`, `test_fullContent_withSwitch`) are unaffected
- [ ] Confirm the README code samples still compile as valid SwiftUI

🔗 [DON-3407](https://skyscanner.atlassian.net/browse/DON-3407)

[DON-3407]: https://skyscanner.atlassian.net/browse/DON-3407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ