### PR TITLE
DON-3709 Fix segmented control a11y issue

### DIFF
--- a/Backpack-SwiftUI/SegmentedControl/Classes/BPKSegmentedControl.swift
+++ b/Backpack-SwiftUI/SegmentedControl/Classes/BPKSegmentedControl.swift
@@ -76,7 +76,10 @@ public struct BPKSegmentedControl: View {
     private func segmentButton(for index: Int) -> some View {
         HStack(spacing: 0) {
             Button(
-                action: { withAnimation { selectedIndex = index } },
+                action: {
+                    guard selectedIndex != index else { return }
+                    withAnimation { selectedIndex = index }
+                },
                 label: {
                     Text(items[index])
                         .font(style: .label2)
@@ -89,7 +92,6 @@ public struct BPKSegmentedControl: View {
                 }
             )
             .frame(maxHeight: .infinity)
-            .disabled(selectedIndex == index)
 
             if index < items.count - 1 && selectedIndex != index && selectedIndex != index + 1 {
                 separator


### PR DESCRIPTION
Fix segmented control selected item announced as dimmed with VoiceOver

https://skyscanner.atlassian.net/browse/DON-3709

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-ios/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `README.md`
+ [ ] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-ios/blob/main/Example/Backpack%20Screenshot/Screenshots.swift)
+ [ ] Adding a component? Remember to expose it in the [main `Backpack.h` header file](https://github.com/Skyscanner/backpack-ios/tree/main/Backpack/Backpack.h)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
