### PR TITLE
Fix broken relative links and stale prose in docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,5 +36,3 @@ We use Ruby and [`Bundler`](https://bundler.io/) to perform most other automatio
 * `cocoapods` publishing the project, hosting the example project.
 * `fastlane` iOS project automation, used for taking our screenshots.
 * `jazzy` generates static HTML documentation from our reference docs, which is published at https://backpack.github.io/ios.
-
-We have a fair amount of automation in `Rakefile` that might be more suited for `fastlane` e.g. building the project, running the tests, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,7 +290,6 @@
   - In Objective-C some options are no longer supported e.g. the ability to show a notification dot and the support for badges.
   - The component adopts the new `BPKIcon` API and enforces the correct usage of icons with the appropriate horizontal navigation size at compile time.
   - Due to a bug in Swift/UIKit with generic views the component no longer supports theming. Theming can still be achieved with an explicit wrapping view that integrates with `UIAppearance`.
-  - For migration instructions see the [guide](./migration-guides/horizontal-nav-migration-guide.md).
 - Backpack/Chip:
   - The type of `iconName` has changed from the deprecated `BPKIconName` to `BPKIconNameLarge`. Some icons previously used might to be available.
 
@@ -313,7 +312,6 @@
 
 - Backpack/Icon:
   - Added `BPKSmallIconView`, `BPKLargeIconView` and `BPKXlIconView` - preferred ways to create an icon view.
-  - See the [migration guide](https://github.com/Skyscanner/backpack-ios/blob/main/migration-guides/icon-migration-guide.md).
  
 # 43.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -414,13 +414,12 @@ As new versions of Xcode and iOS are released, we have to upgrade both to stay u
 
 ### How to upgrade
 
-1. Change the value of `runs-on` in [`ci.yml`](./.github/workflows/ci.yml#26). The new value should be on of the [available environments](https://github.com/actions/virtual-environments/tree/main/images/macos) in GitHub Actions.
-1. Update the `BUILD_SDK` variable in [`Rakefile`](./Rakefile#5) to the new build SDK we should use.
-1. Update `correctMajorVersion` and `correctMinorVersion` in [`BPKSnapshotTest`](./Example/SnapshotTests/BPKSnapshotTest.h).
-1. Update `expectedMajorVersion` and `expectedMinorVersion` in [`BPKSnapshotTest.swift`](./Example/SnapshotTests/BPKSnapshotTest.swift#26).
+1. Change the value of `runs-on` in the workflows that build and test on macOS: [`_build.yml`](./.github/workflows/_build.yml), [`_test.yml`](./.github/workflows/_test.yml), [`_build-docs.yml`](./.github/workflows/_build-docs.yml), [`_spm-build.yml`](./.github/workflows/_spm-build.yml) and [`_spm-test.yml`](./.github/workflows/_spm-test.yml). The new value should be one of the [available environments](https://github.com/actions/runner-images/tree/main/images/macos) in GitHub Actions.
+1. Update the steps that run `xcode-select --switch` in [`_build.yml`](./.github/workflows/_build.yml), [`_test.yml`](./.github/workflows/_test.yml) and [`_build-docs.yml`](./.github/workflows/_build-docs.yml), and check the Xcode version you pick is installed on the runner image chosen above.
+1. Update the simulator we test against to the new iOS version. This is pinned in three places: the `DESTINATION` default and the `simctl` runtime filter below it in [`scripts/ci`](./scripts/ci), the `SPM_DESTINATION` environment variable in [`_spm-build.yml`](./.github/workflows/_spm-build.yml) and [`_spm-test.yml`](./.github/workflows/_spm-test.yml), and the `SIM_RUNTIME` default in [`scripts/install-sim`](./scripts/install-sim).
 1. Run all snapshot tests.
 1. **Review the failing snapshots thoroughly.** Most likely, all snapshots will have changed, **but** the diffs should be miniscule and mostly to do with changes in Apple's fonts.
-1. **Run all snapshot tests in record mode.** At the time of writing this involves manually setting `recordMode` in every test case, we should have a better method than this, but alas we don't :(
+1. **Re-record the snapshots.** Push a commit whose message is exactly `Record snapshots` as the most recent commit on your pull request. That triggers [`snapshot.yml`](./.github/workflows/snapshot.yml), which re-runs the suite with `retake_snapshots`, deletes the existing `__Snapshots__` directories and commits the newly recorded images back to your branch.
 1. Manually test the example app with the new version.
 </details>
 


### PR DESCRIPTION
Five relative markdown links pointed at files that do not exist. They are pre-existing (not introduced by DON-3723) and were found while validating docs links. In each case the surrounding prose was stale too, so this repoints the links that still have a real target and removes the ones that do not.

## Changes

### `CHANGELOG.md`
- **`[guide](./migration-guides/horizontal-nav-migration-guide.md)`** — `migration-guides/` was deleted in `df370c450` ("No jira project cleanup"). The guide does not exist anywhere in the repo, so the bullet is removed rather than repointed.
- **Also removed:** the 43.2.0 icon migration guide link. It points into the same deleted directory but via an absolute `github.com/.../blob/main/...` URL, so a relative-link check does not catch it. Called out separately since it is outside the five originally reported — happy to restore it if you would rather keep that one.

### `CONTRIBUTING.md` — "Upgrading Xcode/iOS"
All four remaining links were in one numbered list, and the list as a whole no longer described the pipeline:

| Was | Now |
| --- | --- |
| `runs-on` in `ci.yml` | `runs-on` in `_build.yml`, `_test.yml`, `_build-docs.yml`, `_spm-build.yml`, `_spm-test.yml` |
| `BUILD_SDK` in `Rakefile` | the `DESTINATION` default + `simctl` runtime filter in `scripts/ci`, `SPM_DESTINATION` in the two `_spm-*` workflows, and `SIM_RUNTIME` in `scripts/install-sim` |
| `correctMajorVersion` in `BPKSnapshotTest.h` | *removed* — helper no longer exists |
| `expectedMajorVersion` in `BPKSnapshotTest.swift` | *removed* — helper no longer exists |

`ci.yml` has been replaced by `pr.yml`/`main.yml` plus the reusable `_build`/`_test`/`_build-docs`/`_spm-*` workflows. There is no `Rakefile`, and its `BUILD_SDK` would not have been the right knob anyway — it is `iphonesimulator` regardless of iOS version, so the step now points at the places the iOS version is actually pinned. The `BPKSnapshotTest` version assertions are gone now that snapshots run on `swift-snapshot-testing`.

Two further steps were stale without being broken links, so they are corrected while the section is open:
- Added a step for the `xcode-select --switch` pin (currently `Xcode_16.4.app`), which the old list did not mention at all.
- **"Run all snapshot tests in record mode... manually setting `recordMode` in every test case"** now describes the real flow: a head commit of exactly `Record snapshots` triggers `snapshot.yml`, which runs `_test.yml` with `retake_snapshots`, wipes `__Snapshots__` and commits the new images back.

Line-number anchors (`#26`, `#5`) are dropped — they were already wrong and are the reason this rotted quietly.

### `ARCHITECTURE.md`
Removed "We have a fair amount of automation in `Rakefile`..." — there is no Rakefile.

## Verification

A script extracts relative markdown links from all tracked `.md` files (skipping fenced blocks and inline code spans) and stats each target:

- **After:** 27 links checked, **0 broken**.
- **Before:** the same script reports **exactly the 5** reported links, at the reported locations — so the check is genuinely exercising them, not passing vacuously.

Note: `Documentation/SPM/README.md` and `Documentation/SPM/ci-performance.md` are not on `main` and so are not present in this branch. Nothing here touches them; they stay clean by construction, but this run does not cover them.

Docs-only — no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)