### PR TITLE
[TEMPURA-4472] Add isHeader accessibility trait to BPKNavigationView title

### DIFF
--- a/Backpack-SwiftUI/NavigationBar/Classes/CollapsedNavigationBar.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/CollapsedNavigationBar.swift
@@ -53,7 +53,7 @@ struct CollapsedNavigationBar: View {
                         BPKText(title ?? "", style: .heading5)
                             .foregroundColor(style.foregroundColor(expanded: expanded))
                             .lineLimit(1)
-                            .accessibilityAddTraits(.isHeader)
+                            .accessibilityAddTraits(title?.isEmpty == false ? .isHeader : [])
                     }
                     
                     Spacer()

--- a/Backpack-SwiftUI/NavigationBar/Classes/CollapsedNavigationBar.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/CollapsedNavigationBar.swift
@@ -53,6 +53,7 @@ struct CollapsedNavigationBar: View {
                         BPKText(title ?? "", style: .heading5)
                             .foregroundColor(style.foregroundColor(expanded: expanded))
                             .lineLimit(1)
+                            .accessibilityAddTraits(.isHeader)
                     }
                     
                     Spacer()

--- a/Backpack-SwiftUI/NavigationBar/Classes/ExpandedNavigationBar.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/ExpandedNavigationBar.swift
@@ -32,6 +32,7 @@ struct ExpandedNavigationBar: View {
                 .frame(height: style.expandedNavigationBarHeight)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, .base)
+                .accessibilityAddTraits(.isHeader)
         }
     }
 }

--- a/Backpack-SwiftUI/NavigationBar/Classes/ExpandedNavigationBar.swift
+++ b/Backpack-SwiftUI/NavigationBar/Classes/ExpandedNavigationBar.swift
@@ -32,7 +32,7 @@ struct ExpandedNavigationBar: View {
                 .frame(height: style.expandedNavigationBarHeight)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, .base)
-                .accessibilityAddTraits(.isHeader)
+                .accessibilityAddTraits(title?.isEmpty == false ? .isHeader : [])
         }
     }
 }


### PR DESCRIPTION
## What
Add `.accessibilityAddTraits(.isHeader)` to the title `BPKText` in both `ExpandedNavigationBar` and `CollapsedNavigationBar`.

## Why
The navigation bar title rendered by `BPKNavigationView` was not exposed as a heading in the accessibility tree, meaning VoiceOver users could not identify it as the page topic. This fixes accessibility issue 1.3.1 (element represents topic of page).